### PR TITLE
Add Swiss localities and expand job management features

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-scripts": "5.0.1",
+    "swiss-cities": "^1.2.0",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/src/SwissStartupConnect.css
+++ b/src/SwissStartupConnect.css
@@ -500,6 +500,13 @@
   color: var(--ssc-muted);
 }
 
+.ssc__advanced-filters {
+  display: grid;
+  gap: 1rem;
+  margin-bottom: 1.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
 .ssc__clear-filters {
   border: none;
   background: none;
@@ -768,11 +775,25 @@
   font-weight: 600;
   color: var(--ssc-ink);
   transition: all 0.2s ease;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
 }
 
 .ssc__ghost-btn:hover {
   border-color: var(--ssc-primary);
   color: var(--ssc-primary);
+}
+
+.ssc__ghost-btn--danger {
+  border-color: rgba(220, 38, 38, 0.25);
+  color: #dc2626;
+}
+
+.ssc__ghost-btn--danger:hover {
+  border-color: #dc2626;
+  background: rgba(220, 38, 38, 0.08);
+  color: #dc2626;
 }
 
 .ssc__primary-btn {
@@ -1547,6 +1568,14 @@
   gap: 1rem;
 }
 
+.ssc__candidate--job {
+  align-items: flex-start;
+}
+
+.ssc__candidate--job ul {
+  margin: 0.2rem 0 0;
+}
+
 .ssc__avatar-medium {
   width: 54px;
   height: 54px;
@@ -1708,6 +1737,34 @@
   border-radius: 10px;
   font-size: 0.85rem;
   color: var(--ssc-muted);
+}
+
+.ssc__modal-meta-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+  margin: 1.25rem 0 0;
+}
+
+.ssc__modal-meta-grid div {
+  background: rgba(15, 23, 42, 0.05);
+  border-radius: 12px;
+  padding: 0.9rem 1rem;
+}
+
+.ssc__modal-meta-grid strong {
+  display: block;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ssc-muted);
+  margin-bottom: 0.35rem;
+}
+
+.ssc__modal-meta-grid span {
+  display: block;
+  color: var(--ssc-ink);
+  font-weight: 600;
 }
 
 .ssc__modal-body {

--- a/src/data/swissLocalities.json
+++ b/src/data/swissLocalities.json
@@ -1,0 +1,35384 @@
+[
+  {
+    "id": "8355|Aadorf|TG",
+    "name": "Aadorf",
+    "zipCode": "8355",
+    "canton": "TG"
+  },
+  {
+    "id": "5000|Aarau|AG",
+    "name": "Aarau",
+    "zipCode": "5000",
+    "canton": "AG"
+  },
+  {
+    "id": "3270|Aarberg|BE",
+    "name": "Aarberg",
+    "zipCode": "3270",
+    "canton": "BE"
+  },
+  {
+    "id": "4663|Aarburg|AG",
+    "name": "Aarburg",
+    "zipCode": "4663",
+    "canton": "AG"
+  },
+  {
+    "id": "4912|Aarwangen|BE",
+    "name": "Aarwangen",
+    "zipCode": "4912",
+    "canton": "BE"
+  },
+  {
+    "id": "8607|Aathal|ZH",
+    "name": "Aathal",
+    "zipCode": "8607",
+    "canton": "ZH"
+  },
+  {
+    "id": "8522|Aawangen|TG",
+    "name": "Aawangen",
+    "zipCode": "8522",
+    "canton": "TG"
+  },
+  {
+    "id": "1657|Abländschen|BE",
+    "name": "Abländschen",
+    "zipCode": "1657",
+    "canton": "BE"
+  },
+  {
+    "id": "5646|Abtwil|AG",
+    "name": "Abtwil",
+    "zipCode": "5646",
+    "canton": "AG"
+  },
+  {
+    "id": "9030|Abtwil|SG",
+    "name": "Abtwil",
+    "zipCode": "9030",
+    "canton": "SG"
+  },
+  {
+    "id": "3725|Achseten|BE",
+    "name": "Achseten",
+    "zipCode": "3725",
+    "canton": "BE"
+  },
+  {
+    "id": "7185|Acla|GR",
+    "name": "Acla",
+    "zipCode": "7185",
+    "canton": "GR"
+  },
+  {
+    "id": "7104|Acla (Safien)|GR",
+    "name": "Acla (Safien)",
+    "zipCode": "7104",
+    "canton": "GR"
+  },
+  {
+    "id": "1123|Aclens|VD",
+    "name": "Aclens",
+    "zipCode": "1123",
+    "canton": "VD"
+  },
+  {
+    "id": "6718|Acquacalda|TI",
+    "name": "Acquacalda",
+    "zipCode": "6718",
+    "canton": "TI"
+  },
+  {
+    "id": "6716|Acquarossa|TI",
+    "name": "Acquarossa",
+    "zipCode": "6716",
+    "canton": "TI"
+  },
+  {
+    "id": "3715|Adelboden|BE",
+    "name": "Adelboden",
+    "zipCode": "3715",
+    "canton": "BE"
+  },
+  {
+    "id": "4806|Adelboden|LU",
+    "name": "Adelboden",
+    "zipCode": "4806",
+    "canton": "LU"
+  },
+  {
+    "id": "8345|Adetswil|ZH",
+    "name": "Adetswil",
+    "zipCode": "8345",
+    "canton": "ZH"
+  },
+  {
+    "id": "6043|Adligenswil|LU",
+    "name": "Adligenswil",
+    "zipCode": "6043",
+    "canton": "LU"
+  },
+  {
+    "id": "8452|Adlikon bei Andelfingen|ZH",
+    "name": "Adlikon bei Andelfingen",
+    "zipCode": "8452",
+    "canton": "ZH"
+  },
+  {
+    "id": "8106|Adlikon bei Regensdorf|ZH",
+    "name": "Adlikon bei Regensdorf",
+    "zipCode": "8106",
+    "canton": "ZH"
+  },
+  {
+    "id": "8134|Adliswil|ZH",
+    "name": "Adliswil",
+    "zipCode": "8134",
+    "canton": "ZH"
+  },
+  {
+    "id": "3673|Aebersold (Ringgis)|BE",
+    "name": "Aebersold (Ringgis)",
+    "zipCode": "3673",
+    "canton": "BE"
+  },
+  {
+    "id": "4714|Aedermannsdorf|SO",
+    "name": "Aedermannsdorf",
+    "zipCode": "4714",
+    "canton": "SO"
+  },
+  {
+    "id": "3426|Aefligen|BE",
+    "name": "Aefligen",
+    "zipCode": "3426",
+    "canton": "BE"
+  },
+  {
+    "id": "2558|Aegerten|BE",
+    "name": "Aegerten",
+    "zipCode": "2558",
+    "canton": "BE"
+  },
+  {
+    "id": "3147|Aekenmatt|BE",
+    "name": "Aekenmatt",
+    "zipCode": "3147",
+    "canton": "BE"
+  },
+  {
+    "id": "4147|Aesch|BL",
+    "name": "Aesch",
+    "zipCode": "4147",
+    "canton": "BL"
+  },
+  {
+    "id": "6287|Aesch|LU",
+    "name": "Aesch",
+    "zipCode": "6287",
+    "canton": "LU"
+  },
+  {
+    "id": "8904|Aesch (ZH)|ZH",
+    "name": "Aesch (ZH)",
+    "zipCode": "8904",
+    "canton": "ZH"
+  },
+  {
+    "id": "8127|Aesch bei Maur|ZH",
+    "name": "Aesch bei Maur",
+    "zipCode": "8127",
+    "canton": "ZH"
+  },
+  {
+    "id": "8412|Aesch bei Neftenbach|ZH",
+    "name": "Aesch bei Neftenbach",
+    "zipCode": "8412",
+    "canton": "ZH"
+  },
+  {
+    "id": "3536|Aeschau|BE",
+    "name": "Aeschau",
+    "zipCode": "3536",
+    "canton": "BE"
+  },
+  {
+    "id": "4556|Aeschi|SO",
+    "name": "Aeschi",
+    "zipCode": "4556",
+    "canton": "SO"
+  },
+  {
+    "id": "3703|Aeschi bei Spiez|BE",
+    "name": "Aeschi bei Spiez",
+    "zipCode": "3703",
+    "canton": "BE"
+  },
+  {
+    "id": "3703|Aeschiried|BE",
+    "name": "Aeschiried",
+    "zipCode": "3703",
+    "canton": "BE"
+  },
+  {
+    "id": "3672|Aeschlen bei Oberdiessbach|BE",
+    "name": "Aeschlen bei Oberdiessbach",
+    "zipCode": "3672",
+    "canton": "BE"
+  },
+  {
+    "id": "3656|Aeschlen bei Sigriswil|BE",
+    "name": "Aeschlen bei Sigriswil",
+    "zipCode": "3656",
+    "canton": "BE"
+  },
+  {
+    "id": "4583|Aetigkofen|SO",
+    "name": "Aetigkofen",
+    "zipCode": "4583",
+    "canton": "SO"
+  },
+  {
+    "id": "4587|Aetingen|SO",
+    "name": "Aetingen",
+    "zipCode": "4587",
+    "canton": "SO"
+  },
+  {
+    "id": "5645|Aettenschwil|AG",
+    "name": "Aettenschwil",
+    "zipCode": "5645",
+    "canton": "AG"
+  },
+  {
+    "id": "8914|Aeugst am Albis|ZH",
+    "name": "Aeugst am Albis",
+    "zipCode": "8914",
+    "canton": "ZH"
+  },
+  {
+    "id": "8914|Aeugstertal|ZH",
+    "name": "Aeugstertal",
+    "zipCode": "8914",
+    "canton": "ZH"
+  },
+  {
+    "id": "9466|Aeugustisried|SG",
+    "name": "Aeugustisried",
+    "zipCode": "9466",
+    "canton": "SG"
+  },
+  {
+    "id": "7250|Aeuja|GR",
+    "name": "Aeuja",
+    "zipCode": "7250",
+    "canton": "GR"
+  },
+  {
+    "id": "7134|Affeier|GR",
+    "name": "Affeier",
+    "zipCode": "7134",
+    "canton": "GR"
+  },
+  {
+    "id": "9556|Affeltrangen|TG",
+    "name": "Affeltrangen",
+    "zipCode": "9556",
+    "canton": "TG"
+  },
+  {
+    "id": "8910|Affoltern am Albis|ZH",
+    "name": "Affoltern am Albis",
+    "zipCode": "8910",
+    "canton": "ZH"
+  },
+  {
+    "id": "8000|Affoltern bei Zürich|ZH",
+    "name": "Affoltern bei Zürich",
+    "zipCode": "8000",
+    "canton": "ZH"
+  },
+  {
+    "id": "3416|Affoltern im Emmental|BE",
+    "name": "Affoltern im Emmental",
+    "zipCode": "3416",
+    "canton": "BE"
+  },
+  {
+    "id": "3951|Agarn|VS",
+    "name": "Agarn",
+    "zipCode": "3951",
+    "canton": "VS"
+  },
+  {
+    "id": "6597|Agarone|TI",
+    "name": "Agarone",
+    "zipCode": "6597",
+    "canton": "TI"
+  },
+  {
+    "id": "8308|Agasul|ZH",
+    "name": "Agasul",
+    "zipCode": "8308",
+    "canton": "ZH"
+  },
+  {
+    "id": "4923|Ägerten|BE",
+    "name": "Ägerten",
+    "zipCode": "4923",
+    "canton": "BE"
+  },
+  {
+    "id": "1352|Agiez|VD",
+    "name": "Agiez",
+    "zipCode": "1352",
+    "canton": "VD"
+  },
+  {
+    "id": "6982|Agno|TI",
+    "name": "Agno",
+    "zipCode": "6982",
+    "canton": "TI"
+  },
+  {
+    "id": "6933|Agnuzzo|TI",
+    "name": "Agnuzzo",
+    "zipCode": "6933",
+    "canton": "TI"
+  },
+  {
+    "id": "6927|Agra|TI",
+    "name": "Agra",
+    "zipCode": "6927",
+    "canton": "TI"
+  },
+  {
+    "id": "3216|Agriswil|FR",
+    "name": "Agriswil",
+    "zipCode": "3216",
+    "canton": "FR"
+  },
+  {
+    "id": "1860|Aigle|VD",
+    "name": "Aigle",
+    "zipCode": "1860",
+    "canton": "VD"
+  },
+  {
+    "id": "1219|Aïre|GE",
+    "name": "Aïre",
+    "zipCode": "1219",
+    "canton": "GE"
+  },
+  {
+    "id": "1288|Aire-la-Ville|GE",
+    "name": "Aire-la-Ville",
+    "zipCode": "1288",
+    "canton": "GE"
+  },
+  {
+    "id": "6780|Airolo|TI",
+    "name": "Airolo",
+    "zipCode": "6780",
+    "canton": "TI"
+  },
+  {
+    "id": "3930|Albenried|VS",
+    "name": "Albenried",
+    "zipCode": "3930",
+    "canton": "VS"
+  },
+  {
+    "id": "6248|Alberswil|LU",
+    "name": "Alberswil",
+    "zipCode": "6248",
+    "canton": "LU"
+  },
+  {
+    "id": "1669|Albeuve|FR",
+    "name": "Albeuve",
+    "zipCode": "1669",
+    "canton": "FR"
+  },
+  {
+    "id": "3955|Albinen|VS",
+    "name": "Albinen",
+    "zipCode": "3955",
+    "canton": "VS"
+  },
+  {
+    "id": "8135|Albis|ZH",
+    "name": "Albis",
+    "zipCode": "8135",
+    "canton": "ZH"
+  },
+  {
+    "id": "8915|Albisbrunn|ZH",
+    "name": "Albisbrunn",
+    "zipCode": "8915",
+    "canton": "ZH"
+  },
+  {
+    "id": "8000|Albisrieden|ZH",
+    "name": "Albisrieden",
+    "zipCode": "8000",
+    "canton": "ZH"
+  },
+  {
+    "id": "3183|Albligen|BE",
+    "name": "Albligen",
+    "zipCode": "3183",
+    "canton": "BE"
+  },
+  {
+    "id": "6962|Albonago|TI",
+    "name": "Albonago",
+    "zipCode": "6962",
+    "canton": "TI"
+  },
+  {
+    "id": "6958|Albumo|TI",
+    "name": "Albumo",
+    "zipCode": "6958",
+    "canton": "TI"
+  },
+  {
+    "id": "3422|Alchenflüh|BE",
+    "name": "Alchenflüh",
+    "zipCode": "3422",
+    "canton": "BE"
+  },
+  {
+    "id": "3473|Alchenstorf|BE",
+    "name": "Alchenstorf",
+    "zipCode": "3473",
+    "canton": "BE"
+  },
+  {
+    "id": "6974|Aldesago|TI",
+    "name": "Aldesago",
+    "zipCode": "6974",
+    "canton": "TI"
+  },
+  {
+    "id": "2512|Alfermée|BE",
+    "name": "Alfermée",
+    "zipCode": "2512",
+    "canton": "BE"
+  },
+  {
+    "id": "9249|Algetshausen|SG",
+    "name": "Algetshausen",
+    "zipCode": "9249",
+    "canton": "SG"
+  },
+  {
+    "id": "5643|Alikon|AG",
+    "name": "Alikon",
+    "zipCode": "5643",
+    "canton": "AG"
+  },
+  {
+    "id": "6781|All'Acqua|TI",
+    "name": "All'Acqua",
+    "zipCode": "6781",
+    "canton": "TI"
+  },
+  {
+    "id": "1165|Allaman|VD",
+    "name": "Allaman",
+    "zipCode": "1165",
+    "canton": "VD"
+  },
+  {
+    "id": "2942|Alle|JU",
+    "name": "Alle",
+    "zipCode": "2942",
+    "canton": "JU"
+  },
+  {
+    "id": "3205|Allenlüften|BE",
+    "name": "Allenlüften",
+    "zipCode": "3205",
+    "canton": "BE"
+  },
+  {
+    "id": "1304|Allens|VD",
+    "name": "Allens",
+    "zipCode": "1304",
+    "canton": "VD"
+  },
+  {
+    "id": "3054|Allenwil|BE",
+    "name": "Allenwil",
+    "zipCode": "3054",
+    "canton": "BE"
+  },
+  {
+    "id": "6319|Allenwinden|ZG",
+    "name": "Allenwinden",
+    "zipCode": "6319",
+    "canton": "ZG"
+  },
+  {
+    "id": "4615|Allerheiligenberg|SO",
+    "name": "Allerheiligenberg",
+    "zipCode": "4615",
+    "canton": "SO"
+  },
+  {
+    "id": "1905|Allesse|VS",
+    "name": "Allesse",
+    "zipCode": "1905",
+    "canton": "VS"
+  },
+  {
+    "id": "1669|Allières|FR",
+    "name": "Allières",
+    "zipCode": "1669",
+    "canton": "FR"
+  },
+  {
+    "id": "5706|Alliswil|AG",
+    "name": "Alliswil",
+    "zipCode": "5706",
+    "canton": "AG"
+  },
+  {
+    "id": "3600|Allmendingen|BE",
+    "name": "Allmendingen",
+    "zipCode": "3600",
+    "canton": "BE"
+  },
+  {
+    "id": "3112|Allmendingen bei Bern|BE",
+    "name": "Allmendingen bei Bern",
+    "zipCode": "3112",
+    "canton": "BE"
+  },
+  {
+    "id": "9428|Allmendsberg|AR",
+    "name": "Allmendsberg",
+    "zipCode": "9428",
+    "canton": "AR"
+  },
+  {
+    "id": "4123|Allschwil|BL",
+    "name": "Allschwil",
+    "zipCode": "4123",
+    "canton": "BL"
+  },
+  {
+    "id": "6372|Allweg|NW",
+    "name": "Allweg",
+    "zipCode": "6372",
+    "canton": "NW"
+  },
+  {
+    "id": "7416|Almens|GR",
+    "name": "Almens",
+    "zipCode": "7416",
+    "canton": "GR"
+  },
+  {
+    "id": "6315|Alosen|ZG",
+    "name": "Alosen",
+    "zipCode": "6315",
+    "canton": "ZG"
+  },
+  {
+    "id": "7710|Alp Grüm|GR",
+    "name": "Alp Grüm",
+    "zipCode": "7710",
+    "canton": "GR"
+  },
+  {
+    "id": "6055|Alpnach Dorf|OW",
+    "name": "Alpnach Dorf",
+    "zipCode": "6055",
+    "canton": "OW"
+  },
+  {
+    "id": "6053|Alpnachstad|OW",
+    "name": "Alpnachstad",
+    "zipCode": "6053",
+    "canton": "OW"
+  },
+  {
+    "id": "8849|Alpthal|SZ",
+    "name": "Alpthal",
+    "zipCode": "8849",
+    "canton": "SZ"
+  },
+  {
+    "id": "9656|Alt St. Johann|SG",
+    "name": "Alt St. Johann",
+    "zipCode": "9656",
+    "canton": "SG"
+  },
+  {
+    "id": "6776|Altanca|TI",
+    "name": "Altanca",
+    "zipCode": "6776",
+    "canton": "TI"
+  },
+  {
+    "id": "3280|Altavilla|FR",
+    "name": "Altavilla",
+    "zipCode": "3280",
+    "canton": "FR"
+  },
+  {
+    "id": "8164|Altbachs|ZH",
+    "name": "Altbachs",
+    "zipCode": "8164",
+    "canton": "ZH"
+  },
+  {
+    "id": "6147|Altbüron|LU",
+    "name": "Altbüron",
+    "zipCode": "6147",
+    "canton": "LU"
+  },
+  {
+    "id": "6460|Altdorf|UR",
+    "name": "Altdorf",
+    "zipCode": "6460",
+    "canton": "UR"
+  },
+  {
+    "id": "8243|Altdorf|SH",
+    "name": "Altdorf",
+    "zipCode": "8243",
+    "canton": "SH"
+  },
+  {
+    "id": "8453|Alten|ZH",
+    "name": "Alten",
+    "zipCode": "8453",
+    "canton": "ZH"
+  },
+  {
+    "id": "5210|Altenburg|AG",
+    "name": "Altenburg",
+    "zipCode": "5210",
+    "canton": "AG"
+  },
+  {
+    "id": "8852|Altendorf|SZ",
+    "name": "Altendorf",
+    "zipCode": "8852",
+    "canton": "SZ"
+  },
+  {
+    "id": "9470|Altendorf|SG",
+    "name": "Altendorf",
+    "zipCode": "9470",
+    "canton": "SG"
+  },
+  {
+    "id": "8560|Altenklingen|TG",
+    "name": "Altenklingen",
+    "zipCode": "8560",
+    "canton": "TG"
+  },
+  {
+    "id": "9423|Altenrhein|SG",
+    "name": "Altenrhein",
+    "zipCode": "9423",
+    "canton": "SG"
+  },
+  {
+    "id": "1715|Alterswil|FR",
+    "name": "Alterswil",
+    "zipCode": "1715",
+    "canton": "FR"
+  },
+  {
+    "id": "9230|Alterswil|SG",
+    "name": "Alterswil",
+    "zipCode": "9230",
+    "canton": "SG"
+  },
+  {
+    "id": "8573|Alterswilen|TG",
+    "name": "Alterswilen",
+    "zipCode": "8573",
+    "canton": "TG"
+  },
+  {
+    "id": "5628|Althäusern|AG",
+    "name": "Althäusern",
+    "zipCode": "5628",
+    "canton": "AG"
+  },
+  {
+    "id": "8479|Altikon|ZH",
+    "name": "Altikon",
+    "zipCode": "8479",
+    "canton": "ZH"
+  },
+  {
+    "id": "8573|Altishausen|TG",
+    "name": "Altishausen",
+    "zipCode": "8573",
+    "canton": "TG"
+  },
+  {
+    "id": "6246|Altishofen|LU",
+    "name": "Altishofen",
+    "zipCode": "6246",
+    "canton": "LU"
+  },
+  {
+    "id": "8595|Altnau|TG",
+    "name": "Altnau",
+    "zipCode": "8595",
+    "canton": "TG"
+  },
+  {
+    "id": "2545|Altreu|SO",
+    "name": "Altreu",
+    "zipCode": "2545",
+    "canton": "SO"
+  },
+  {
+    "id": "5225|Altstalden|AG",
+    "name": "Altstalden",
+    "zipCode": "5225",
+    "canton": "AG"
+  },
+  {
+    "id": "9450|Altstätten|SG",
+    "name": "Altstätten",
+    "zipCode": "9450",
+    "canton": "SG"
+  },
+  {
+    "id": "8000|Altstetten|ZH",
+    "name": "Altstetten",
+    "zipCode": "8000",
+    "canton": "ZH"
+  },
+  {
+    "id": "6286|Altwis|LU",
+    "name": "Altwis",
+    "zipCode": "6286",
+    "canton": "LU"
+  },
+  {
+    "id": "7473|Alvaneu Bad|GR",
+    "name": "Alvaneu Bad",
+    "zipCode": "7473",
+    "canton": "GR"
+  },
+  {
+    "id": "7492|Alvaneu Dorf|GR",
+    "name": "Alvaneu Dorf",
+    "zipCode": "7492",
+    "canton": "GR"
+  },
+  {
+    "id": "7451|Alvaschein|GR",
+    "name": "Alvaschein",
+    "zipCode": "7451",
+    "canton": "GR"
+  },
+  {
+    "id": "7447|Am Bach|GR",
+    "name": "Am Bach",
+    "zipCode": "7447",
+    "canton": "GR"
+  },
+  {
+    "id": "6775|Ambrì|TI",
+    "name": "Ambrì",
+    "zipCode": "6775",
+    "canton": "TI"
+  },
+  {
+    "id": "8873|Amden|SG",
+    "name": "Amden",
+    "zipCode": "8873",
+    "canton": "SG"
+  },
+  {
+    "id": "8133|Ämet|ZH",
+    "name": "Ämet",
+    "zipCode": "8133",
+    "canton": "ZH"
+  },
+  {
+    "id": "3963|Aminona-sur-Sierre|VS",
+    "name": "Aminona-sur-Sierre",
+    "zipCode": "3963",
+    "canton": "VS"
+  },
+  {
+    "id": "8514|Amlikon|TG",
+    "name": "Amlikon",
+    "zipCode": "8514",
+    "canton": "TG"
+  },
+  {
+    "id": "4573|Ammannsegg|SO",
+    "name": "Ammannsegg",
+    "zipCode": "4573",
+    "canton": "SO"
+  },
+  {
+    "id": "8506|Ammenhausen|TG",
+    "name": "Ammenhausen",
+    "zipCode": "8506",
+    "canton": "TG"
+  },
+  {
+    "id": "5600|Ammerswil|AG",
+    "name": "Ammerswil",
+    "zipCode": "5600",
+    "canton": "AG"
+  },
+  {
+    "id": "3257|Ammerzwil|BE",
+    "name": "Ammerzwil",
+    "zipCode": "3257",
+    "canton": "BE"
+  },
+  {
+    "id": "8580|Amriswil|TG",
+    "name": "Amriswil",
+    "zipCode": "8580",
+    "canton": "TG"
+  },
+  {
+    "id": "3633|Amsoldingen|BE",
+    "name": "Amsoldingen",
+    "zipCode": "3633",
+    "canton": "BE"
+  },
+  {
+    "id": "6474|Amsteg|UR",
+    "name": "Amsteg",
+    "zipCode": "6474",
+    "canton": "UR"
+  },
+  {
+    "id": "7440|Andeer|GR",
+    "name": "Andeer",
+    "zipCode": "7440",
+    "canton": "GR"
+  },
+  {
+    "id": "8450|Andelfingen|ZH",
+    "name": "Andelfingen",
+    "zipCode": "8450",
+    "canton": "ZH"
+  },
+  {
+    "id": "6490|Andermatt|UR",
+    "name": "Andermatt",
+    "zipCode": "6490",
+    "canton": "UR"
+  },
+  {
+    "id": "8572|Andhausen|TG",
+    "name": "Andhausen",
+    "zipCode": "8572",
+    "canton": "TG"
+  },
+  {
+    "id": "7159|Andiast|GR",
+    "name": "Andiast",
+    "zipCode": "7159",
+    "canton": "GR"
+  },
+  {
+    "id": "8586|Andwil|TG",
+    "name": "Andwil",
+    "zipCode": "8586",
+    "canton": "TG"
+  },
+  {
+    "id": "9204|Andwil|SG",
+    "name": "Andwil",
+    "zipCode": "9204",
+    "canton": "SG"
+  },
+  {
+    "id": "9545|Anetswil|TG",
+    "name": "Anetswil",
+    "zipCode": "9545",
+    "canton": "TG"
+  },
+  {
+    "id": "4147|Angenstein|BL",
+    "name": "Angenstein",
+    "zipCode": "4147",
+    "canton": "BL"
+  },
+  {
+    "id": "5611|Anglikon|AG",
+    "name": "Anglikon",
+    "zipCode": "5611",
+    "canton": "AG"
+  },
+  {
+    "id": "1247|Anières|GE",
+    "name": "Anières",
+    "zipCode": "1247",
+    "canton": "GE"
+  },
+  {
+    "id": "7745|Annunziata|GR",
+    "name": "Annunziata",
+    "zipCode": "7745",
+    "canton": "GR"
+  },
+  {
+    "id": "1867|Antagnes|VD",
+    "name": "Antagnes",
+    "zipCode": "1867",
+    "canton": "VD"
+  },
+  {
+    "id": "4469|Anwil|BL",
+    "name": "Anwil",
+    "zipCode": "4469",
+    "canton": "BL"
+  },
+  {
+    "id": "1882|Anzeinda|VD",
+    "name": "Anzeinda",
+    "zipCode": "1882",
+    "canton": "VD"
+  },
+  {
+    "id": "1972|Anzère|VS",
+    "name": "Anzère",
+    "zipCode": "1972",
+    "canton": "VS"
+  },
+  {
+    "id": "6748|Anzonico|TI",
+    "name": "Anzonico",
+    "zipCode": "6748",
+    "canton": "TI"
+  },
+  {
+    "id": "9050|Appenzell|AI",
+    "name": "Appenzell",
+    "zipCode": "9050",
+    "canton": "AI"
+  },
+  {
+    "id": "1143|Apples|VD",
+    "name": "Apples",
+    "zipCode": "1143",
+    "canton": "VD"
+  },
+  {
+    "id": "1994|Aproz|VS",
+    "name": "Aproz",
+    "zipCode": "1994",
+    "canton": "VS"
+  },
+  {
+    "id": "6719|Aquila|TI",
+    "name": "Aquila",
+    "zipCode": "6719",
+    "canton": "TI"
+  },
+  {
+    "id": "1091|Aran|VD",
+    "name": "Aran",
+    "zipCode": "1091",
+    "canton": "VD"
+  },
+  {
+    "id": "6994|Aranno|TI",
+    "name": "Aranno",
+    "zipCode": "6994",
+    "canton": "TI"
+  },
+  {
+    "id": "1212|Arare|GE",
+    "name": "Arare",
+    "zipCode": "1212",
+    "canton": "GE"
+  },
+  {
+    "id": "7062|Araschgen|GR",
+    "name": "Araschgen",
+    "zipCode": "7062",
+    "canton": "GR"
+  },
+  {
+    "id": "6340|Arbach|ZG",
+    "name": "Arbach",
+    "zipCode": "6340",
+    "canton": "ZG"
+  },
+  {
+    "id": "1974|Arbaz|VS",
+    "name": "Arbaz",
+    "zipCode": "1974",
+    "canton": "VS"
+  },
+  {
+    "id": "6517|Arbedo|TI",
+    "name": "Arbedo",
+    "zipCode": "6517",
+    "canton": "TI"
+  },
+  {
+    "id": "4424|Arboldswil|BL",
+    "name": "Arboldswil",
+    "zipCode": "4424",
+    "canton": "BL"
+  },
+  {
+    "id": "9320|Arbon|TG",
+    "name": "Arbon",
+    "zipCode": "9320",
+    "canton": "TG"
+  },
+  {
+    "id": "6618|Arcegno|TI",
+    "name": "Arcegno",
+    "zipCode": "6618",
+    "canton": "TI"
+  },
+  {
+    "id": "3296|Arch|BE",
+    "name": "Arch",
+    "zipCode": "3296",
+    "canton": "BE"
+  },
+  {
+    "id": "1732|Arconciel|FR",
+    "name": "Arconciel",
+    "zipCode": "1732",
+    "canton": "FR"
+  },
+  {
+    "id": "7546|Ardez|GR",
+    "name": "Ardez",
+    "zipCode": "7546",
+    "canton": "GR"
+  },
+  {
+    "id": "1957|Ardon|VS",
+    "name": "Ardon",
+    "zipCode": "1957",
+    "canton": "VS"
+  },
+  {
+    "id": "8268|Arenenberg|TG",
+    "name": "Arenenberg",
+    "zipCode": "8268",
+    "canton": "TG"
+  },
+  {
+    "id": "2015|Areuse|NE",
+    "name": "Areuse",
+    "zipCode": "2015",
+    "canton": "NE"
+  },
+  {
+    "id": "7104|Arezen|GR",
+    "name": "Arezen",
+    "zipCode": "7104",
+    "canton": "GR"
+  },
+  {
+    "id": "1966|Argnoud|VS",
+    "name": "Argnoud",
+    "zipCode": "1966",
+    "canton": "VS"
+  },
+  {
+    "id": "4422|Arisdorf|BL",
+    "name": "Arisdorf",
+    "zipCode": "4422",
+    "canton": "BL"
+  },
+  {
+    "id": "5628|Aristau|AG",
+    "name": "Aristau",
+    "zipCode": "5628",
+    "canton": "AG"
+  },
+  {
+    "id": "4144|Arlesheim|BL",
+    "name": "Arlesheim",
+    "zipCode": "4144",
+    "canton": "BL"
+  },
+  {
+    "id": "8810|Arn|ZH",
+    "name": "Arn",
+    "zipCode": "8810",
+    "canton": "ZH"
+  },
+  {
+    "id": "9212|Arnegg|SG",
+    "name": "Arnegg",
+    "zipCode": "9212",
+    "canton": "SG"
+  },
+  {
+    "id": "1277|Arnex-sur-Nyon|VD",
+    "name": "Arnex-sur-Nyon",
+    "zipCode": "1277",
+    "canton": "VD"
+  },
+  {
+    "id": "1321|Arnex-sur-Orbe|VD",
+    "name": "Arnex-sur-Orbe",
+    "zipCode": "1321",
+    "canton": "VD"
+  },
+  {
+    "id": "3508|Arni|BE",
+    "name": "Arni",
+    "zipCode": "3508",
+    "canton": "BE"
+  },
+  {
+    "id": "8905|Arni|AG",
+    "name": "Arni",
+    "zipCode": "8905",
+    "canton": "AG"
+  },
+  {
+    "id": "3508|Arnisäge|BE",
+    "name": "Arnisäge",
+    "zipCode": "3508",
+    "canton": "BE"
+  },
+  {
+    "id": "6822|Arogno|TI",
+    "name": "Arogno",
+    "zipCode": "6822",
+    "canton": "TI"
+  },
+  {
+    "id": "1986|Arolla|VS",
+    "name": "Arolla",
+    "zipCode": "1986",
+    "canton": "VS"
+  },
+  {
+    "id": "7050|Arosa|GR",
+    "name": "Arosa",
+    "zipCode": "7050",
+    "canton": "GR"
+  },
+  {
+    "id": "6939|Arosio|TI",
+    "name": "Arosio",
+    "zipCode": "6939",
+    "canton": "TI"
+  },
+  {
+    "id": "1463|Arrissoules|VD",
+    "name": "Arrissoules",
+    "zipCode": "1463",
+    "canton": "VD"
+  },
+  {
+    "id": "1680|Arruffens|FR",
+    "name": "Arruffens",
+    "zipCode": "1680",
+    "canton": "FR"
+  },
+  {
+    "id": "6415|Arth|SZ",
+    "name": "Arth",
+    "zipCode": "6415",
+    "canton": "SZ"
+  },
+  {
+    "id": "6500|Artore|TI",
+    "name": "Artore",
+    "zipCode": "6500",
+    "canton": "TI"
+  },
+  {
+    "id": "1884|Arveyes|VD",
+    "name": "Arveyes",
+    "zipCode": "1884",
+    "canton": "VD"
+  },
+  {
+    "id": "6543|Arvigo|GR",
+    "name": "Arvigo",
+    "zipCode": "6543",
+    "canton": "GR"
+  },
+  {
+    "id": "1991|Arvillard|VS",
+    "name": "Arvillard",
+    "zipCode": "1991",
+    "canton": "VS"
+  },
+  {
+    "id": "1273|Arzier|VD",
+    "name": "Arzier",
+    "zipCode": "1273",
+    "canton": "VD"
+  },
+  {
+    "id": "6864|Arzo|TI",
+    "name": "Arzo",
+    "zipCode": "6864",
+    "canton": "TI"
+  },
+  {
+    "id": "7245|Ascharina|GR",
+    "name": "Ascharina",
+    "zipCode": "7245",
+    "canton": "GR"
+  },
+  {
+    "id": "6612|Ascona|TI",
+    "name": "Ascona",
+    "zipCode": "6612",
+    "canton": "TI"
+  },
+  {
+    "id": "5025|Asp|AG",
+    "name": "Asp",
+    "zipCode": "5025",
+    "canton": "AG"
+  },
+  {
+    "id": "1042|Assens|VD",
+    "name": "Assens",
+    "zipCode": "1042",
+    "canton": "VD"
+  },
+  {
+    "id": "8572|Ast|TG",
+    "name": "Ast",
+    "zipCode": "8572",
+    "canton": "TG"
+  },
+  {
+    "id": "6999|Astano|TI",
+    "name": "Astano",
+    "zipCode": "6999",
+    "canton": "TI"
+  },
+  {
+    "id": "2954|Asuel|JU",
+    "name": "Asuel",
+    "zipCode": "2954",
+    "canton": "JU"
+  },
+  {
+    "id": "1285|Athenaz|GE",
+    "name": "Athenaz",
+    "zipCode": "1285",
+    "canton": "GE"
+  },
+  {
+    "id": "1616|Attalens|FR",
+    "name": "Attalens",
+    "zipCode": "1616",
+    "canton": "FR"
+  },
+  {
+    "id": "5056|Attelwil|AG",
+    "name": "Attelwil",
+    "zipCode": "5056",
+    "canton": "AG"
+  },
+  {
+    "id": "8544|Attikon|ZH",
+    "name": "Attikon",
+    "zipCode": "8544",
+    "canton": "ZH"
+  },
+  {
+    "id": "6468|Attinghausen|UR",
+    "name": "Attinghausen",
+    "zipCode": "6468",
+    "canton": "UR"
+  },
+  {
+    "id": "4533|Attisholz|SO",
+    "name": "Attisholz",
+    "zipCode": "4533",
+    "canton": "SO"
+  },
+  {
+    "id": "4536|Attiswil|BE",
+    "name": "Attiswil",
+    "zipCode": "4536",
+    "canton": "BE"
+  },
+  {
+    "id": "5105|Au|AG",
+    "name": "Au",
+    "zipCode": "5105",
+    "canton": "AG"
+  },
+  {
+    "id": "8376|Au|TG",
+    "name": "Au",
+    "zipCode": "8376",
+    "canton": "TG"
+  },
+  {
+    "id": "8804|Au|ZH",
+    "name": "Au",
+    "zipCode": "8804",
+    "canton": "ZH"
+  },
+  {
+    "id": "9434|Au|SG",
+    "name": "Au",
+    "zipCode": "9434",
+    "canton": "SG"
+  },
+  {
+    "id": "1170|Aubonne|VD",
+    "name": "Aubonne",
+    "zipCode": "1170",
+    "canton": "VD"
+  },
+  {
+    "id": "1673|Auboranges|FR",
+    "name": "Auboranges",
+    "zipCode": "1673",
+    "canton": "FR"
+  },
+  {
+    "id": "1914|Auddes-sur-Riddes|VS",
+    "name": "Auddes-sur-Riddes",
+    "zipCode": "1914",
+    "canton": "VS"
+  },
+  {
+    "id": "5105|Auenstein|AG",
+    "name": "Auenstein",
+    "zipCode": "5105",
+    "canton": "AG"
+  },
+  {
+    "id": "6547|Augio|GR",
+    "name": "Augio",
+    "zipCode": "6547",
+    "canton": "GR"
+  },
+  {
+    "id": "4302|Augst|BL",
+    "name": "Augst",
+    "zipCode": "4302",
+    "canton": "BL"
+  },
+  {
+    "id": "8426|Augwil|ZH",
+    "name": "Augwil",
+    "zipCode": "8426",
+    "canton": "ZH"
+  },
+  {
+    "id": "1867|Auliens|VD",
+    "name": "Auliens",
+    "zipCode": "1867",
+    "canton": "VD"
+  },
+  {
+    "id": "1484|Aumont|FR",
+    "name": "Aumont",
+    "zipCode": "1484",
+    "canton": "FR"
+  },
+  {
+    "id": "6661|Auressio|TI",
+    "name": "Auressio",
+    "zipCode": "6661",
+    "canton": "TI"
+  },
+  {
+    "id": "6677|Aurigeno|TI",
+    "name": "Aurigeno",
+    "zipCode": "6677",
+    "canton": "TI"
+  },
+  {
+    "id": "8331|Auslikon|ZH",
+    "name": "Auslikon",
+    "zipCode": "8331",
+    "canton": "ZH"
+  },
+  {
+    "id": "1891|Aussays|VS",
+    "name": "Aussays",
+    "zipCode": "1891",
+    "canton": "VS"
+  },
+  {
+    "id": "3938|Ausserberg|VS",
+    "name": "Ausserberg",
+    "zipCode": "3938",
+    "canton": "VS"
+  },
+  {
+    "id": "3995|Ausserbinn|VS",
+    "name": "Ausserbinn",
+    "zipCode": "3995",
+    "canton": "VS"
+  },
+  {
+    "id": "8474|Ausserdinhard|ZH",
+    "name": "Ausserdinhard",
+    "zipCode": "8474",
+    "canton": "ZH"
+  },
+  {
+    "id": "3619|Aussereriz|BE",
+    "name": "Aussereriz",
+    "zipCode": "3619",
+    "canton": "BE"
+  },
+  {
+    "id": "7444|Ausserferrera|GR",
+    "name": "Ausserferrera",
+    "zipCode": "7444",
+    "canton": "GR"
+  },
+  {
+    "id": "8000|Aussersihl|ZH",
+    "name": "Aussersihl",
+    "zipCode": "8000",
+    "canton": "ZH"
+  },
+  {
+    "id": "4944|Auswil|BE",
+    "name": "Auswil",
+    "zipCode": "4944",
+    "canton": "BE"
+  },
+  {
+    "id": "1782|Autafond|FR",
+    "name": "Autafond",
+    "zipCode": "1782",
+    "canton": "FR"
+  },
+  {
+    "id": "1475|Autavaux|FR",
+    "name": "Autavaux",
+    "zipCode": "1475",
+    "canton": "FR"
+  },
+  {
+    "id": "1742|Autigny|FR",
+    "name": "Autigny",
+    "zipCode": "1742",
+    "canton": "FR"
+  },
+  {
+    "id": "2012|Auvernier|NE",
+    "name": "Auvernier",
+    "zipCode": "2012",
+    "canton": "NE"
+  },
+  {
+    "id": "5644|Auw|AG",
+    "name": "Auw",
+    "zipCode": "5644",
+    "canton": "AG"
+  },
+  {
+    "id": "6670|Avegno|TI",
+    "name": "Avegno",
+    "zipCode": "6670",
+    "canton": "TI"
+  },
+  {
+    "id": "1976|Aven|VS",
+    "name": "Aven",
+    "zipCode": "1976",
+    "canton": "VS"
+  },
+  {
+    "id": "1580|Avenches|VD",
+    "name": "Avenches",
+    "zipCode": "1580",
+    "canton": "VD"
+  },
+  {
+    "id": "1274|Avenex|VD",
+    "name": "Avenex",
+    "zipCode": "1274",
+    "canton": "VD"
+  },
+  {
+    "id": "7447|Avers|GR",
+    "name": "Avers",
+    "zipCode": "7447",
+    "canton": "GR"
+  },
+  {
+    "id": "1644|Avry-devant-Pont|FR",
+    "name": "Avry-devant-Pont",
+    "zipCode": "1644",
+    "canton": "FR"
+  },
+  {
+    "id": "1754|Avry-sur-Matran|FR",
+    "name": "Avry-sur-Matran",
+    "zipCode": "1754",
+    "canton": "FR"
+  },
+  {
+    "id": "1237|Avully|GE",
+    "name": "Avully",
+    "zipCode": "1237",
+    "canton": "GE"
+  },
+  {
+    "id": "1285|Avusy|GE",
+    "name": "Avusy",
+    "zipCode": "1285",
+    "canton": "GE"
+  },
+  {
+    "id": "3855|Axalp|BE",
+    "name": "Axalp",
+    "zipCode": "3855",
+    "canton": "BE"
+  },
+  {
+    "id": "3961|Ayer|VS",
+    "name": "Ayer",
+    "zipCode": "3961",
+    "canton": "VS"
+  },
+  {
+    "id": "9478|Azmoos|SG",
+    "name": "Azmoos",
+    "zipCode": "9478",
+    "canton": "SG"
+  },
+  {
+    "id": "1996|Baar|VS",
+    "name": "Baar",
+    "zipCode": "1996",
+    "canton": "VS"
+  },
+  {
+    "id": "6340|Baar|ZG",
+    "name": "Baar",
+    "zipCode": "6340",
+    "canton": "ZG"
+  },
+  {
+    "id": "8806|Bäch|SZ",
+    "name": "Bäch",
+    "zipCode": "8806",
+    "canton": "SZ"
+  },
+  {
+    "id": "8806|Bächau|SZ",
+    "name": "Bächau",
+    "zipCode": "8806",
+    "canton": "SZ"
+  },
+  {
+    "id": "8184|Bachenbülach|ZH",
+    "name": "Bachenbülach",
+    "zipCode": "8184",
+    "canton": "ZH"
+  },
+  {
+    "id": "9452|Bächis|SG",
+    "name": "Bächis",
+    "zipCode": "9452",
+    "canton": "SG"
+  },
+  {
+    "id": "4000|Bachletten|BS",
+    "name": "Bachletten",
+    "zipCode": "4000",
+    "canton": "BS"
+  },
+  {
+    "id": "9633|Bächli|SG",
+    "name": "Bächli",
+    "zipCode": "9633",
+    "canton": "SG"
+  },
+  {
+    "id": "8164|Bachs|ZH",
+    "name": "Bachs",
+    "zipCode": "8164",
+    "canton": "ZH"
+  },
+  {
+    "id": "8342|Bachtel|ZH",
+    "name": "Bachtel",
+    "zipCode": "8342",
+    "canton": "ZH"
+  },
+  {
+    "id": "6213|Bad Knutwil|LU",
+    "name": "Bad Knutwil",
+    "zipCode": "6213",
+    "canton": "LU"
+  },
+  {
+    "id": "7310|Bad Ragaz|SG",
+    "name": "Bad Ragaz",
+    "zipCode": "7310",
+    "canton": "SG"
+  },
+  {
+    "id": "5330|Bad Zurzach|AG",
+    "name": "Bad Zurzach",
+    "zipCode": "5330",
+    "canton": "AG"
+  },
+  {
+    "id": "5400|Baden|AG",
+    "name": "Baden",
+    "zipCode": "5400",
+    "canton": "AG"
+  },
+  {
+    "id": "3267|Baggwil|BE",
+    "name": "Baggwil",
+    "zipCode": "3267",
+    "canton": "BE"
+  },
+  {
+    "id": "1934|Bagnes|VS",
+    "name": "Bagnes",
+    "zipCode": "1934",
+    "canton": "VS"
+  },
+  {
+    "id": "6283|Baldegg|LU",
+    "name": "Baldegg",
+    "zipCode": "6283",
+    "canton": "LU"
+  },
+  {
+    "id": "5333|Baldingen|AG",
+    "name": "Baldingen",
+    "zipCode": "5333",
+    "canton": "AG"
+  },
+  {
+    "id": "7317|Balen|SG",
+    "name": "Balen",
+    "zipCode": "7317",
+    "canton": "SG"
+  },
+  {
+    "id": "6828|Balerna|TI",
+    "name": "Balerna",
+    "zipCode": "6828",
+    "canton": "TI"
+  },
+  {
+    "id": "9436|Balgach|SG",
+    "name": "Balgach",
+    "zipCode": "9436",
+    "canton": "SG"
+  },
+  {
+    "id": "1338|Ballaigues|VD",
+    "name": "Ballaigues",
+    "zipCode": "1338",
+    "canton": "VD"
+  },
+  {
+    "id": "1144|Ballens|VD",
+    "name": "Ballens",
+    "zipCode": "1144",
+    "canton": "VD"
+  },
+  {
+    "id": "3303|Ballmoos|BE",
+    "name": "Ballmoos",
+    "zipCode": "3303",
+    "canton": "BE"
+  },
+  {
+    "id": "6275|Ballwil|LU",
+    "name": "Ballwil",
+    "zipCode": "6275",
+    "canton": "LU"
+  },
+  {
+    "id": "4525|Balm bei Günsberg|SO",
+    "name": "Balm bei Günsberg",
+    "zipCode": "4525",
+    "canton": "SO"
+  },
+  {
+    "id": "3860|Balm bei Meiringen|BE",
+    "name": "Balm bei Meiringen",
+    "zipCode": "3860",
+    "canton": "BE"
+  },
+  {
+    "id": "3254|Balm bei Messen|SO",
+    "name": "Balm bei Messen",
+    "zipCode": "3254",
+    "canton": "SO"
+  },
+  {
+    "id": "4524|Balmberg|SO",
+    "name": "Balmberg",
+    "zipCode": "4524",
+    "canton": "SO"
+  },
+  {
+    "id": "4710|Balsthal|SO",
+    "name": "Balsthal",
+    "zipCode": "4710",
+    "canton": "SO"
+  },
+  {
+    "id": "8962|Baltenschwil|AG",
+    "name": "Baltenschwil",
+    "zipCode": "8962",
+    "canton": "AG"
+  },
+  {
+    "id": "8303|Baltenswil|ZH",
+    "name": "Baltenswil",
+    "zipCode": "8303",
+    "canton": "ZH"
+  },
+  {
+    "id": "8362|Balterswil|TG",
+    "name": "Balterswil",
+    "zipCode": "8362",
+    "canton": "TG"
+  },
+  {
+    "id": "3937|Baltschieder|VS",
+    "name": "Baltschieder",
+    "zipCode": "3937",
+    "canton": "VS"
+  },
+  {
+    "id": "4856|Balzenwil|AG",
+    "name": "Balzenwil",
+    "zipCode": "4856",
+    "canton": "AG"
+  },
+  {
+    "id": "6981|Banco|TI",
+    "name": "Banco",
+    "zipCode": "6981",
+    "canton": "TI"
+  },
+  {
+    "id": "3256|Bangerten bei Dieterswil|BE",
+    "name": "Bangerten bei Dieterswil",
+    "zipCode": "3256",
+    "canton": "BE"
+  },
+  {
+    "id": "3076|Bangerten bei Worb|BE",
+    "name": "Bangerten bei Worb",
+    "zipCode": "3076",
+    "canton": "BE"
+  },
+  {
+    "id": "8426|Bänikon|ZH",
+    "name": "Bänikon",
+    "zipCode": "8426",
+    "canton": "ZH"
+  },
+  {
+    "id": "8514|Bänikon|TG",
+    "name": "Bänikon",
+    "zipCode": "8514",
+    "canton": "TG"
+  },
+  {
+    "id": "8471|Bänk|ZH",
+    "name": "Bänk",
+    "zipCode": "8471",
+    "canton": "ZH"
+  },
+  {
+    "id": "4913|Bannwil|BE",
+    "name": "Bannwil",
+    "zipCode": "4913",
+    "canton": "BE"
+  },
+  {
+    "id": "3065|Bantigen|BE",
+    "name": "Bantigen",
+    "zipCode": "3065",
+    "canton": "BE"
+  },
+  {
+    "id": "3552|Bärau|BE",
+    "name": "Bärau",
+    "zipCode": "3552",
+    "canton": "BE"
+  },
+  {
+    "id": "6917|Barbengo|TI",
+    "name": "Barbengo",
+    "zipCode": "6917",
+    "canton": "TI"
+  },
+  {
+    "id": "6917|Barbengo Paese|TI",
+    "name": "Barbengo Paese",
+    "zipCode": "6917",
+    "canton": "TI"
+  },
+  {
+    "id": "1783|Barberêche|FR",
+    "name": "Barberêche",
+    "zipCode": "1783",
+    "canton": "FR"
+  },
+  {
+    "id": "1257|Bardonnex|GE",
+    "name": "Bardonnex",
+    "zipCode": "1257",
+    "canton": "GE"
+  },
+  {
+    "id": "8344|Bäretswil|ZH",
+    "name": "Bäretswil",
+    "zipCode": "8344",
+    "canton": "ZH"
+  },
+  {
+    "id": "3204|Bärfischenhaus|BE",
+    "name": "Bärfischenhaus",
+    "zipCode": "3204",
+    "canton": "BE"
+  },
+  {
+    "id": "3282|Bargen|BE",
+    "name": "Bargen",
+    "zipCode": "3282",
+    "canton": "BE"
+  },
+  {
+    "id": "8233|Bargen|SH",
+    "name": "Bargen",
+    "zipCode": "8233",
+    "canton": "SH"
+  },
+  {
+    "id": "3323|Bäriswil|BE",
+    "name": "Bäriswil",
+    "zipCode": "3323",
+    "canton": "BE"
+  },
+  {
+    "id": "5017|Barmelweid|AG",
+    "name": "Barmelweid",
+    "zipCode": "5017",
+    "canton": "AG"
+  },
+  {
+    "id": "4252|Bärschwil|SO",
+    "name": "Bärschwil",
+    "zipCode": "4252",
+    "canton": "SO"
+  },
+  {
+    "id": "4252|Bärschwil Station|SO",
+    "name": "Bärschwil Station",
+    "zipCode": "4252",
+    "canton": "SO"
+  },
+  {
+    "id": "8241|Barzheim|SH",
+    "name": "Barzheim",
+    "zipCode": "8241",
+    "canton": "SH"
+  },
+  {
+    "id": "1786|Bas-Vully|FR",
+    "name": "Bas-Vully",
+    "zipCode": "1786",
+    "canton": "FR"
+  },
+  {
+    "id": "8254|Basadingen|TG",
+    "name": "Basadingen",
+    "zipCode": "8254",
+    "canton": "TG"
+  },
+  {
+    "id": "4000|Basel|BS",
+    "name": "Basel",
+    "zipCode": "4000",
+    "canton": "BS"
+  },
+  {
+    "id": "1996|Basse-Nendaz|VS",
+    "name": "Basse-Nendaz",
+    "zipCode": "1996",
+    "canton": "VS"
+  },
+  {
+    "id": "2854|Bassecourt|JU",
+    "name": "Bassecourt",
+    "zipCode": "2854",
+    "canton": "JU"
+  },
+  {
+    "id": "8303|Bassersdorf|ZH",
+    "name": "Bassersdorf",
+    "zipCode": "8303",
+    "canton": "ZH"
+  },
+  {
+    "id": "1269|Bassins|VD",
+    "name": "Bassins",
+    "zipCode": "1269",
+    "canton": "VD"
+  },
+  {
+    "id": "8573|Bätershausen|TG",
+    "name": "Bätershausen",
+    "zipCode": "8573",
+    "canton": "TG"
+  },
+  {
+    "id": "3315|Bätterkinden|BE",
+    "name": "Bätterkinden",
+    "zipCode": "3315",
+    "canton": "BE"
+  },
+  {
+    "id": "4112|Bättwil|SO",
+    "name": "Bättwil",
+    "zipCode": "4112",
+    "canton": "SO"
+  },
+  {
+    "id": "6466|Bauen|UR",
+    "name": "Bauen",
+    "zipCode": "6466",
+    "canton": "UR"
+  },
+  {
+    "id": "1815|Baugy|VD",
+    "name": "Baugy",
+    "zipCode": "1815",
+    "canton": "VD"
+  },
+  {
+    "id": "1446|Baulmes|VD",
+    "name": "Baulmes",
+    "zipCode": "1446",
+    "canton": "VD"
+  },
+  {
+    "id": "8494|Bauma|ZH",
+    "name": "Bauma",
+    "zipCode": "8494",
+    "canton": "ZH"
+  },
+  {
+    "id": "1372|Bavois|VD",
+    "name": "Bavois",
+    "zipCode": "1372",
+    "canton": "VD"
+  },
+  {
+    "id": "9602|Bazenheid|SG",
+    "name": "Bazenheid",
+    "zipCode": "9602",
+    "canton": "SG"
+  },
+  {
+    "id": "3803|Beatenberg|BE",
+    "name": "Beatenberg",
+    "zipCode": "3803",
+    "canton": "BE"
+  },
+  {
+    "id": "3658|Beatenbucht|BE",
+    "name": "Beatenbucht",
+    "zipCode": "3658",
+    "canton": "BE"
+  },
+  {
+    "id": "8414|Bebikon|ZH",
+    "name": "Bebikon",
+    "zipCode": "8414",
+    "canton": "ZH"
+  },
+  {
+    "id": "6375|Beckenried|NW",
+    "name": "Beckenried",
+    "zipCode": "6375",
+    "canton": "NW"
+  },
+  {
+    "id": "6930|Bedano|TI",
+    "name": "Bedano",
+    "zipCode": "6930",
+    "canton": "TI"
+  },
+  {
+    "id": "6981|Bedigliora|TI",
+    "name": "Bedigliora",
+    "zipCode": "6981",
+    "canton": "TI"
+  },
+  {
+    "id": "6781|Bedretto|TI",
+    "name": "Bedretto",
+    "zipCode": "6781",
+    "canton": "TI"
+  },
+  {
+    "id": "8228|Beggingen|SH",
+    "name": "Beggingen",
+    "zipCode": "8228",
+    "canton": "SH"
+  },
+  {
+    "id": "1268|Begnins|VD",
+    "name": "Begnins",
+    "zipCode": "1268",
+    "canton": "VD"
+  },
+  {
+    "id": "4229|Beinwil|SO",
+    "name": "Beinwil",
+    "zipCode": "4229",
+    "canton": "SO"
+  },
+  {
+    "id": "5637|Beinwil (Freiamt)|AG",
+    "name": "Beinwil (Freiamt)",
+    "zipCode": "5637",
+    "canton": "AG"
+  },
+  {
+    "id": "5712|Beinwil am See|AG",
+    "name": "Beinwil am See",
+    "zipCode": "5712",
+    "canton": "AG"
+  },
+  {
+    "id": "3113|Beitenwil|BE",
+    "name": "Beitenwil",
+    "zipCode": "3113",
+    "canton": "BE"
+  },
+  {
+    "id": "3914|Belalp|VS",
+    "name": "Belalp",
+    "zipCode": "3914",
+    "canton": "VS"
+  },
+  {
+    "id": "1782|Belfaux|FR",
+    "name": "Belfaux",
+    "zipCode": "1782",
+    "canton": "FR"
+  },
+  {
+    "id": "2354|Belfond|JU",
+    "name": "Belfond",
+    "zipCode": "2354",
+    "canton": "JU"
+  },
+  {
+    "id": "4512|Bellach|SO",
+    "name": "Bellach",
+    "zipCode": "4512",
+    "canton": "SO"
+  },
+  {
+    "id": "1786|Bellechasse|FR",
+    "name": "Bellechasse",
+    "zipCode": "1786",
+    "canton": "FR"
+  },
+  {
+    "id": "2713|Bellelay|BE",
+    "name": "Bellelay",
+    "zipCode": "2713",
+    "canton": "BE"
+  },
+  {
+    "id": "1222|Bellerive|GE",
+    "name": "Bellerive",
+    "zipCode": "1222",
+    "canton": "GE"
+  },
+  {
+    "id": "1585|Bellerive|VD",
+    "name": "Bellerive",
+    "zipCode": "1585",
+    "canton": "VD"
+  },
+  {
+    "id": "2805|Bellerive|JU",
+    "name": "Bellerive",
+    "zipCode": "2805",
+    "canton": "JU"
+  },
+  {
+    "id": "1293|Bellevue|GE",
+    "name": "Bellevue",
+    "zipCode": "1293",
+    "canton": "GE"
+  },
+  {
+    "id": "5454|Bellikon|AG",
+    "name": "Bellikon",
+    "zipCode": "5454",
+    "canton": "AG"
+  },
+  {
+    "id": "6500|Bellinzona|TI",
+    "name": "Bellinzona",
+    "zipCode": "6500",
+    "canton": "TI"
+  },
+  {
+    "id": "2564|Bellmund|BE",
+    "name": "Bellmund",
+    "zipCode": "2564",
+    "canton": "BE"
+  },
+  {
+    "id": "3997|Bellwald|VS",
+    "name": "Bellwald",
+    "zipCode": "3997",
+    "canton": "VS"
+  },
+  {
+    "id": "1092|Belmont-sur-Lausanne|VD",
+    "name": "Belmont-sur-Lausanne",
+    "zipCode": "1092",
+    "canton": "VD"
+  },
+  {
+    "id": "1432|Belmont-sur-Yverdon|VD",
+    "name": "Belmont-sur-Yverdon",
+    "zipCode": "1432",
+    "canton": "VD"
+  },
+  {
+    "id": "3123|Belp|BE",
+    "name": "Belp",
+    "zipCode": "3123",
+    "canton": "BE"
+  },
+  {
+    "id": "3124|Belpberg|BE",
+    "name": "Belpberg",
+    "zipCode": "3124",
+    "canton": "BE"
+  },
+  {
+    "id": "2744|Belprahon|BE",
+    "name": "Belprahon",
+    "zipCode": "2744",
+    "canton": "BE"
+  },
+  {
+    "id": "2406|Bémont|NE",
+    "name": "Bémont",
+    "zipCode": "2406",
+    "canton": "NE"
+  },
+  {
+    "id": "9042|Bendlehn|AR",
+    "name": "Bendlehn",
+    "zipCode": "9042",
+    "canton": "AR"
+  },
+  {
+    "id": "8802|Bendlikon|ZH",
+    "name": "Bendlikon",
+    "zipCode": "8802",
+    "canton": "ZH"
+  },
+  {
+    "id": "1197|Bénex|VD",
+    "name": "Bénex",
+    "zipCode": "1197",
+    "canton": "VD"
+  },
+  {
+    "id": "8121|Benglen|ZH",
+    "name": "Benglen",
+    "zipCode": "8121",
+    "canton": "ZH"
+  },
+  {
+    "id": "4105|Benken|BL",
+    "name": "Benken",
+    "zipCode": "4105",
+    "canton": "BL"
+  },
+  {
+    "id": "8463|Benken|ZH",
+    "name": "Benken",
+    "zipCode": "8463",
+    "canton": "ZH"
+  },
+  {
+    "id": "8717|Benken|SG",
+    "name": "Benken",
+    "zipCode": "8717",
+    "canton": "SG"
+  },
+  {
+    "id": "8836|Bennau|SZ",
+    "name": "Bennau",
+    "zipCode": "8836",
+    "canton": "SZ"
+  },
+  {
+    "id": "4431|Bennwil|BL",
+    "name": "Bennwil",
+    "zipCode": "4431",
+    "canton": "BL"
+  },
+  {
+    "id": "5636|Benzenschwil|AG",
+    "name": "Benzenschwil",
+    "zipCode": "5636",
+    "canton": "AG"
+  },
+  {
+    "id": "1038|Bercher|VD",
+    "name": "Bercher",
+    "zipCode": "1038",
+    "canton": "VD"
+  },
+  {
+    "id": "8471|Berg|ZH",
+    "name": "Berg",
+    "zipCode": "8471",
+    "canton": "ZH"
+  },
+  {
+    "id": "8572|Berg|TG",
+    "name": "Berg",
+    "zipCode": "8572",
+    "canton": "TG"
+  },
+  {
+    "id": "8625|Berg|ZH",
+    "name": "Berg",
+    "zipCode": "8625",
+    "canton": "ZH"
+  },
+  {
+    "id": "9305|Berg|SG",
+    "name": "Berg",
+    "zipCode": "9305",
+    "canton": "SG"
+  },
+  {
+    "id": "8415|Berg am Irchel|ZH",
+    "name": "Berg am Irchel",
+    "zipCode": "8415",
+    "canton": "ZH"
+  },
+  {
+    "id": "8962|Bergdietikon|AG",
+    "name": "Bergdietikon",
+    "zipCode": "8962",
+    "canton": "AG"
+  },
+  {
+    "id": "7482|Bergün/Bravuogn|GR",
+    "name": "Bergün/Bravuogn",
+    "zipCode": "7482",
+    "canton": "GR"
+  },
+  {
+    "id": "6981|Beride|TI",
+    "name": "Beride",
+    "zipCode": "6981",
+    "canton": "TI"
+  },
+  {
+    "id": "8965|Berikon|AG",
+    "name": "Berikon",
+    "zipCode": "8965",
+    "canton": "AG"
+  },
+  {
+    "id": "8222|Beringen|SH",
+    "name": "Beringen",
+    "zipCode": "8222",
+    "canton": "SH"
+  },
+  {
+    "id": "3900|Berisal|VS",
+    "name": "Berisal",
+    "zipCode": "3900",
+    "canton": "VS"
+  },
+  {
+    "id": "3376|Berken|BE",
+    "name": "Berken",
+    "zipCode": "3376",
+    "canton": "BE"
+  },
+  {
+    "id": "1680|Berlens|FR",
+    "name": "Berlens",
+    "zipCode": "1680",
+    "canton": "FR"
+  },
+  {
+    "id": "2854|Berlincourt|JU",
+    "name": "Berlincourt",
+    "zipCode": "2854",
+    "canton": "JU"
+  },
+  {
+    "id": "8267|Berlingen|TG",
+    "name": "Berlingen",
+    "zipCode": "8267",
+    "canton": "TG"
+  },
+  {
+    "id": "3000|Bern|BE",
+    "name": "Bern",
+    "zipCode": "3000",
+    "canton": "BE"
+  },
+  {
+    "id": "5325|Bernau|AG",
+    "name": "Bernau",
+    "zipCode": "5325",
+    "canton": "AG"
+  },
+  {
+    "id": "9442|Berneck|AI",
+    "name": "Berneck",
+    "zipCode": "9442",
+    "canton": "AI"
+  },
+  {
+    "id": "9442|Berneck|SG",
+    "name": "Berneck",
+    "zipCode": "9442",
+    "canton": "SG"
+  },
+  {
+    "id": "1233|Bernex|GE",
+    "name": "Bernex",
+    "zipCode": "1233",
+    "canton": "GE"
+  },
+  {
+    "id": "9304|Bernhardzell|SG",
+    "name": "Bernhardzell",
+    "zipCode": "9304",
+    "canton": "SG"
+  },
+  {
+    "id": "7504|Bernina Suot|GR",
+    "name": "Bernina Suot",
+    "zipCode": "7504",
+    "canton": "GR"
+  },
+  {
+    "id": "8280|Bernrain|TG",
+    "name": "Bernrain",
+    "zipCode": "8280",
+    "canton": "TG"
+  },
+  {
+    "id": "1149|Berolle|VD",
+    "name": "Berolle",
+    "zipCode": "1149",
+    "canton": "VD"
+  },
+  {
+    "id": "6215|Beromünster|LU",
+    "name": "Beromünster",
+    "zipCode": "6215",
+    "canton": "LU"
+  },
+  {
+    "id": "8892|Berschis|SG",
+    "name": "Berschis",
+    "zipCode": "8892",
+    "canton": "SG"
+  },
+  {
+    "id": "8614|Bertschikon|ZH",
+    "name": "Bertschikon",
+    "zipCode": "8614",
+    "canton": "ZH"
+  },
+  {
+    "id": "8543|Bertschikon bei Attikon|ZH",
+    "name": "Bertschikon bei Attikon",
+    "zipCode": "8543",
+    "canton": "ZH"
+  },
+  {
+    "id": "6661|Berzona|TI",
+    "name": "Berzona",
+    "zipCode": "6661",
+    "canton": "TI"
+  },
+  {
+    "id": "6863|Besazio|TI",
+    "name": "Besazio",
+    "zipCode": "6863",
+    "canton": "TI"
+  },
+  {
+    "id": "5627|Besenbüren|AG",
+    "name": "Besenbüren",
+    "zipCode": "5627",
+    "canton": "AG"
+  },
+  {
+    "id": "1609|Besencens|FR",
+    "name": "Besencens",
+    "zipCode": "1609",
+    "canton": "FR"
+  },
+  {
+    "id": "8546|Bethelhausen|TG",
+    "name": "Bethelhausen",
+    "zipCode": "8546",
+    "canton": "TG"
+  },
+  {
+    "id": "3000|Bethlehem|BE",
+    "name": "Bethlehem",
+    "zipCode": "3000",
+    "canton": "BE"
+  },
+  {
+    "id": "8872|Betlis|SG",
+    "name": "Betlis",
+    "zipCode": "8872",
+    "canton": "SG"
+  },
+  {
+    "id": "8777|Betschwanden|GL",
+    "name": "Betschwanden",
+    "zipCode": "8777",
+    "canton": "GL"
+  },
+  {
+    "id": "3991|Betten|VS",
+    "name": "Betten",
+    "zipCode": "3991",
+    "canton": "VS"
+  },
+  {
+    "id": "3366|Bettenhausen|BE",
+    "name": "Bettenhausen",
+    "zipCode": "3366",
+    "canton": "BE"
+  },
+  {
+    "id": "1042|Bettens|VD",
+    "name": "Bettens",
+    "zipCode": "1042",
+    "canton": "VD"
+  },
+  {
+    "id": "4126|Bettingen|BS",
+    "name": "Bettingen",
+    "zipCode": "4126",
+    "canton": "BS"
+  },
+  {
+    "id": "2544|Bettlach|SO",
+    "name": "Bettlach",
+    "zipCode": "2544",
+    "canton": "SO"
+  },
+  {
+    "id": "3992|Bettmeralp|VS",
+    "name": "Bettmeralp",
+    "zipCode": "3992",
+    "canton": "VS"
+  },
+  {
+    "id": "9553|Bettwiesen|TG",
+    "name": "Bettwiesen",
+    "zipCode": "9553",
+    "canton": "TG"
+  },
+  {
+    "id": "5618|Bettwil|AG",
+    "name": "Bettwil",
+    "zipCode": "5618",
+    "canton": "AG"
+  },
+  {
+    "id": "2935|Beurnevésin|JU",
+    "name": "Beurnevésin",
+    "zipCode": "2935",
+    "canton": "JU"
+  },
+  {
+    "id": "1996|Beuson|VS",
+    "name": "Beuson",
+    "zipCode": "1996",
+    "canton": "VS"
+  },
+  {
+    "id": "2022|Bevaix|NE",
+    "name": "Bevaix",
+    "zipCode": "2022",
+    "canton": "NE"
+  },
+  {
+    "id": "7502|Bever|GR",
+    "name": "Bever",
+    "zipCode": "7502",
+    "canton": "GR"
+  },
+  {
+    "id": "2735|Bévilard|BE",
+    "name": "Bévilard",
+    "zipCode": "2735",
+    "canton": "BE"
+  },
+  {
+    "id": "8543|Bewangen|ZH",
+    "name": "Bewangen",
+    "zipCode": "8543",
+    "canton": "ZH"
+  },
+  {
+    "id": "1880|Bex|VD",
+    "name": "Bex",
+    "zipCode": "1880",
+    "canton": "VD"
+  },
+  {
+    "id": "8735|Bezikon|SG",
+    "name": "Bezikon",
+    "zipCode": "8735",
+    "canton": "SG"
+  },
+  {
+    "id": "5312|Beznau|AG",
+    "name": "Beznau",
+    "zipCode": "5312",
+    "canton": "AG"
+  },
+  {
+    "id": "6710|Biasca|TI",
+    "name": "Biasca",
+    "zipCode": "6710",
+    "canton": "TI"
+  },
+  {
+    "id": "6710|Biasca Stazione|TI",
+    "name": "Biasca Stazione",
+    "zipCode": "6710",
+    "canton": "TI"
+  },
+  {
+    "id": "2336|Biaufond|JU",
+    "name": "Biaufond",
+    "zipCode": "2336",
+    "canton": "JU"
+  },
+  {
+    "id": "8836|Biberbrugg|SZ",
+    "name": "Biberbrugg",
+    "zipCode": "8836",
+    "canton": "SZ"
+  },
+  {
+    "id": "3206|Biberen|BE",
+    "name": "Biberen",
+    "zipCode": "3206",
+    "canton": "BE"
+  },
+  {
+    "id": "4562|Biberist|SO",
+    "name": "Biberist",
+    "zipCode": "4562",
+    "canton": "SO"
+  },
+  {
+    "id": "8262|Bibermühle bei Ramsen|SH",
+    "name": "Bibermühle bei Ramsen",
+    "zipCode": "8262",
+    "canton": "SH"
+  },
+  {
+    "id": "4578|Bibern|SO",
+    "name": "Bibern",
+    "zipCode": "4578",
+    "canton": "SO"
+  },
+  {
+    "id": "8242|Bibern|SH",
+    "name": "Bibern",
+    "zipCode": "8242",
+    "canton": "SH"
+  },
+  {
+    "id": "5023|Biberstein|AG",
+    "name": "Biberstein",
+    "zipCode": "5023",
+    "canton": "AG"
+  },
+  {
+    "id": "8363|Bichelsee|TG",
+    "name": "Bichelsee",
+    "zipCode": "8363",
+    "canton": "TG"
+  },
+  {
+    "id": "9248|Bichwil|SG",
+    "name": "Bichwil",
+    "zipCode": "9248",
+    "canton": "SG"
+  },
+  {
+    "id": "3472|Bickigen|BE",
+    "name": "Bickigen",
+    "zipCode": "3472",
+    "canton": "BE"
+  },
+  {
+    "id": "8912|Bickwil|ZH",
+    "name": "Bickwil",
+    "zipCode": "8912",
+    "canton": "ZH"
+  },
+  {
+    "id": "6958|Bidogno|TI",
+    "name": "Bidogno",
+    "zipCode": "6958",
+    "canton": "TI"
+  },
+  {
+    "id": "3989|Biel|VS",
+    "name": "Biel",
+    "zipCode": "3989",
+    "canton": "VS"
+  },
+  {
+    "id": "4105|Biel|BL",
+    "name": "Biel",
+    "zipCode": "4105",
+    "canton": "BL"
+  },
+  {
+    "id": "2500|Biel/Bienne|BE",
+    "name": "Biel/Bienne",
+    "zipCode": "2500",
+    "canton": "BE"
+  },
+  {
+    "id": "3419|Biembach im Emmental|BE",
+    "name": "Biembach im Emmental",
+    "zipCode": "3419",
+    "canton": "BE"
+  },
+  {
+    "id": "4410|Bienenberg|BL",
+    "name": "Bienenberg",
+    "zipCode": "4410",
+    "canton": "BL"
+  },
+  {
+    "id": "1145|Bière|VD",
+    "name": "Bière",
+    "zipCode": "1145",
+    "canton": "VD"
+  },
+  {
+    "id": "8580|Biessenhofen|TG",
+    "name": "Biessenhofen",
+    "zipCode": "8580",
+    "canton": "TG"
+  },
+  {
+    "id": "8307|Bietenholz|ZH",
+    "name": "Bietenholz",
+    "zipCode": "8307",
+    "canton": "ZH"
+  },
+  {
+    "id": "1996|Bieudron|VS",
+    "name": "Bieudron",
+    "zipCode": "1996",
+    "canton": "VS"
+  },
+  {
+    "id": "4585|Biezwil|SO",
+    "name": "Biezwil",
+    "zipCode": "4585",
+    "canton": "SO"
+  },
+  {
+    "id": "3513|Bigenthal|BE",
+    "name": "Bigenthal",
+    "zipCode": "3513",
+    "canton": "BE"
+  },
+  {
+    "id": "3507|Biglen|BE",
+    "name": "Biglen",
+    "zipCode": "3507",
+    "canton": "BE"
+  },
+  {
+    "id": "6676|Bignasco|TI",
+    "name": "Bignasco",
+    "zipCode": "6676",
+    "canton": "TI"
+  },
+  {
+    "id": "6927|Bigogno|TI",
+    "name": "Bigogno",
+    "zipCode": "6927",
+    "canton": "TI"
+  },
+  {
+    "id": "6954|Bigorio|TI",
+    "name": "Bigorio",
+    "zipCode": "6954",
+    "canton": "TI"
+  },
+  {
+    "id": "8314|Billikon|ZH",
+    "name": "Billikon",
+    "zipCode": "8314",
+    "canton": "ZH"
+  },
+  {
+    "id": "8865|Bilten|GL",
+    "name": "Bilten",
+    "zipCode": "8865",
+    "canton": "GL"
+  },
+  {
+    "id": "3996|Binn|VS",
+    "name": "Binn",
+    "zipCode": "3996",
+    "canton": "VS"
+  },
+  {
+    "id": "4102|Binningen|BL",
+    "name": "Binningen",
+    "zipCode": "4102",
+    "canton": "BL"
+  },
+  {
+    "id": "8122|Binz|ZH",
+    "name": "Binz",
+    "zipCode": "8122",
+    "canton": "ZH"
+  },
+  {
+    "id": "8627|Binzikon|ZH",
+    "name": "Binzikon",
+    "zipCode": "8627",
+    "canton": "ZH"
+  },
+  {
+    "id": "6934|Bioggio|TI",
+    "name": "Bioggio",
+    "zipCode": "6934",
+    "canton": "TI"
+  },
+  {
+    "id": "6932|Biogno|TI",
+    "name": "Biogno",
+    "zipCode": "6932",
+    "canton": "TI"
+  },
+  {
+    "id": "6981|Biogno|TI",
+    "name": "Biogno",
+    "zipCode": "6981",
+    "canton": "TI"
+  },
+  {
+    "id": "1407|Bioley-Magnoux|VD",
+    "name": "Bioley-Magnoux",
+    "zipCode": "1407",
+    "canton": "VD"
+  },
+  {
+    "id": "1042|Bioley-Orjulaz|VD",
+    "name": "Bioley-Orjulaz",
+    "zipCode": "1042",
+    "canton": "VD"
+  },
+  {
+    "id": "1670|Bionnens|FR",
+    "name": "Bionnens",
+    "zipCode": "1670",
+    "canton": "FR"
+  },
+  {
+    "id": "8309|Birchwil|ZH",
+    "name": "Birchwil",
+    "zipCode": "8309",
+    "canton": "ZH"
+  },
+  {
+    "id": "3903|Birgisch|VS",
+    "name": "Birgisch",
+    "zipCode": "3903",
+    "canton": "VS"
+  },
+  {
+    "id": "8903|Birmensdorf|ZH",
+    "name": "Birmensdorf",
+    "zipCode": "8903",
+    "canton": "ZH"
+  },
+  {
+    "id": "5413|Birmenstorf|AG",
+    "name": "Birmenstorf",
+    "zipCode": "5413",
+    "canton": "AG"
+  },
+  {
+    "id": "6804|Bironico|TI",
+    "name": "Bironico",
+    "zipCode": "6804",
+    "canton": "TI"
+  },
+  {
+    "id": "5242|Birr|AG",
+    "name": "Birr",
+    "zipCode": "5242",
+    "canton": "AG"
+  },
+  {
+    "id": "5244|Birrhard|AG",
+    "name": "Birrhard",
+    "zipCode": "5244",
+    "canton": "AG"
+  },
+  {
+    "id": "5628|Birri|AG",
+    "name": "Birri",
+    "zipCode": "5628",
+    "canton": "AG"
+  },
+  {
+    "id": "5708|Birrwil|AG",
+    "name": "Birrwil",
+    "zipCode": "5708",
+    "canton": "AG"
+  },
+  {
+    "id": "4127|Birsfelden|BL",
+    "name": "Birsfelden",
+    "zipCode": "4127",
+    "canton": "BL"
+  },
+  {
+    "id": "8585|Birwinken|TG",
+    "name": "Birwinken",
+    "zipCode": "8585",
+    "canton": "TG"
+  },
+  {
+    "id": "9220|Bischofszell|TG",
+    "name": "Bischofszell",
+    "zipCode": "9220",
+    "canton": "TG"
+  },
+  {
+    "id": "8307|Bisikon|ZH",
+    "name": "Bisikon",
+    "zipCode": "8307",
+    "canton": "ZH"
+  },
+  {
+    "id": "6436|Bisisthal|SZ",
+    "name": "Bisisthal",
+    "zipCode": "6436",
+    "canton": "SZ"
+  },
+  {
+    "id": "8514|Bissegg|TG",
+    "name": "Bissegg",
+    "zipCode": "8514",
+    "canton": "TG"
+  },
+  {
+    "id": "6816|Bissone|TI",
+    "name": "Bissone",
+    "zipCode": "6816",
+    "canton": "TI"
+  },
+  {
+    "id": "3983|Bister|VS",
+    "name": "Bister",
+    "zipCode": "3983",
+    "canton": "VS"
+  },
+  {
+    "id": "3982|Bitsch|VS",
+    "name": "Bitsch",
+    "zipCode": "3982",
+    "canton": "VS"
+  },
+  {
+    "id": "3255|Bittwil bei Rapperswil|BE",
+    "name": "Bittwil bei Rapperswil",
+    "zipCode": "3255",
+    "canton": "BE"
+  },
+  {
+    "id": "7457|Bivio|GR",
+    "name": "Bivio",
+    "zipCode": "7457",
+    "canton": "GR"
+  },
+  {
+    "id": "3771|Blankenburg|BE",
+    "name": "Blankenburg",
+    "zipCode": "3771",
+    "canton": "BE"
+  },
+  {
+    "id": "3537|Blapach|BE",
+    "name": "Blapach",
+    "zipCode": "3537",
+    "canton": "BE"
+  },
+  {
+    "id": "3919|Blatten|VS",
+    "name": "Blatten",
+    "zipCode": "3919",
+    "canton": "VS"
+  },
+  {
+    "id": "6102|Blatten (Malters)|LU",
+    "name": "Blatten (Malters)",
+    "zipCode": "6102",
+    "canton": "LU"
+  },
+  {
+    "id": "3914|Blatten bei Naters|VS",
+    "name": "Blatten bei Naters",
+    "zipCode": "3914",
+    "canton": "VS"
+  },
+  {
+    "id": "4223|Blauen|BL",
+    "name": "Blauen",
+    "zipCode": "4223",
+    "canton": "BL"
+  },
+  {
+    "id": "3717|Blausee|BE",
+    "name": "Blausee",
+    "zipCode": "3717",
+    "canton": "BE"
+  },
+  {
+    "id": "4562|Bleichenberg|SO",
+    "name": "Bleichenberg",
+    "zipCode": "4562",
+    "canton": "SO"
+  },
+  {
+    "id": "3368|Bleienbach|BE",
+    "name": "Bleienbach",
+    "zipCode": "3368",
+    "canton": "BE"
+  },
+  {
+    "id": "8583|Bleiken|TG",
+    "name": "Bleiken",
+    "zipCode": "8583",
+    "canton": "TG"
+  },
+  {
+    "id": "3674|Bleiken bei Oberdiessbach|BE",
+    "name": "Bleiken bei Oberdiessbach",
+    "zipCode": "3674",
+    "canton": "BE"
+  },
+  {
+    "id": "1675|Blessens|FR",
+    "name": "Blessens",
+    "zipCode": "1675",
+    "canton": "FR"
+  },
+  {
+    "id": "6340|Blickensdorf|ZG",
+    "name": "Blickensdorf",
+    "zipCode": "6340",
+    "canton": "ZG"
+  },
+  {
+    "id": "9220|Blidegg|TG",
+    "name": "Blidegg",
+    "zipCode": "9220",
+    "canton": "TG"
+  },
+  {
+    "id": "8494|Bliggenswil|ZH",
+    "name": "Bliggenswil",
+    "zipCode": "8494",
+    "canton": "ZH"
+  },
+  {
+    "id": "1966|Blignoud|VS",
+    "name": "Blignoud",
+    "zipCode": "1966",
+    "canton": "VS"
+  },
+  {
+    "id": "8493|Blitterswil|ZH",
+    "name": "Blitterswil",
+    "zipCode": "8493",
+    "canton": "ZH"
+  },
+  {
+    "id": "3989|Blitzingen|VS",
+    "name": "Blitzingen",
+    "zipCode": "3989",
+    "canton": "VS"
+  },
+  {
+    "id": "1807|Blonay|VD",
+    "name": "Blonay",
+    "zipCode": "1807",
+    "canton": "VD"
+  },
+  {
+    "id": "3975|Bluche|VS",
+    "name": "Bluche",
+    "zipCode": "3975",
+    "canton": "VS"
+  },
+  {
+    "id": "3638|Blumenstein|BE",
+    "name": "Blumenstein",
+    "zipCode": "3638",
+    "canton": "BE"
+  },
+  {
+    "id": "5334|Böbikon|AG",
+    "name": "Böbikon",
+    "zipCode": "5334",
+    "canton": "AG"
+  },
+  {
+    "id": "4461|Böckten|BL",
+    "name": "Böckten",
+    "zipCode": "4461",
+    "canton": "BL"
+  },
+  {
+    "id": "3715|Boden|BE",
+    "name": "Boden",
+    "zipCode": "3715",
+    "canton": "BE"
+  },
+  {
+    "id": "6743|Bodio|TI",
+    "name": "Bodio",
+    "zipCode": "6743",
+    "canton": "TI"
+  },
+  {
+    "id": "2856|Boécourt|JU",
+    "name": "Boécourt",
+    "zipCode": "2856",
+    "canton": "JU"
+  },
+  {
+    "id": "1353|Bofflens|VD",
+    "name": "Bofflens",
+    "zipCode": "1353",
+    "canton": "VD"
+  },
+  {
+    "id": "1279|Bogis-Bossey|VD",
+    "name": "Bogis-Bossey",
+    "zipCode": "1279",
+    "canton": "VD"
+  },
+  {
+    "id": "6216|Bognau|LU",
+    "name": "Bognau",
+    "zipCode": "6216",
+    "canton": "LU"
+  },
+  {
+    "id": "6951|Bogno|TI",
+    "name": "Bogno",
+    "zipCode": "6951",
+    "canton": "TI"
+  },
+  {
+    "id": "6221|Bohler|LU",
+    "name": "Bohler",
+    "zipCode": "6221",
+    "canton": "LU"
+  },
+  {
+    "id": "6221|Bohler|AG",
+    "name": "Bohler",
+    "zipCode": "6221",
+    "canton": "AG"
+  },
+  {
+    "id": "1260|Bois-Bougy|VD",
+    "name": "Bois-Bougy",
+    "zipCode": "1260",
+    "canton": "VD"
+  },
+  {
+    "id": "2014|Bôle|NE",
+    "name": "Bôle",
+    "zipCode": "2014",
+    "canton": "NE"
+  },
+  {
+    "id": "4556|Bolken|SO",
+    "name": "Bolken",
+    "zipCode": "4556",
+    "canton": "SO"
+  },
+  {
+    "id": "3067|Boll|BE",
+    "name": "Boll",
+    "zipCode": "3067",
+    "canton": "BE"
+  },
+  {
+    "id": "5610|Boll bei Wohlen|AG",
+    "name": "Boll bei Wohlen",
+    "zipCode": "5610",
+    "canton": "AG"
+  },
+  {
+    "id": "3065|Bolligen|BE",
+    "name": "Bolligen",
+    "zipCode": "3065",
+    "canton": "BE"
+  },
+  {
+    "id": "8715|Bollingen|SG",
+    "name": "Bollingen",
+    "zipCode": "8715",
+    "canton": "SG"
+  },
+  {
+    "id": "1470|Bollion|FR",
+    "name": "Bollion",
+    "zipCode": "1470",
+    "canton": "FR"
+  },
+  {
+    "id": "3366|Bollodingen|BE",
+    "name": "Bollodingen",
+    "zipCode": "3366",
+    "canton": "BE"
+  },
+  {
+    "id": "3766|Boltigen|BE",
+    "name": "Boltigen",
+    "zipCode": "3766",
+    "canton": "BE"
+  },
+  {
+    "id": "8561|Boltshausen|TG",
+    "name": "Boltshausen",
+    "zipCode": "8561",
+    "canton": "TG"
+  },
+  {
+    "id": "6981|Bombinasco|TI",
+    "name": "Bombinasco",
+    "zipCode": "6981",
+    "canton": "TI"
+  },
+  {
+    "id": "7402|Bonaduz|GR",
+    "name": "Bonaduz",
+    "zipCode": "7402",
+    "canton": "GR"
+  },
+  {
+    "id": "8554|Bonau|TG",
+    "name": "Bonau",
+    "zipCode": "8554",
+    "canton": "TG"
+  },
+  {
+    "id": "2926|Boncourt|JU",
+    "name": "Boncourt",
+    "zipCode": "2926",
+    "canton": "JU"
+  },
+  {
+    "id": "7606|Bondo|GR",
+    "name": "Bondo",
+    "zipCode": "7606",
+    "canton": "GR"
+  },
+  {
+    "id": "2944|Bonfol|JU",
+    "name": "Bonfol",
+    "zipCode": "2944",
+    "canton": "JU"
+  },
+  {
+    "id": "3806|Bönigen|BE",
+    "name": "Bönigen",
+    "zipCode": "3806",
+    "canton": "BE"
+  },
+  {
+    "id": "4618|Boningen|SO",
+    "name": "Boningen",
+    "zipCode": "4618",
+    "canton": "SO"
+  },
+  {
+    "id": "5706|Boniswil|AG",
+    "name": "Boniswil",
+    "zipCode": "5706",
+    "canton": "AG"
+  },
+  {
+    "id": "1724|Bonnefontaine|FR",
+    "name": "Bonnefontaine",
+    "zipCode": "1724",
+    "canton": "FR"
+  },
+  {
+    "id": "8906|Bonstetten|ZH",
+    "name": "Bonstetten",
+    "zipCode": "8906",
+    "canton": "ZH"
+  },
+  {
+    "id": "1427|Bonvillars|VD",
+    "name": "Bonvillars",
+    "zipCode": "1427",
+    "canton": "VD"
+  },
+  {
+    "id": "8113|Boppelsen|ZH",
+    "name": "Boppelsen",
+    "zipCode": "8113",
+    "canton": "ZH"
+  },
+  {
+    "id": "1277|Borex|VD",
+    "name": "Borex",
+    "zipCode": "1277",
+    "canton": "VD"
+  },
+  {
+    "id": "6658|Borgnone|TI",
+    "name": "Borgnone",
+    "zipCode": "6658",
+    "canton": "TI"
+  },
+  {
+    "id": "7604|Borgonovo|GR",
+    "name": "Borgonovo",
+    "zipCode": "7604",
+    "canton": "GR"
+  },
+  {
+    "id": "8264|Bornhausen|TG",
+    "name": "Bornhausen",
+    "zipCode": "8264",
+    "canton": "TG"
+  },
+  {
+    "id": "7545|Bos-cha|GR",
+    "name": "Bos-cha",
+    "zipCode": "7545",
+    "canton": "GR"
+  },
+  {
+    "id": "6852|Boscherina|TI",
+    "name": "Boscherina",
+    "zipCode": "6852",
+    "canton": "TI"
+  },
+  {
+    "id": "6935|Bosco Luganese|TI",
+    "name": "Bosco Luganese",
+    "zipCode": "6935",
+    "canton": "TI"
+  },
+  {
+    "id": "6685|Bosco/Gurin|TI",
+    "name": "Bosco/Gurin",
+    "zipCode": "6685",
+    "canton": "TI"
+  },
+  {
+    "id": "3178|Bösingen|FR",
+    "name": "Bösingen",
+    "zipCode": "3178",
+    "canton": "FR"
+  },
+  {
+    "id": "1615|Bossonnens|FR",
+    "name": "Bossonnens",
+    "zipCode": "1615",
+    "canton": "FR"
+  },
+  {
+    "id": "1239|Bossy|GE",
+    "name": "Bossy",
+    "zipCode": "1239",
+    "canton": "GE"
+  },
+  {
+    "id": "5623|Boswil|AG",
+    "name": "Boswil",
+    "zipCode": "5623",
+    "canton": "AG"
+  },
+  {
+    "id": "9230|Botsberg|SG",
+    "name": "Botsberg",
+    "zipCode": "9230",
+    "canton": "SG"
+  },
+  {
+    "id": "1041|Bottens|VD",
+    "name": "Bottens",
+    "zipCode": "1041",
+    "canton": "VD"
+  },
+  {
+    "id": "4814|Bottenwil|AG",
+    "name": "Bottenwil",
+    "zipCode": "4814",
+    "canton": "AG"
+  },
+  {
+    "id": "1652|Botterens|FR",
+    "name": "Botterens",
+    "zipCode": "1652",
+    "canton": "FR"
+  },
+  {
+    "id": "8598|Bottighofen|TG",
+    "name": "Bottighofen",
+    "zipCode": "8598",
+    "canton": "TG"
+  },
+  {
+    "id": "4103|Bottmingen|BL",
+    "name": "Bottmingen",
+    "zipCode": "4103",
+    "canton": "BL"
+  },
+  {
+    "id": "5315|Böttstein|AG",
+    "name": "Böttstein",
+    "zipCode": "5315",
+    "canton": "AG"
+  },
+  {
+    "id": "1966|Botyre|VS",
+    "name": "Botyre",
+    "zipCode": "1966",
+    "canton": "VS"
+  },
+  {
+    "id": "2043|Boudevilliers|NE",
+    "name": "Boudevilliers",
+    "zipCode": "2043",
+    "canton": "NE"
+  },
+  {
+    "id": "2017|Boudry|NE",
+    "name": "Boudry",
+    "zipCode": "2017",
+    "canton": "NE"
+  },
+  {
+    "id": "1172|Bougy-Villars|VD",
+    "name": "Bougy-Villars",
+    "zipCode": "1172",
+    "canton": "VD"
+  },
+  {
+    "id": "1063|Boulens|VD",
+    "name": "Boulens",
+    "zipCode": "1063",
+    "canton": "VD"
+  },
+  {
+    "id": "1699|Bouloz|FR",
+    "name": "Bouloz",
+    "zipCode": "1699",
+    "canton": "FR"
+  },
+  {
+    "id": "1242|Bourdigny|GE",
+    "name": "Bourdigny",
+    "zipCode": "1242",
+    "canton": "GE"
+  },
+  {
+    "id": "1946|Bourg-St-Pierre|VS",
+    "name": "Bourg-St-Pierre",
+    "zipCode": "1946",
+    "canton": "VS"
+  },
+  {
+    "id": "1722|Bourguillon|FR",
+    "name": "Bourguillon",
+    "zipCode": "1722",
+    "canton": "FR"
+  },
+  {
+    "id": "1035|Bournens|VD",
+    "name": "Bournens",
+    "zipCode": "1035",
+    "canton": "VD"
+  },
+  {
+    "id": "2803|Bourrignon|JU",
+    "name": "Bourrignon",
+    "zipCode": "2803",
+    "canton": "JU"
+  },
+  {
+    "id": "1034|Boussens|VD",
+    "name": "Boussens",
+    "zipCode": "1034",
+    "canton": "VD"
+  },
+  {
+    "id": "1897|Bouveret|VS",
+    "name": "Bouveret",
+    "zipCode": "1897",
+    "canton": "VS"
+  },
+  {
+    "id": "2113|Boveresse|NE",
+    "name": "Boveresse",
+    "zipCode": "2113",
+    "canton": "NE"
+  },
+  {
+    "id": "1932|Bovernier|VS",
+    "name": "Bovernier",
+    "zipCode": "1932",
+    "canton": "VS"
+  },
+  {
+    "id": "3533|Bowil|BE",
+    "name": "Bowil",
+    "zipCode": "3533",
+    "canton": "BE"
+  },
+  {
+    "id": "5076|Bözen|AG",
+    "name": "Bözen",
+    "zipCode": "5076",
+    "canton": "AG"
+  },
+  {
+    "id": "2500|Bözingen|BE",
+    "name": "Bözingen",
+    "zipCode": "2500",
+    "canton": "BE"
+  },
+  {
+    "id": "6544|Braggio|GR",
+    "name": "Braggio",
+    "zipCode": "6544",
+    "canton": "GR"
+  },
+  {
+    "id": "7527|Brail|GR",
+    "name": "Brail",
+    "zipCode": "7527",
+    "canton": "GR"
+  },
+  {
+    "id": "3176|Bramberg|BE",
+    "name": "Bramberg",
+    "zipCode": "3176",
+    "canton": "BE"
+  },
+  {
+    "id": "6167|Bramboden|LU",
+    "name": "Bramboden",
+    "zipCode": "6167",
+    "canton": "LU"
+  },
+  {
+    "id": "1967|Bramois|VS",
+    "name": "Bramois",
+    "zipCode": "1967",
+    "canton": "VS"
+  },
+  {
+    "id": "1944|Branche-d'en-Bas|VS",
+    "name": "Branche-d'en-Bas",
+    "zipCode": "1944",
+    "canton": "VS"
+  },
+  {
+    "id": "1944|Branche-d'en-Haut|VS",
+    "name": "Branche-d'en-Haut",
+    "zipCode": "1944",
+    "canton": "VS"
+  },
+  {
+    "id": "1926|Branson|VS",
+    "name": "Branson",
+    "zipCode": "1926",
+    "canton": "VS"
+  },
+  {
+    "id": "3957|Bratsch|VS",
+    "name": "Bratsch",
+    "zipCode": "3957",
+    "canton": "VS"
+  },
+  {
+    "id": "9502|Braunau|TG",
+    "name": "Braunau",
+    "zipCode": "9502",
+    "canton": "TG"
+  },
+  {
+    "id": "8784|Braunwald|GL",
+    "name": "Braunwald",
+    "zipCode": "8784",
+    "canton": "GL"
+  },
+  {
+    "id": "6979|Brè sopra Lugano|TI",
+    "name": "Brè sopra Lugano",
+    "zipCode": "6979",
+    "canton": "TI"
+  },
+  {
+    "id": "6932|Breganzona|TI",
+    "name": "Breganzona",
+    "zipCode": "6932",
+    "canton": "TI"
+  },
+  {
+    "id": "7165|Breil/Brigels|GR",
+    "name": "Breil/Brigels",
+    "zipCode": "7165",
+    "canton": "GR"
+  },
+  {
+    "id": "1783|Breilles|FR",
+    "name": "Breilles",
+    "zipCode": "1783",
+    "canton": "FR"
+  },
+  {
+    "id": "4000|Breite|BS",
+    "name": "Breite",
+    "zipCode": "4000",
+    "canton": "BS"
+  },
+  {
+    "id": "8309|Breite|ZH",
+    "name": "Breite",
+    "zipCode": "8309",
+    "canton": "ZH"
+  },
+  {
+    "id": "3983|Breiten|VS",
+    "name": "Breiten",
+    "zipCode": "3983",
+    "canton": "VS"
+  },
+  {
+    "id": "6130|Breiten|LU",
+    "name": "Breiten",
+    "zipCode": "6130",
+    "canton": "LU"
+  },
+  {
+    "id": "4226|Breitenbach|SO",
+    "name": "Breitenbach",
+    "zipCode": "4226",
+    "canton": "SO"
+  },
+  {
+    "id": "3474|Breitenegg|BE",
+    "name": "Breitenegg",
+    "zipCode": "3474",
+    "canton": "BE"
+  },
+  {
+    "id": "9214|Breitenloo|TG",
+    "name": "Breitenloo",
+    "zipCode": "9214",
+    "canton": "TG"
+  },
+  {
+    "id": "3000|Breitenrain|BE",
+    "name": "Breitenrain",
+    "zipCode": "3000",
+    "canton": "BE"
+  },
+  {
+    "id": "8492|Breiti-Saland|ZH",
+    "name": "Breiti-Saland",
+    "zipCode": "8492",
+    "canton": "ZH"
+  },
+  {
+    "id": "1121|Bremblens|VD",
+    "name": "Bremblens",
+    "zipCode": "1121",
+    "canton": "VD"
+  },
+  {
+    "id": "5620|Bremgarten|AG",
+    "name": "Bremgarten",
+    "zipCode": "5620",
+    "canton": "AG"
+  },
+  {
+    "id": "3047|Bremgarten bei Bern|BE",
+    "name": "Bremgarten bei Bern",
+    "zipCode": "3047",
+    "canton": "BE"
+  },
+  {
+    "id": "9426|Brenden|AR",
+    "name": "Brenden",
+    "zipCode": "9426",
+    "canton": "AR"
+  },
+  {
+    "id": "1683|Brenles|VD",
+    "name": "Brenles",
+    "zipCode": "1683",
+    "canton": "VD"
+  },
+  {
+    "id": "6937|Breno|TI",
+    "name": "Breno",
+    "zipCode": "6937",
+    "canton": "TI"
+  },
+  {
+    "id": "1817|Brent|VD",
+    "name": "Brent",
+    "zipCode": "1817",
+    "canton": "VD"
+  },
+  {
+    "id": "3671|Brenzikofen|BE",
+    "name": "Brenzikofen",
+    "zipCode": "3671",
+    "canton": "BE"
+  },
+  {
+    "id": "2904|Bressaucourt|JU",
+    "name": "Bressaucourt",
+    "zipCode": "2904",
+    "canton": "JU"
+  },
+  {
+    "id": "1510|Bressonnaz|VD",
+    "name": "Bressonnaz",
+    "zipCode": "1510",
+    "canton": "VD"
+  },
+  {
+    "id": "1884|Bretaye|VD",
+    "name": "Bretaye",
+    "zipCode": "1884",
+    "canton": "VD"
+  },
+  {
+    "id": "1053|Bretigny-sur-Morrens|VD",
+    "name": "Bretigny-sur-Morrens",
+    "zipCode": "1053",
+    "canton": "VD"
+  },
+  {
+    "id": "1329|Bretonnières|VD",
+    "name": "Bretonnières",
+    "zipCode": "1329",
+    "canton": "VD"
+  },
+  {
+    "id": "4207|Bretzwil|BL",
+    "name": "Bretzwil",
+    "zipCode": "4207",
+    "canton": "BL"
+  },
+  {
+    "id": "3951|Briannen|VS",
+    "name": "Briannen",
+    "zipCode": "3951",
+    "canton": "VS"
+  },
+  {
+    "id": "3966|Brie|VS",
+    "name": "Brie",
+    "zipCode": "3966",
+    "canton": "VS"
+  },
+  {
+    "id": "6672|Briee|TI",
+    "name": "Briee",
+    "zipCode": "6672",
+    "canton": "TI"
+  },
+  {
+    "id": "3855|Brienz|BE",
+    "name": "Brienz",
+    "zipCode": "3855",
+    "canton": "BE"
+  },
+  {
+    "id": "7084|Brienz/Brinzauls|GR",
+    "name": "Brienz/Brinzauls",
+    "zipCode": "7084",
+    "canton": "GR"
+  },
+  {
+    "id": "3856|Brienzwiler|BE",
+    "name": "Brienzwiler",
+    "zipCode": "3856",
+    "canton": "BE"
+  },
+  {
+    "id": "3900|Brig|VS",
+    "name": "Brig",
+    "zipCode": "3900",
+    "canton": "VS"
+  },
+  {
+    "id": "3900|Brigerbad|VS",
+    "name": "Brigerbad",
+    "zipCode": "3900",
+    "canton": "VS"
+  },
+  {
+    "id": "1996|Brignon|VS",
+    "name": "Brignon",
+    "zipCode": "1996",
+    "canton": "VS"
+  },
+  {
+    "id": "6634|Brione (Verzasca)|TI",
+    "name": "Brione (Verzasca)",
+    "zipCode": "6634",
+    "canton": "TI"
+  },
+  {
+    "id": "6645|Brione sopra Minusio|TI",
+    "name": "Brione sopra Minusio",
+    "zipCode": "6645",
+    "canton": "TI"
+  },
+  {
+    "id": "6144|Briseck|LU",
+    "name": "Briseck",
+    "zipCode": "6144",
+    "canton": "LU"
+  },
+  {
+    "id": "4225|Brislach|BL",
+    "name": "Brislach",
+    "zipCode": "4225",
+    "canton": "BL"
+  },
+  {
+    "id": "6614|Brissago|TI",
+    "name": "Brissago",
+    "zipCode": "6614",
+    "canton": "TI"
+  },
+  {
+    "id": "6475|Bristen|UR",
+    "name": "Bristen",
+    "zipCode": "6475",
+    "canton": "UR"
+  },
+  {
+    "id": "4588|Brittern|SO",
+    "name": "Brittern",
+    "zipCode": "4588",
+    "canton": "SO"
+  },
+  {
+    "id": "4805|Brittnau|AG",
+    "name": "Brittnau",
+    "zipCode": "4805",
+    "canton": "AG"
+  },
+  {
+    "id": "1636|Broc|FR",
+    "name": "Broc",
+    "zipCode": "1636",
+    "canton": "FR"
+  },
+  {
+    "id": "1636|Broc-Fabrique|FR",
+    "name": "Broc-Fabrique",
+    "zipCode": "1636",
+    "canton": "FR"
+  },
+  {
+    "id": "3752|Brodhüsi|BE",
+    "name": "Brodhüsi",
+    "zipCode": "3752",
+    "canton": "BE"
+  },
+  {
+    "id": "6693|Broglio|TI",
+    "name": "Broglio",
+    "zipCode": "6693",
+    "canton": "TI"
+  },
+  {
+    "id": "9552|Bronschhofen|SG",
+    "name": "Bronschhofen",
+    "zipCode": "9552",
+    "canton": "SG"
+  },
+  {
+    "id": "6692|Brontallo|TI",
+    "name": "Brontallo",
+    "zipCode": "6692",
+    "canton": "TI"
+  },
+  {
+    "id": "2149|Brot-Dessous|NE",
+    "name": "Brot-Dessous",
+    "zipCode": "2149",
+    "canton": "NE"
+  },
+  {
+    "id": "2318|Brot-Dessus|NE",
+    "name": "Brot-Dessus",
+    "zipCode": "2318",
+    "canton": "NE"
+  },
+  {
+    "id": "2318|Brot-Plamboz|NE",
+    "name": "Brot-Plamboz",
+    "zipCode": "2318",
+    "canton": "NE"
+  },
+  {
+    "id": "4000|Bruderholz|BS",
+    "name": "Bruderholz",
+    "zipCode": "4000",
+    "canton": "BS"
+  },
+  {
+    "id": "4101|Bruderholz|BL",
+    "name": "Bruderholz",
+    "zipCode": "4101",
+    "canton": "BL"
+  },
+  {
+    "id": "2555|Brügg|BE",
+    "name": "Brügg",
+    "zipCode": "2555",
+    "canton": "BE"
+  },
+  {
+    "id": "5200|Brugg|AG",
+    "name": "Brugg",
+    "zipCode": "5200",
+    "canton": "AG"
+  },
+  {
+    "id": "3176|Brüggelbach|BE",
+    "name": "Brüggelbach",
+    "zipCode": "3176",
+    "canton": "BE"
+  },
+  {
+    "id": "9000|Bruggen|SG",
+    "name": "Bruggen",
+    "zipCode": "9000",
+    "canton": "SG"
+  },
+  {
+    "id": "4582|Brügglen|SO",
+    "name": "Brügglen",
+    "zipCode": "4582",
+    "canton": "SO"
+  },
+  {
+    "id": "9058|Brülisau|AI",
+    "name": "Brülisau",
+    "zipCode": "9058",
+    "canton": "AI"
+  },
+  {
+    "id": "7122|Brün|GR",
+    "name": "Brün",
+    "zipCode": "7122",
+    "canton": "GR"
+  },
+  {
+    "id": "5505|Brunegg|AG",
+    "name": "Brunegg",
+    "zipCode": "5505",
+    "canton": "AG"
+  },
+  {
+    "id": "8483|Brünggen|ZH",
+    "name": "Brünggen",
+    "zipCode": "8483",
+    "canton": "ZH"
+  },
+  {
+    "id": "3860|Brünig|BE",
+    "name": "Brünig",
+    "zipCode": "3860",
+    "canton": "BE"
+  },
+  {
+    "id": "3860|Brünigen|BE",
+    "name": "Brünigen",
+    "zipCode": "3860",
+    "canton": "BE"
+  },
+  {
+    "id": "1719|Brünisried|FR",
+    "name": "Brünisried",
+    "zipCode": "1719",
+    "canton": "FR"
+  },
+  {
+    "id": "9125|Brunnadern|SG",
+    "name": "Brunnadern",
+    "zipCode": "9125",
+    "canton": "SG"
+  },
+  {
+    "id": "6440|Brunnen|SZ",
+    "name": "Brunnen",
+    "zipCode": "6440",
+    "canton": "SZ"
+  },
+  {
+    "id": "3307|Brunnenthal|SO",
+    "name": "Brunnenthal",
+    "zipCode": "3307",
+    "canton": "SO"
+  },
+  {
+    "id": "4717|Brunnersberg|SO",
+    "name": "Brunnersberg",
+    "zipCode": "4717",
+    "canton": "SO"
+  },
+  {
+    "id": "5637|Brunnwil|AG",
+    "name": "Brunnwil",
+    "zipCode": "5637",
+    "canton": "AG"
+  },
+  {
+    "id": "6883|Brusata|TI",
+    "name": "Brusata",
+    "zipCode": "6883",
+    "canton": "TI"
+  },
+  {
+    "id": "8580|Brüschwil|TG",
+    "name": "Brüschwil",
+    "zipCode": "8580",
+    "canton": "TG"
+  },
+  {
+    "id": "6827|Brusino Arsizio|TI",
+    "name": "Brusino Arsizio",
+    "zipCode": "6827",
+    "canton": "TI"
+  },
+  {
+    "id": "7743|Brusio|GR",
+    "name": "Brusio",
+    "zipCode": "7743",
+    "canton": "GR"
+  },
+  {
+    "id": "1934|Bruson|VS",
+    "name": "Bruson",
+    "zipCode": "1934",
+    "canton": "VS"
+  },
+  {
+    "id": "3237|Brüttelen|BE",
+    "name": "Brüttelen",
+    "zipCode": "3237",
+    "canton": "BE"
+  },
+  {
+    "id": "8311|Brütten|ZH",
+    "name": "Brütten",
+    "zipCode": "8311",
+    "canton": "ZH"
+  },
+  {
+    "id": "8306|Brüttisellen|ZH",
+    "name": "Brüttisellen",
+    "zipCode": "8306",
+    "canton": "ZH"
+  },
+  {
+    "id": "6837|Bruzella|TI",
+    "name": "Bruzella",
+    "zipCode": "6837",
+    "canton": "TI"
+  },
+  {
+    "id": "4416|Bubendorf|BL",
+    "name": "Bubendorf",
+    "zipCode": "4416",
+    "canton": "BL"
+  },
+  {
+    "id": "8608|Bubikon|ZH",
+    "name": "Bubikon",
+    "zipCode": "8608",
+    "canton": "ZH"
+  },
+  {
+    "id": "5512|Büblikon|AG",
+    "name": "Büblikon",
+    "zipCode": "5512",
+    "canton": "AG"
+  },
+  {
+    "id": "8263|Buch|SH",
+    "name": "Buch",
+    "zipCode": "8263",
+    "canton": "SH"
+  },
+  {
+    "id": "8414|Buch am Irchel|ZH",
+    "name": "Buch am Irchel",
+    "zipCode": "8414",
+    "canton": "ZH"
+  },
+  {
+    "id": "8524|Buch bei Frauenfeld|TG",
+    "name": "Buch bei Frauenfeld",
+    "zipCode": "8524",
+    "canton": "TG"
+  },
+  {
+    "id": "8586|Buch bei Happerswil|TG",
+    "name": "Buch bei Happerswil",
+    "zipCode": "8586",
+    "canton": "TG"
+  },
+  {
+    "id": "9562|Buch bei Märwil|TG",
+    "name": "Buch bei Märwil",
+    "zipCode": "9562",
+    "canton": "TG"
+  },
+  {
+    "id": "3205|Buch bei Mühleberg|BE",
+    "name": "Buch bei Mühleberg",
+    "zipCode": "3205",
+    "canton": "BE"
+  },
+  {
+    "id": "8586|Buchackern|TG",
+    "name": "Buchackern",
+    "zipCode": "8586",
+    "canton": "TG"
+  },
+  {
+    "id": "8454|Buchberg|SH",
+    "name": "Buchberg",
+    "zipCode": "8454",
+    "canton": "SH"
+  },
+  {
+    "id": "4586|Buchegg|SO",
+    "name": "Buchegg",
+    "zipCode": "4586",
+    "canton": "SO"
+  },
+  {
+    "id": "9464|Büchel|SG",
+    "name": "Büchel",
+    "zipCode": "9464",
+    "canton": "SG"
+  },
+  {
+    "id": "3623|Buchen|BE",
+    "name": "Buchen",
+    "zipCode": "3623",
+    "canton": "BE"
+  },
+  {
+    "id": "7223|Buchen im Prättigau|GR",
+    "name": "Buchen im Prättigau",
+    "zipCode": "7223",
+    "canton": "GR"
+  },
+  {
+    "id": "8143|Buchenegg|ZH",
+    "name": "Buchenegg",
+    "zipCode": "8143",
+    "canton": "ZH"
+  },
+  {
+    "id": "3615|Buchholterberg|BE",
+    "name": "Buchholterberg",
+    "zipCode": "3615",
+    "canton": "BE"
+  },
+  {
+    "id": "3600|Buchholz|BE",
+    "name": "Buchholz",
+    "zipCode": "3600",
+    "canton": "BE"
+  },
+  {
+    "id": "1164|Buchillon|VD",
+    "name": "Buchillon",
+    "zipCode": "1164",
+    "canton": "VD"
+  },
+  {
+    "id": "6033|Buchrain|LU",
+    "name": "Buchrain",
+    "zipCode": "6033",
+    "canton": "LU"
+  },
+  {
+    "id": "5033|Buchs|AG",
+    "name": "Buchs",
+    "zipCode": "5033",
+    "canton": "AG"
+  },
+  {
+    "id": "6211|Buchs|LU",
+    "name": "Buchs",
+    "zipCode": "6211",
+    "canton": "LU"
+  },
+  {
+    "id": "8107|Buchs|ZH",
+    "name": "Buchs",
+    "zipCode": "8107",
+    "canton": "ZH"
+  },
+  {
+    "id": "9470|Buchs|SG",
+    "name": "Buchs",
+    "zipCode": "9470",
+    "canton": "SG"
+  },
+  {
+    "id": "3215|Büchslen|FR",
+    "name": "Büchslen",
+    "zipCode": "3215",
+    "canton": "FR"
+  },
+  {
+    "id": "8203|Buchthalen|SH",
+    "name": "Buchthalen",
+    "zipCode": "8203",
+    "canton": "SH"
+  },
+  {
+    "id": "4446|Buckten|BL",
+    "name": "Buckten",
+    "zipCode": "4446",
+    "canton": "BL"
+  },
+  {
+    "id": "9422|Buechen bei Staad|SG",
+    "name": "Buechen bei Staad",
+    "zipCode": "9422",
+    "canton": "SG"
+  },
+  {
+    "id": "5622|Büelisacher|AG",
+    "name": "Büelisacher",
+    "zipCode": "5622",
+    "canton": "AG"
+  },
+  {
+    "id": "3263|Büetigen|BE",
+    "name": "Büetigen",
+    "zipCode": "3263",
+    "canton": "BE"
+  },
+  {
+    "id": "1180|Bugnaux|VD",
+    "name": "Bugnaux",
+    "zipCode": "1180",
+    "canton": "VD"
+  },
+  {
+    "id": "8500|Bühl|TG",
+    "name": "Bühl",
+    "zipCode": "8500",
+    "canton": "TG"
+  },
+  {
+    "id": "3274|Bühl bei Aarberg|BE",
+    "name": "Bühl bei Aarberg",
+    "zipCode": "3274",
+    "canton": "BE"
+  },
+  {
+    "id": "9055|Bühler|AR",
+    "name": "Bühler",
+    "zipCode": "9055",
+    "canton": "AR"
+  },
+  {
+    "id": "9215|Buhwil|TG",
+    "name": "Buhwil",
+    "zipCode": "9215",
+    "canton": "TG"
+  },
+  {
+    "id": "2925|Buix|JU",
+    "name": "Buix",
+    "zipCode": "2925",
+    "canton": "JU"
+  },
+  {
+    "id": "8180|Bülach|ZH",
+    "name": "Bülach",
+    "zipCode": "8180",
+    "canton": "ZH"
+  },
+  {
+    "id": "1630|Bulle|FR",
+    "name": "Bulle",
+    "zipCode": "1630",
+    "canton": "FR"
+  },
+  {
+    "id": "1453|Bullet|VD",
+    "name": "Bullet",
+    "zipCode": "1453",
+    "canton": "VD"
+  },
+  {
+    "id": "6197|Bumbach|BE",
+    "name": "Bumbach",
+    "zipCode": "6197",
+    "canton": "BE"
+  },
+  {
+    "id": "3000|Bümpliz|BE",
+    "name": "Bümpliz",
+    "zipCode": "3000",
+    "canton": "BE"
+  },
+  {
+    "id": "3054|Bundkofen|BE",
+    "name": "Bundkofen",
+    "zipCode": "3054",
+    "canton": "BE"
+  },
+  {
+    "id": "3186|Bundtels|FR",
+    "name": "Bundtels",
+    "zipCode": "3186",
+    "canton": "FR"
+  },
+  {
+    "id": "9630|Bunt|SG",
+    "name": "Bunt",
+    "zipCode": "9630",
+    "canton": "SG"
+  },
+  {
+    "id": "5624|Bünzen|AG",
+    "name": "Bünzen",
+    "zipCode": "5624",
+    "canton": "AG"
+  },
+  {
+    "id": "6374|Buochs|NW",
+    "name": "Buochs",
+    "zipCode": "6374",
+    "canton": "NW"
+  },
+  {
+    "id": "6343|Buonas|ZG",
+    "name": "Buonas",
+    "zipCode": "6343",
+    "canton": "ZG"
+  },
+  {
+    "id": "3935|Bürchen|VS",
+    "name": "Bürchen",
+    "zipCode": "3935",
+    "canton": "VS"
+  },
+  {
+    "id": "2915|Bure|JU",
+    "name": "Bure",
+    "zipCode": "2915",
+    "canton": "JU"
+  },
+  {
+    "id": "4413|Büren|SO",
+    "name": "Büren",
+    "zipCode": "4413",
+    "canton": "SO"
+  },
+  {
+    "id": "5272|Büren|AG",
+    "name": "Büren",
+    "zipCode": "5272",
+    "canton": "AG"
+  },
+  {
+    "id": "8558|Büren|TG",
+    "name": "Büren",
+    "zipCode": "8558",
+    "canton": "TG"
+  },
+  {
+    "id": "3294|Büren an der Aare|BE",
+    "name": "Büren an der Aare",
+    "zipCode": "3294",
+    "canton": "BE"
+  },
+  {
+    "id": "6382|Büren nid dem Bach|NW",
+    "name": "Büren nid dem Bach",
+    "zipCode": "6382",
+    "canton": "NW"
+  },
+  {
+    "id": "3313|Büren zum Hof|BE",
+    "name": "Büren zum Hof",
+    "zipCode": "3313",
+    "canton": "BE"
+  },
+  {
+    "id": "2603|Bürenberg|BE",
+    "name": "Bürenberg",
+    "zipCode": "2603",
+    "canton": "BE"
+  },
+  {
+    "id": "5736|Burg|AG",
+    "name": "Burg",
+    "zipCode": "5736",
+    "canton": "AG"
+  },
+  {
+    "id": "8570|Burg|TG",
+    "name": "Burg",
+    "zipCode": "8570",
+    "canton": "TG"
+  },
+  {
+    "id": "8732|Bürg|SG",
+    "name": "Bürg",
+    "zipCode": "8732",
+    "canton": "SG"
+  },
+  {
+    "id": "3280|Burg bei Murten|FR",
+    "name": "Burg bei Murten",
+    "zipCode": "3280",
+    "canton": "FR"
+  },
+  {
+    "id": "4117|Burg im Leimental|BL",
+    "name": "Burg im Leimental",
+    "zipCode": "4117",
+    "canton": "BL"
+  },
+  {
+    "id": "4556|Burgäschi|SO",
+    "name": "Burgäschi",
+    "zipCode": "4556",
+    "canton": "SO"
+  },
+  {
+    "id": "9230|Burgau|SG",
+    "name": "Burgau",
+    "zipCode": "9230",
+    "canton": "SG"
+  },
+  {
+    "id": "3400|Burgdorf|BE",
+    "name": "Burgdorf",
+    "zipCode": "3400",
+    "canton": "BE"
+  },
+  {
+    "id": "6363|Bürgenstock|NW",
+    "name": "Bürgenstock",
+    "zipCode": "6363",
+    "canton": "NW"
+  },
+  {
+    "id": "9470|Burgerau|SG",
+    "name": "Burgerau",
+    "zipCode": "9470",
+    "canton": "SG"
+  },
+  {
+    "id": "8805|Burghalden|ZH",
+    "name": "Burghalden",
+    "zipCode": "8805",
+    "canton": "ZH"
+  },
+  {
+    "id": "3664|Burgistein|BE",
+    "name": "Burgistein",
+    "zipCode": "3664",
+    "canton": "BE"
+  },
+  {
+    "id": "3664|Burgistein Station|BE",
+    "name": "Burgistein Station",
+    "zipCode": "3664",
+    "canton": "BE"
+  },
+  {
+    "id": "3816|Burglauenen|BE",
+    "name": "Burglauenen",
+    "zipCode": "3816",
+    "canton": "BE"
+  },
+  {
+    "id": "6078|Bürglen|OW",
+    "name": "Bürglen",
+    "zipCode": "6078",
+    "canton": "OW"
+  },
+  {
+    "id": "6463|Bürglen|UR",
+    "name": "Bürglen",
+    "zipCode": "6463",
+    "canton": "UR"
+  },
+  {
+    "id": "8575|Bürglen|TG",
+    "name": "Bürglen",
+    "zipCode": "8575",
+    "canton": "TG"
+  },
+  {
+    "id": "1814|Burier|VD",
+    "name": "Burier",
+    "zipCode": "1814",
+    "canton": "VD"
+  },
+  {
+    "id": "9425|Buriet|SG",
+    "name": "Buriet",
+    "zipCode": "9425",
+    "canton": "SG"
+  },
+  {
+    "id": "9442|Büriswilen|AI",
+    "name": "Büriswilen",
+    "zipCode": "9442",
+    "canton": "AI"
+  },
+  {
+    "id": "6233|Büron|LU",
+    "name": "Büron",
+    "zipCode": "6233",
+    "canton": "LU"
+  },
+  {
+    "id": "1195|Bursinel|VD",
+    "name": "Bursinel",
+    "zipCode": "1195",
+    "canton": "VD"
+  },
+  {
+    "id": "1183|Bursins|VD",
+    "name": "Bursins",
+    "zipCode": "1183",
+    "canton": "VD"
+  },
+  {
+    "id": "1268|Burtigny|VD",
+    "name": "Burtigny",
+    "zipCode": "1268",
+    "canton": "VD"
+  },
+  {
+    "id": "5522|Büschikon|AG",
+    "name": "Büschikon",
+    "zipCode": "5522",
+    "canton": "AG"
+  },
+  {
+    "id": "6542|Buseno|GR",
+    "name": "Buseno",
+    "zipCode": "6542",
+    "canton": "GR"
+  },
+  {
+    "id": "8330|Bussenhusen|ZH",
+    "name": "Bussenhusen",
+    "zipCode": "8330",
+    "canton": "ZH"
+  },
+  {
+    "id": "4227|Büsserach|SO",
+    "name": "Büsserach",
+    "zipCode": "4227",
+    "canton": "SO"
+  },
+  {
+    "id": "1030|Bussigny-près-Lausanne|VD",
+    "name": "Bussigny-près-Lausanne",
+    "zipCode": "1030",
+    "canton": "VD"
+  },
+  {
+    "id": "1608|Bussigny-sur-Oron|VD",
+    "name": "Bussigny-sur-Oron",
+    "zipCode": "1608",
+    "canton": "VD"
+  },
+  {
+    "id": "5453|Busslingen|AG",
+    "name": "Busslingen",
+    "zipCode": "5453",
+    "canton": "AG"
+  },
+  {
+    "id": "9565|Bussnang|TG",
+    "name": "Bussnang",
+    "zipCode": "9565",
+    "canton": "TG"
+  },
+  {
+    "id": "8371|Busswil|TG",
+    "name": "Busswil",
+    "zipCode": "8371",
+    "canton": "TG"
+  },
+  {
+    "id": "3292|Busswil bei Büren|BE",
+    "name": "Busswil bei Büren",
+    "zipCode": "3292",
+    "canton": "BE"
+  },
+  {
+    "id": "3414|Busswil bei Heimiswil|BE",
+    "name": "Busswil bei Heimiswil",
+    "zipCode": "3414",
+    "canton": "BE"
+  },
+  {
+    "id": "4917|Busswil bei Melchnau|BE",
+    "name": "Busswil bei Melchnau",
+    "zipCode": "4917",
+    "canton": "BE"
+  },
+  {
+    "id": "1541|Bussy|FR",
+    "name": "Bussy",
+    "zipCode": "1541",
+    "canton": "FR"
+  },
+  {
+    "id": "1136|Bussy-Chardonney|VD",
+    "name": "Bussy-Chardonney",
+    "zipCode": "1136",
+    "canton": "VD"
+  },
+  {
+    "id": "1514|Bussy-sur-Moudon|VD",
+    "name": "Bussy-sur-Moudon",
+    "zipCode": "1514",
+    "canton": "VD"
+  },
+  {
+    "id": "3422|Bütikofen|BE",
+    "name": "Bütikofen",
+    "zipCode": "3422",
+    "canton": "BE"
+  },
+  {
+    "id": "9606|Bütschwil|SG",
+    "name": "Bütschwil",
+    "zipCode": "9606",
+    "canton": "SG"
+  },
+  {
+    "id": "8236|Büttenhardt|SH",
+    "name": "Büttenhardt",
+    "zipCode": "8236",
+    "canton": "SH"
+  },
+  {
+    "id": "3203|Buttenried|BE",
+    "name": "Buttenried",
+    "zipCode": "3203",
+    "canton": "BE"
+  },
+  {
+    "id": "2115|Buttes|NE",
+    "name": "Buttes",
+    "zipCode": "2115",
+    "canton": "NE"
+  },
+  {
+    "id": "5619|Büttikon|AG",
+    "name": "Büttikon",
+    "zipCode": "5619",
+    "canton": "AG"
+  },
+  {
+    "id": "8863|Buttikon|SZ",
+    "name": "Buttikon",
+    "zipCode": "8863",
+    "canton": "SZ"
+  },
+  {
+    "id": "6018|Buttisholz|LU",
+    "name": "Buttisholz",
+    "zipCode": "6018",
+    "canton": "LU"
+  },
+  {
+    "id": "5632|Buttwil|AG",
+    "name": "Buttwil",
+    "zipCode": "5632",
+    "canton": "AG"
+  },
+  {
+    "id": "5085|Bütz|AG",
+    "name": "Bütz",
+    "zipCode": "5085",
+    "canton": "AG"
+  },
+  {
+    "id": "4922|Bützberg|BE",
+    "name": "Bützberg",
+    "zipCode": "4922",
+    "canton": "BE"
+  },
+  {
+    "id": "4463|Buus|BL",
+    "name": "Buus",
+    "zipCode": "4463",
+    "canton": "BL"
+  },
+  {
+    "id": "6838|Cabbio|TI",
+    "name": "Cabbio",
+    "zipCode": "6838",
+    "canton": "TI"
+  },
+  {
+    "id": "6558|Cabbiolo|GR",
+    "name": "Cabbiolo",
+    "zipCode": "6558",
+    "canton": "GR"
+  },
+  {
+    "id": "6658|Cadanza|TI",
+    "name": "Cadanza",
+    "zipCode": "6658",
+    "canton": "TI"
+  },
+  {
+    "id": "6936|Cademario|TI",
+    "name": "Cademario",
+    "zipCode": "6936",
+    "canton": "TI"
+  },
+  {
+    "id": "6814|Cadempino|TI",
+    "name": "Cadempino",
+    "zipCode": "6814",
+    "canton": "TI"
+  },
+  {
+    "id": "6593|Cadenazzo|TI",
+    "name": "Cadenazzo",
+    "zipCode": "6593",
+    "canton": "TI"
+  },
+  {
+    "id": "6917|Cadepiano|TI",
+    "name": "Cadepiano",
+    "zipCode": "6917",
+    "canton": "TI"
+  },
+  {
+    "id": "6965|Cadro|TI",
+    "name": "Cadro",
+    "zipCode": "6965",
+    "canton": "TI"
+  },
+  {
+    "id": "6955|Cagiallo|TI",
+    "name": "Cagiallo",
+    "zipCode": "6955",
+    "canton": "TI"
+  },
+  {
+    "id": "6655|Calezzo|TI",
+    "name": "Calezzo",
+    "zipCode": "6655",
+    "canton": "TI"
+  },
+  {
+    "id": "7027|Calfreisen|GR",
+    "name": "Calfreisen",
+    "zipCode": "7027",
+    "canton": "GR"
+  },
+  {
+    "id": "6746|Calonico|TI",
+    "name": "Calonico",
+    "zipCode": "6746",
+    "canton": "TI"
+  },
+  {
+    "id": "6760|Calpiogna|TI",
+    "name": "Calpiogna",
+    "zipCode": "6760",
+    "canton": "TI"
+  },
+  {
+    "id": "6900|Calprino|TI",
+    "name": "Calprino",
+    "zipCode": "6900",
+    "canton": "TI"
+  },
+  {
+    "id": "6557|Cama|GR",
+    "name": "Cama",
+    "zipCode": "6557",
+    "canton": "GR"
+  },
+  {
+    "id": "7107|Camana|GR",
+    "name": "Camana",
+    "zipCode": "7107",
+    "canton": "GR"
+  },
+  {
+    "id": "6659|Camedo|TI",
+    "name": "Camedo",
+    "zipCode": "6659",
+    "canton": "TI"
+  },
+  {
+    "id": "6803|Camignolo|TI",
+    "name": "Camignolo",
+    "zipCode": "6803",
+    "canton": "TI"
+  },
+  {
+    "id": "7187|Camischolas|GR",
+    "name": "Camischolas",
+    "zipCode": "7187",
+    "canton": "GR"
+  },
+  {
+    "id": "6528|Camorino|TI",
+    "name": "Camorino",
+    "zipCode": "6528",
+    "canton": "TI"
+  },
+  {
+    "id": "7748|Campascio|GR",
+    "name": "Campascio",
+    "zipCode": "7748",
+    "canton": "GR"
+  },
+  {
+    "id": "6760|Campello|TI",
+    "name": "Campello",
+    "zipCode": "6760",
+    "canton": "TI"
+  },
+  {
+    "id": "6718|Camperio|TI",
+    "name": "Camperio",
+    "zipCode": "6718",
+    "canton": "TI"
+  },
+  {
+    "id": "6950|Campestro|TI",
+    "name": "Campestro",
+    "zipCode": "6950",
+    "canton": "TI"
+  },
+  {
+    "id": "7166|Campliun|GR",
+    "name": "Campliun",
+    "zipCode": "7166",
+    "canton": "GR"
+  },
+  {
+    "id": "6720|Campo (Blenio)|TI",
+    "name": "Campo (Blenio)",
+    "zipCode": "6720",
+    "canton": "TI"
+  },
+  {
+    "id": "6684|Campo (Vallemaggia)|TI",
+    "name": "Campo (Vallemaggia)",
+    "zipCode": "6684",
+    "canton": "TI"
+  },
+  {
+    "id": "7744|Campocologno|GR",
+    "name": "Campocologno",
+    "zipCode": "7744",
+    "canton": "GR"
+  },
+  {
+    "id": "6875|Campora|TI",
+    "name": "Campora",
+    "zipCode": "6875",
+    "canton": "TI"
+  },
+  {
+    "id": "6718|Campra|TI",
+    "name": "Campra",
+    "zipCode": "6718",
+    "canton": "TI"
+  },
+  {
+    "id": "7446|Campsut|GR",
+    "name": "Campsut",
+    "zipCode": "7446",
+    "canton": "GR"
+  },
+  {
+    "id": "7113|Camuns|GR",
+    "name": "Camuns",
+    "zipCode": "7113",
+    "canton": "GR"
+  },
+  {
+    "id": "6837|Caneggio|TI",
+    "name": "Caneggio",
+    "zipCode": "6837",
+    "canton": "TI"
+  },
+  {
+    "id": "6952|Canobbio|TI",
+    "name": "Canobbio",
+    "zipCode": "6952",
+    "canton": "TI"
+  },
+  {
+    "id": "7077|Canols|GR",
+    "name": "Canols",
+    "zipCode": "7077",
+    "canton": "GR"
+  },
+  {
+    "id": "6802|Capidogno|TI",
+    "name": "Capidogno",
+    "zipCode": "6802",
+    "canton": "TI"
+  },
+  {
+    "id": "6825|Capolago|TI",
+    "name": "Capolago",
+    "zipCode": "6825",
+    "canton": "TI"
+  },
+  {
+    "id": "6823|Caprino|TI",
+    "name": "Caprino",
+    "zipCode": "6823",
+    "canton": "TI"
+  },
+  {
+    "id": "1243|Cara|GE",
+    "name": "Cara",
+    "zipCode": "1243",
+    "canton": "GE"
+  },
+  {
+    "id": "6913|Carabbia|TI",
+    "name": "Carabbia",
+    "zipCode": "6913",
+    "canton": "TI"
+  },
+  {
+    "id": "6919|Carabietta|TI",
+    "name": "Carabietta",
+    "zipCode": "6919",
+    "canton": "TI"
+  },
+  {
+    "id": "6500|Carasso|TI",
+    "name": "Carasso",
+    "zipCode": "6500",
+    "canton": "TI"
+  },
+  {
+    "id": "6600|Cardada|TI",
+    "name": "Cardada",
+    "zipCode": "6600",
+    "canton": "TI"
+  },
+  {
+    "id": "6584|Carena|TI",
+    "name": "Carena",
+    "zipCode": "6584",
+    "canton": "TI"
+  },
+  {
+    "id": "6760|Carì|TI",
+    "name": "Carì",
+    "zipCode": "6760",
+    "canton": "TI"
+  },
+  {
+    "id": "1565|Carignan|FR",
+    "name": "Carignan",
+    "zipCode": "1565",
+    "canton": "FR"
+  },
+  {
+    "id": "6583|Carmena|TI",
+    "name": "Carmena",
+    "zipCode": "6583",
+    "canton": "TI"
+  },
+  {
+    "id": "6914|Carona|TI",
+    "name": "Carona",
+    "zipCode": "6914",
+    "canton": "TI"
+  },
+  {
+    "id": "1227|Carouge|GE",
+    "name": "Carouge",
+    "zipCode": "1227",
+    "canton": "GE"
+  },
+  {
+    "id": "7122|Carrera|GR",
+    "name": "Carrera",
+    "zipCode": "7122",
+    "canton": "GR"
+  },
+  {
+    "id": "1084|Carrouge|VD",
+    "name": "Carrouge",
+    "zipCode": "1084",
+    "canton": "VD"
+  },
+  {
+    "id": "1236|Cartigny|GE",
+    "name": "Cartigny",
+    "zipCode": "1236",
+    "canton": "GE"
+  },
+  {
+    "id": "7602|Casaccia|GR",
+    "name": "Casaccia",
+    "zipCode": "7602",
+    "canton": "GR"
+  },
+  {
+    "id": "6883|Casate|TI",
+    "name": "Casate",
+    "zipCode": "6883",
+    "canton": "TI"
+  },
+  {
+    "id": "6875|Casima|TI",
+    "name": "Casima",
+    "zipCode": "6875",
+    "canton": "TI"
+  },
+  {
+    "id": "6987|Caslano|TI",
+    "name": "Caslano",
+    "zipCode": "6987",
+    "canton": "TI"
+  },
+  {
+    "id": "6900|Cassarate|TI",
+    "name": "Cassarate",
+    "zipCode": "6900",
+    "canton": "TI"
+  },
+  {
+    "id": "6702|Cassero|TI",
+    "name": "Cassero",
+    "zipCode": "6702",
+    "canton": "TI"
+  },
+  {
+    "id": "6990|Cassina d'Agno|TI",
+    "name": "Cassina d'Agno",
+    "zipCode": "6990",
+    "canton": "TI"
+  },
+  {
+    "id": "6976|Castagnola|TI",
+    "name": "Castagnola",
+    "zipCode": "6976",
+    "canton": "TI"
+  },
+  {
+    "id": "6540|Castaneda|GR",
+    "name": "Castaneda",
+    "zipCode": "6540",
+    "canton": "GR"
+  },
+  {
+    "id": "7608|Castasegna|GR",
+    "name": "Castasegna",
+    "zipCode": "7608",
+    "canton": "GR"
+  },
+  {
+    "id": "6874|Castel S. Pietro|TI",
+    "name": "Castel S. Pietro",
+    "zipCode": "6874",
+    "canton": "TI"
+  },
+  {
+    "id": "6980|Castelrotto|TI",
+    "name": "Castelrotto",
+    "zipCode": "6980",
+    "canton": "TI"
+  },
+  {
+    "id": "7433|Casti|GR",
+    "name": "Casti",
+    "zipCode": "7433",
+    "canton": "GR"
+  },
+  {
+    "id": "7027|Castiel|GR",
+    "name": "Castiel",
+    "zipCode": "7027",
+    "canton": "GR"
+  },
+  {
+    "id": "6532|Castione|TI",
+    "name": "Castione",
+    "zipCode": "6532",
+    "canton": "TI"
+  },
+  {
+    "id": "7126|Castrisch|GR",
+    "name": "Castrisch",
+    "zipCode": "7126",
+    "canton": "GR"
+  },
+  {
+    "id": "6723|Castro|TI",
+    "name": "Castro",
+    "zipCode": "6723",
+    "canton": "TI"
+  },
+  {
+    "id": "6777|Catto|TI",
+    "name": "Catto",
+    "zipCode": "6777",
+    "canton": "TI"
+  },
+  {
+    "id": "6546|Cauco|GR",
+    "name": "Cauco",
+    "zipCode": "6546",
+    "canton": "GR"
+  },
+  {
+    "id": "1824|Caux|VD",
+    "name": "Caux",
+    "zipCode": "1824",
+    "canton": "VD"
+  },
+  {
+    "id": "7742|Cavaglia|GR",
+    "name": "Cavaglia",
+    "zipCode": "7742",
+    "canton": "GR"
+  },
+  {
+    "id": "6749|Cavagnago|TI",
+    "name": "Cavagnago",
+    "zipCode": "6749",
+    "canton": "TI"
+  },
+  {
+    "id": "7748|Cavajone|GR",
+    "name": "Cavajone",
+    "zipCode": "7748",
+    "canton": "GR"
+  },
+  {
+    "id": "6823|Cavallino|TI",
+    "name": "Cavallino",
+    "zipCode": "6823",
+    "canton": "TI"
+  },
+  {
+    "id": "7182|Cavardiras|GR",
+    "name": "Cavardiras",
+    "zipCode": "7182",
+    "canton": "GR"
+  },
+  {
+    "id": "6690|Cavergno|TI",
+    "name": "Cavergno",
+    "zipCode": "6690",
+    "canton": "TI"
+  },
+  {
+    "id": "6578|Caviano|TI",
+    "name": "Caviano",
+    "zipCode": "6578",
+    "canton": "TI"
+  },
+  {
+    "id": "6654|Cavigliano|TI",
+    "name": "Cavigliano",
+    "zipCode": "6654",
+    "canton": "TI"
+  },
+  {
+    "id": "7408|Cazis|GR",
+    "name": "Cazis",
+    "zipCode": "7408",
+    "canton": "GR"
+  },
+  {
+    "id": "7505|Celerina/Schlarigna|GR",
+    "name": "Celerina/Schlarigna",
+    "zipCode": "7505",
+    "canton": "GR"
+  },
+  {
+    "id": "1298|Céligny|GE",
+    "name": "Céligny",
+    "zipCode": "1298",
+    "canton": "GE"
+  },
+  {
+    "id": "6683|Cerentino|TI",
+    "name": "Cerentino",
+    "zipCode": "6683",
+    "canton": "TI"
+  },
+  {
+    "id": "1863|Cergnat|VD",
+    "name": "Cergnat",
+    "zipCode": "1863",
+    "canton": "VD"
+  },
+  {
+    "id": "2336|Cerneux-Godat|JU",
+    "name": "Cerneux-Godat",
+    "zipCode": "2336",
+    "canton": "JU"
+  },
+  {
+    "id": "1654|Cerniat|FR",
+    "name": "Cerniat",
+    "zipCode": "1654",
+    "canton": "FR"
+  },
+  {
+    "id": "1682|Cerniaz|VD",
+    "name": "Cerniaz",
+    "zipCode": "1682",
+    "canton": "VD"
+  },
+  {
+    "id": "2053|Cernier|NE",
+    "name": "Cernier",
+    "zipCode": "2053",
+    "canton": "NE"
+  },
+  {
+    "id": "6959|Certara|TI",
+    "name": "Certara",
+    "zipCode": "6959",
+    "canton": "TI"
+  },
+  {
+    "id": "6926|Certenago|TI",
+    "name": "Certenago",
+    "zipCode": "6926",
+    "canton": "TI"
+  },
+  {
+    "id": "1258|Certoux|GE",
+    "name": "Certoux",
+    "zipCode": "1258",
+    "canton": "GE"
+  },
+  {
+    "id": "6675|Cevio|TI",
+    "name": "Cevio",
+    "zipCode": "6675",
+    "canton": "TI"
+  },
+  {
+    "id": "1474|Châbles|FR",
+    "name": "Châbles",
+    "zipCode": "1474",
+    "canton": "FR"
+  },
+  {
+    "id": "1589|Chabrey|VD",
+    "name": "Chabrey",
+    "zipCode": "1589",
+    "canton": "VD"
+  },
+  {
+    "id": "1000|Chailly|VD",
+    "name": "Chailly",
+    "zipCode": "1000",
+    "canton": "VD"
+  },
+  {
+    "id": "1816|Chailly|VD",
+    "name": "Chailly",
+    "zipCode": "1816",
+    "canton": "VD"
+  },
+  {
+    "id": "2732|Chaindon|BE",
+    "name": "Chaindon",
+    "zipCode": "2732",
+    "canton": "BE"
+  },
+  {
+    "id": "3966|Chalais|VS",
+    "name": "Chalais",
+    "zipCode": "3966",
+    "canton": "VS"
+  },
+  {
+    "id": "6330|Cham|ZG",
+    "name": "Cham",
+    "zipCode": "6330",
+    "canton": "ZG"
+  },
+  {
+    "id": "1292|Chambésy|GE",
+    "name": "Chambésy",
+    "zipCode": "1292",
+    "canton": "GE"
+  },
+  {
+    "id": "1763|Chamblioux|FR",
+    "name": "Chamblioux",
+    "zipCode": "1763",
+    "canton": "FR"
+  },
+  {
+    "id": "1436|Chamblon|VD",
+    "name": "Chamblon",
+    "zipCode": "1436",
+    "canton": "VD"
+  },
+  {
+    "id": "2019|Chambrelien|NE",
+    "name": "Chambrelien",
+    "zipCode": "2019",
+    "canton": "NE"
+  },
+  {
+    "id": "1832|Chamby|VD",
+    "name": "Chamby",
+    "zipCode": "1832",
+    "canton": "VD"
+  },
+  {
+    "id": "1933|Chamoille|VS",
+    "name": "Chamoille",
+    "zipCode": "1933",
+    "canton": "VS"
+  },
+  {
+    "id": "1937|Chamoille d'Orsières|VS",
+    "name": "Chamoille d'Orsières",
+    "zipCode": "1937",
+    "canton": "VS"
+  },
+  {
+    "id": "1955|Chamoson|VS",
+    "name": "Chamoson",
+    "zipCode": "1955",
+    "canton": "VS"
+  },
+  {
+    "id": "2149|Champ-du-Moulin|NE",
+    "name": "Champ-du-Moulin",
+    "zipCode": "2149",
+    "canton": "NE"
+  },
+  {
+    "id": "1424|Champagne|VD",
+    "name": "Champagne",
+    "zipCode": "1424",
+    "canton": "VD"
+  },
+  {
+    "id": "1874|Champéry|VS",
+    "name": "Champéry",
+    "zipCode": "1874",
+    "canton": "VS"
+  },
+  {
+    "id": "1938|Champex|VS",
+    "name": "Champex",
+    "zipCode": "1938",
+    "canton": "VS"
+  },
+  {
+    "id": "7512|Champfèr|GR",
+    "name": "Champfèr",
+    "zipCode": "7512",
+    "canton": "GR"
+  },
+  {
+    "id": "1971|Champlan|VS",
+    "name": "Champlan",
+    "zipCode": "1971",
+    "canton": "VS"
+  },
+  {
+    "id": "1588|Champmartin|VD",
+    "name": "Champmartin",
+    "zipCode": "1588",
+    "canton": "VD"
+  },
+  {
+    "id": "1873|Champoussin|VS",
+    "name": "Champoussin",
+    "zipCode": "1873",
+    "canton": "VS"
+  },
+  {
+    "id": "2735|Champoz|BE",
+    "name": "Champoz",
+    "zipCode": "2735",
+    "canton": "BE"
+  },
+  {
+    "id": "1947|Champsec|VS",
+    "name": "Champsec",
+    "zipCode": "1947",
+    "canton": "VS"
+  },
+  {
+    "id": "1537|Champtauroz|VD",
+    "name": "Champtauroz",
+    "zipCode": "1537",
+    "canton": "VD"
+  },
+  {
+    "id": "1443|Champvent|VD",
+    "name": "Champvent",
+    "zipCode": "1443",
+    "canton": "VD"
+  },
+  {
+    "id": "3976|Champzabé|VS",
+    "name": "Champzabé",
+    "zipCode": "3976",
+    "canton": "VS"
+  },
+  {
+    "id": "7522|Chamues-ch|GR",
+    "name": "Chamues-ch",
+    "zipCode": "7522",
+    "canton": "GR"
+  },
+  {
+    "id": "1284|Chancy|GE",
+    "name": "Chancy",
+    "zipCode": "1284",
+    "canton": "GE"
+  },
+  {
+    "id": "1965|Chandolin|VS",
+    "name": "Chandolin",
+    "zipCode": "1965",
+    "canton": "VS"
+  },
+  {
+    "id": "3961|Chandolin|VS",
+    "name": "Chandolin",
+    "zipCode": "3961",
+    "canton": "VS"
+  },
+  {
+    "id": "1773|Chandon|FR",
+    "name": "Chandon",
+    "zipCode": "1773",
+    "canton": "FR"
+  },
+  {
+    "id": "1945|Chandonne|VS",
+    "name": "Chandonne",
+    "zipCode": "1945",
+    "canton": "VS"
+  },
+  {
+    "id": "1583|Chandossel|FR",
+    "name": "Chandossel",
+    "zipCode": "1583",
+    "canton": "FR"
+  },
+  {
+    "id": "1409|Chanéaz|VD",
+    "name": "Chanéaz",
+    "zipCode": "1409",
+    "canton": "VD"
+  },
+  {
+    "id": "7526|Chapella|GR",
+    "name": "Chapella",
+    "zipCode": "7526",
+    "canton": "GR"
+  },
+  {
+    "id": "1534|Chapelle (Broye)|FR",
+    "name": "Chapelle (Broye)",
+    "zipCode": "1534",
+    "canton": "FR"
+  },
+  {
+    "id": "1608|Chapelle (Glâne)|FR",
+    "name": "Chapelle (Glâne)",
+    "zipCode": "1608",
+    "canton": "FR"
+  },
+  {
+    "id": "1063|Chapelle-sur-Moudon|VD",
+    "name": "Chapelle-sur-Moudon",
+    "zipCode": "1063",
+    "canton": "VD"
+  },
+  {
+    "id": "9032|Chapf|SG",
+    "name": "Chapf",
+    "zipCode": "9032",
+    "canton": "SG"
+  },
+  {
+    "id": "4153|Chäppeli|BL",
+    "name": "Chäppeli",
+    "zipCode": "4153",
+    "canton": "BL"
+  },
+  {
+    "id": "1803|Chardonne|VD",
+    "name": "Chardonne",
+    "zipCode": "1803",
+    "canton": "VD"
+  },
+  {
+    "id": "1041|Chardonney|VD",
+    "name": "Chardonney",
+    "zipCode": "1041",
+    "canton": "VD"
+  },
+  {
+    "id": "1637|Charmey|FR",
+    "name": "Charmey",
+    "zipCode": "1637",
+    "canton": "FR"
+  },
+  {
+    "id": "2947|Charmoille|JU",
+    "name": "Charmoille",
+    "zipCode": "2947",
+    "canton": "JU"
+  },
+  {
+    "id": "1906|Charrat|VS",
+    "name": "Charrat",
+    "zipCode": "1906",
+    "canton": "VS"
+  },
+  {
+    "id": "1257|Charrot|GE",
+    "name": "Charrot",
+    "zipCode": "1257",
+    "canton": "GE"
+  },
+  {
+    "id": "2518|Chasseral|BE",
+    "name": "Chasseral",
+    "zipCode": "2518",
+    "canton": "BE"
+  },
+  {
+    "id": "1452|Chasseron|VD",
+    "name": "Chasseron",
+    "zipCode": "1452",
+    "canton": "VD"
+  },
+  {
+    "id": "1297|Chataigneriaz|VD",
+    "name": "Chataigneriaz",
+    "zipCode": "1297",
+    "canton": "VD"
+  },
+  {
+    "id": "1926|Châtaignier|VS",
+    "name": "Châtaignier",
+    "zipCode": "1926",
+    "canton": "VS"
+  },
+  {
+    "id": "1660|Château-d'Oex|VD",
+    "name": "Château-d'Oex",
+    "zipCode": "1660",
+    "canton": "VD"
+  },
+  {
+    "id": "1950|Châteauneuf|VS",
+    "name": "Châteauneuf",
+    "zipCode": "1950",
+    "canton": "VS"
+  },
+  {
+    "id": "1618|Châtel-St-Denis|FR",
+    "name": "Châtel-St-Denis",
+    "zipCode": "1618",
+    "canton": "FR"
+  },
+  {
+    "id": "1653|Châtel-sur-Montsalvens|FR",
+    "name": "Châtel-sur-Montsalvens",
+    "zipCode": "1653",
+    "canton": "FR"
+  },
+  {
+    "id": "1186|Châtel-sur-Rolle|VD",
+    "name": "Châtel-sur-Rolle",
+    "zipCode": "1186",
+    "canton": "VD"
+  },
+  {
+    "id": "1219|Châtelaine|GE",
+    "name": "Châtelaine",
+    "zipCode": "1219",
+    "canton": "GE"
+  },
+  {
+    "id": "1095|Châtelard|VD",
+    "name": "Châtelard",
+    "zipCode": "1095",
+    "canton": "VD"
+  },
+  {
+    "id": "2715|Châtelat|BE",
+    "name": "Châtelat",
+    "zipCode": "2715",
+    "canton": "BE"
+  },
+  {
+    "id": "1610|Châtillens|VD",
+    "name": "Châtillens",
+    "zipCode": "1610",
+    "canton": "VD"
+  },
+  {
+    "id": "1473|Châtillon|FR",
+    "name": "Châtillon",
+    "zipCode": "1473",
+    "canton": "FR"
+  },
+  {
+    "id": "2843|Châtillon|JU",
+    "name": "Châtillon",
+    "zipCode": "2843",
+    "canton": "JU"
+  },
+  {
+    "id": "1553|Châtonnaye|FR",
+    "name": "Châtonnaye",
+    "zipCode": "1553",
+    "canton": "FR"
+  },
+  {
+    "id": "2067|Chaumont|NE",
+    "name": "Chaumont",
+    "zipCode": "2067",
+    "canton": "NE"
+  },
+  {
+    "id": "1279|Chavannes-de-Bogis|VD",
+    "name": "Chavannes-de-Bogis",
+    "zipCode": "1279",
+    "canton": "VD"
+  },
+  {
+    "id": "1290|Chavannes-des-Bois|VD",
+    "name": "Chavannes-des-Bois",
+    "zipCode": "1290",
+    "canton": "VD"
+  },
+  {
+    "id": "1464|Chavannes-le-Chêne|VD",
+    "name": "Chavannes-le-Chêne",
+    "zipCode": "1464",
+    "canton": "VD"
+  },
+  {
+    "id": "1148|Chavannes-le-Veyron|VD",
+    "name": "Chavannes-le-Veyron",
+    "zipCode": "1148",
+    "canton": "VD"
+  },
+  {
+    "id": "1676|Chavannes-les-Forts|FR",
+    "name": "Chavannes-les-Forts",
+    "zipCode": "1676",
+    "canton": "FR"
+  },
+  {
+    "id": "1022|Chavannes-près-Renens|VD",
+    "name": "Chavannes-près-Renens",
+    "zipCode": "1022",
+    "canton": "VD"
+  },
+  {
+    "id": "1694|Chavannes-sous-Orsonnens|FR",
+    "name": "Chavannes-sous-Orsonnens",
+    "zipCode": "1694",
+    "canton": "FR"
+  },
+  {
+    "id": "1512|Chavannes-sur-Moudon|VD",
+    "name": "Chavannes-sur-Moudon",
+    "zipCode": "1512",
+    "canton": "VD"
+  },
+  {
+    "id": "1373|Chavornay|VD",
+    "name": "Chavornay",
+    "zipCode": "1373",
+    "canton": "VD"
+  },
+  {
+    "id": "1529|Cheiry|FR",
+    "name": "Cheiry",
+    "zipCode": "1529",
+    "canton": "FR"
+  },
+  {
+    "id": "3978|Chelin|VS",
+    "name": "Chelin",
+    "zipCode": "3978",
+    "canton": "VS"
+  },
+  {
+    "id": "1872|Chemex|VS",
+    "name": "Chemex",
+    "zipCode": "1872",
+    "canton": "VS"
+  },
+  {
+    "id": "1927|Chemin|VS",
+    "name": "Chemin",
+    "zipCode": "1927",
+    "canton": "VS"
+  },
+  {
+    "id": "1927|Chemin-Dessous|VS",
+    "name": "Chemin-Dessous",
+    "zipCode": "1927",
+    "canton": "VS"
+  },
+  {
+    "id": "1091|Chenaux|VD",
+    "name": "Chenaux",
+    "zipCode": "1091",
+    "canton": "VD"
+  },
+  {
+    "id": "1224|Chêne-Bougeries|GE",
+    "name": "Chêne-Bougeries",
+    "zipCode": "1224",
+    "canton": "GE"
+  },
+  {
+    "id": "1225|Chêne-Bourg|GE",
+    "name": "Chêne-Bourg",
+    "zipCode": "1225",
+    "canton": "GE"
+  },
+  {
+    "id": "1464|Chêne-Pâquier|VD",
+    "name": "Chêne-Pâquier",
+    "zipCode": "1464",
+    "canton": "VD"
+  },
+  {
+    "id": "1744|Chénens|FR",
+    "name": "Chénens",
+    "zipCode": "1744",
+    "canton": "FR"
+  },
+  {
+    "id": "3971|Chermignon|VS",
+    "name": "Chermignon",
+    "zipCode": "3971",
+    "canton": "VS"
+  },
+  {
+    "id": "3971|Chermignon-d'en-Bas|VS",
+    "name": "Chermignon-d'en-Bas",
+    "zipCode": "3971",
+    "canton": "VS"
+  },
+  {
+    "id": "3971|Chermignon-d'en-Haut|VS",
+    "name": "Chermignon-d'en-Haut",
+    "zipCode": "3971",
+    "canton": "VS"
+  },
+  {
+    "id": "1822|Chernex|VD",
+    "name": "Chernex",
+    "zipCode": "1822",
+    "canton": "VD"
+  },
+  {
+    "id": "2885|Chervillers|JU",
+    "name": "Chervillers",
+    "zipCode": "2885",
+    "canton": "JU"
+  },
+  {
+    "id": "1683|Chesalles-sur-Moudon|VD",
+    "name": "Chesalles-sur-Moudon",
+    "zipCode": "1683",
+    "canton": "VD"
+  },
+  {
+    "id": "1608|Chesalles-sur-Oron|VD",
+    "name": "Chesalles-sur-Oron",
+    "zipCode": "1608",
+    "canton": "VD"
+  },
+  {
+    "id": "1400|Cheseaux|VD",
+    "name": "Cheseaux",
+    "zipCode": "1400",
+    "canton": "VD"
+  },
+  {
+    "id": "1033|Cheseaux-sur-Lausanne|VD",
+    "name": "Cheseaux-sur-Lausanne",
+    "zipCode": "1033",
+    "canton": "VD"
+  },
+  {
+    "id": "1275|Chéserex|VD",
+    "name": "Chéserex",
+    "zipCode": "1275",
+    "canton": "VD"
+  },
+  {
+    "id": "1885|Chesières|VD",
+    "name": "Chesières",
+    "zipCode": "1885",
+    "canton": "VD"
+  },
+  {
+    "id": "1720|Chésopelloz|FR",
+    "name": "Chésopelloz",
+    "zipCode": "1720",
+    "canton": "FR"
+  },
+  {
+    "id": "1846|Chessel|VD",
+    "name": "Chessel",
+    "zipCode": "1846",
+    "canton": "VD"
+  },
+  {
+    "id": "2906|Chevenez|JU",
+    "name": "Chevenez",
+    "zipCode": "2906",
+    "canton": "JU"
+  },
+  {
+    "id": "1316|Chevilly|VD",
+    "name": "Chevilly",
+    "zipCode": "1316",
+    "canton": "VD"
+  },
+  {
+    "id": "1247|Chevrens|GE",
+    "name": "Chevrens",
+    "zipCode": "1247",
+    "canton": "GE"
+  },
+  {
+    "id": "1233|Chèvres|GE",
+    "name": "Chèvres",
+    "zipCode": "1233",
+    "canton": "GE"
+  },
+  {
+    "id": "1244|Chevrier|GE",
+    "name": "Chevrier",
+    "zipCode": "1244",
+    "canton": "GE"
+  },
+  {
+    "id": "1545|Chevroux|VD",
+    "name": "Chevroux",
+    "zipCode": "1545",
+    "canton": "VD"
+  },
+  {
+    "id": "1071|Chexbres|VD",
+    "name": "Chexbres",
+    "zipCode": "1071",
+    "canton": "VD"
+  },
+  {
+    "id": "1468|Cheyres|FR",
+    "name": "Cheyres",
+    "zipCode": "1468",
+    "canton": "FR"
+  },
+  {
+    "id": "1347|Chez le Maìtre|VD",
+    "name": "Chez le Maìtre",
+    "zipCode": "1347",
+    "canton": "VD"
+  },
+  {
+    "id": "1945|Chez Petit|VS",
+    "name": "Chez Petit",
+    "zipCode": "1945",
+    "canton": "VS"
+  },
+  {
+    "id": "2883|Chez-Basuel|JU",
+    "name": "Chez-Basuel",
+    "zipCode": "2883",
+    "canton": "JU"
+  },
+  {
+    "id": "2025|Chez-le-Bart|NE",
+    "name": "Chez-le-Bart",
+    "zipCode": "2025",
+    "canton": "NE"
+  },
+  {
+    "id": "1937|Chez-les-Addy|VS",
+    "name": "Chez-les-Addy",
+    "zipCode": "1937",
+    "canton": "VS"
+  },
+  {
+    "id": "1937|Chez-les-Reuse|VS",
+    "name": "Chez-les-Reuse",
+    "zipCode": "1937",
+    "canton": "VS"
+  },
+  {
+    "id": "1348|Chez-Meylan|VD",
+    "name": "Chez-Meylan",
+    "zipCode": "1348",
+    "canton": "VD"
+  },
+  {
+    "id": "2054|Chézard|NE",
+    "name": "Chézard",
+    "zipCode": "2054",
+    "canton": "NE"
+  },
+  {
+    "id": "6830|Chiasso|TI",
+    "name": "Chiasso",
+    "zipCode": "6830",
+    "canton": "TI"
+  },
+  {
+    "id": "6713|Chiesa|TI",
+    "name": "Chiesa",
+    "zipCode": "6713",
+    "canton": "TI"
+  },
+  {
+    "id": "6764|Chiggiogna|TI",
+    "name": "Chiggiogna",
+    "zipCode": "6764",
+    "canton": "TI"
+  },
+  {
+    "id": "1134|Chigny|VD",
+    "name": "Chigny",
+    "zipCode": "1134",
+    "canton": "VD"
+  },
+  {
+    "id": "8912|Chilenfeld|ZH",
+    "name": "Chilenfeld",
+    "zipCode": "8912",
+    "canton": "ZH"
+  },
+  {
+    "id": "3965|Chippis|VS",
+    "name": "Chippis",
+    "zipCode": "3965",
+    "canton": "VS"
+  },
+  {
+    "id": "8512|Chirchberg|TG",
+    "name": "Chirchberg",
+    "zipCode": "8512",
+    "canton": "TG"
+  },
+  {
+    "id": "6747|Chironico|TI",
+    "name": "Chironico",
+    "zipCode": "6747",
+    "canton": "TI"
+  },
+  {
+    "id": "1871|Choëx|VS",
+    "name": "Choëx",
+    "zipCode": "1871",
+    "canton": "VS"
+  },
+  {
+    "id": "2830|Choindez|JU",
+    "name": "Choindez",
+    "zipCode": "2830",
+    "canton": "JU"
+  },
+  {
+    "id": "1253|Chougny|GE",
+    "name": "Chougny",
+    "zipCode": "1253",
+    "canton": "GE"
+  },
+  {
+    "id": "1244|Choulex|GE",
+    "name": "Choulex",
+    "zipCode": "1244",
+    "canton": "GE"
+  },
+  {
+    "id": "1242|Choully|GE",
+    "name": "Choully",
+    "zipCode": "1242",
+    "canton": "GE"
+  },
+  {
+    "id": "3453|Chramershus|BE",
+    "name": "Chramershus",
+    "zipCode": "3453",
+    "canton": "BE"
+  },
+  {
+    "id": "3538|Chuderhüsi|BE",
+    "name": "Chuderhüsi",
+    "zipCode": "3538",
+    "canton": "BE"
+  },
+  {
+    "id": "7000|Chur|GR",
+    "name": "Chur",
+    "zipCode": "7000",
+    "canton": "GR"
+  },
+  {
+    "id": "7075|Churwalden|GR",
+    "name": "Churwalden",
+    "zipCode": "7075",
+    "canton": "GR"
+  },
+  {
+    "id": "6959|Cimadera|TI",
+    "name": "Cimadera",
+    "zipCode": "6959",
+    "canton": "TI"
+  },
+  {
+    "id": "6684|Cimalmotto|TI",
+    "name": "Cimalmotto",
+    "zipCode": "6684",
+    "canton": "TI"
+  },
+  {
+    "id": "6992|Cimo|TI",
+    "name": "Cimo",
+    "zipCode": "6992",
+    "canton": "TI"
+  },
+  {
+    "id": "7526|Cinuos-chel|GR",
+    "name": "Cinuos-chel",
+    "zipCode": "7526",
+    "canton": "GR"
+  },
+  {
+    "id": "4000|Clara|BS",
+    "name": "Clara",
+    "zipCode": "4000",
+    "canton": "BS"
+  },
+  {
+    "id": "1815|Clarens|VD",
+    "name": "Clarens",
+    "zipCode": "1815",
+    "canton": "VD"
+  },
+  {
+    "id": "1127|Clarmont|VD",
+    "name": "Clarmont",
+    "zipCode": "1127",
+    "canton": "VD"
+  },
+  {
+    "id": "6702|Claro|TI",
+    "name": "Claro",
+    "zipCode": "6702",
+    "canton": "TI"
+  },
+  {
+    "id": "7272|Clavadel|GR",
+    "name": "Clavadel",
+    "zipCode": "7272",
+    "canton": "GR"
+  },
+  {
+    "id": "1595|Clavaleyres|BE",
+    "name": "Clavaleyres",
+    "zipCode": "1595",
+    "canton": "BE"
+  },
+  {
+    "id": "1993|Clèbes|VS",
+    "name": "Clèbes",
+    "zipCode": "1993",
+    "canton": "VS"
+  },
+  {
+    "id": "2057|Clémesin|NE",
+    "name": "Clémesin",
+    "zipCode": "2057",
+    "canton": "NE"
+  },
+  {
+    "id": "7442|Clugin|GR",
+    "name": "Clugin",
+    "zipCode": "7442",
+    "canton": "GR"
+  },
+  {
+    "id": "2932|Coeuve|JU",
+    "name": "Coeuve",
+    "zipCode": "2932",
+    "canton": "JU"
+  },
+  {
+    "id": "2207|Coffrane|NE",
+    "name": "Coffrane",
+    "zipCode": "2207",
+    "canton": "NE"
+  },
+  {
+    "id": "6678|Coglio|TI",
+    "name": "Coglio",
+    "zipCode": "6678",
+    "canton": "TI"
+  },
+  {
+    "id": "1267|Coinsins|VD",
+    "name": "Coinsins",
+    "zipCode": "1267",
+    "canton": "VD"
+  },
+  {
+    "id": "1216|Cointrin|GE",
+    "name": "Cointrin",
+    "zipCode": "1216",
+    "canton": "GE"
+  },
+  {
+    "id": "1927|Col-des-Planches|VS",
+    "name": "Col-des-Planches",
+    "zipCode": "1927",
+    "canton": "VS"
+  },
+  {
+    "id": "1865|Col-du-Pillon|VD",
+    "name": "Col-du-Pillon",
+    "zipCode": "1865",
+    "canton": "VD"
+  },
+  {
+    "id": "6877|Coldrerio|TI",
+    "name": "Coldrerio",
+    "zipCode": "6877",
+    "canton": "TI"
+  },
+  {
+    "id": "6951|Colla|TI",
+    "name": "Colla",
+    "zipCode": "6951",
+    "canton": "TI"
+  },
+  {
+    "id": "1239|Collex|GE",
+    "name": "Collex",
+    "zipCode": "1239",
+    "canton": "GE"
+  },
+  {
+    "id": "6683|Collinasca|TI",
+    "name": "Collinasca",
+    "zipCode": "6683",
+    "canton": "TI"
+  },
+  {
+    "id": "1868|Collombey|VS",
+    "name": "Collombey",
+    "zipCode": "1868",
+    "canton": "VS"
+  },
+  {
+    "id": "1868|Collombey-le-Grand|VS",
+    "name": "Collombey-le-Grand",
+    "zipCode": "1868",
+    "canton": "VS"
+  },
+  {
+    "id": "1245|Collonge|GE",
+    "name": "Collonge",
+    "zipCode": "1245",
+    "canton": "GE"
+  },
+  {
+    "id": "1903|Collonges|VS",
+    "name": "Collonges",
+    "zipCode": "1903",
+    "canton": "VS"
+  },
+  {
+    "id": "7742|Cologna|GR",
+    "name": "Cologna",
+    "zipCode": "7742",
+    "canton": "GR"
+  },
+  {
+    "id": "1223|Cologny|GE",
+    "name": "Cologny",
+    "zipCode": "1223",
+    "canton": "GE"
+  },
+  {
+    "id": "1114|Colombier|VD",
+    "name": "Colombier",
+    "zipCode": "1114",
+    "canton": "VD"
+  },
+  {
+    "id": "2013|Colombier|NE",
+    "name": "Colombier",
+    "zipCode": "2013",
+    "canton": "NE"
+  },
+  {
+    "id": "6949|Comano|TI",
+    "name": "Comano",
+    "zipCode": "6949",
+    "canton": "TI"
+  },
+  {
+    "id": "1535|Combremont-le-Grand|VD",
+    "name": "Combremont-le-Grand",
+    "zipCode": "1535",
+    "canton": "VD"
+  },
+  {
+    "id": "1536|Combremont-le-Petit|VD",
+    "name": "Combremont-le-Petit",
+    "zipCode": "1536",
+    "canton": "VD"
+  },
+  {
+    "id": "1937|Commeire|VS",
+    "name": "Commeire",
+    "zipCode": "1937",
+    "canton": "VS"
+  },
+  {
+    "id": "1291|Commugny|VD",
+    "name": "Commugny",
+    "zipCode": "1291",
+    "canton": "VD"
+  },
+  {
+    "id": "6663|Comologno|TI",
+    "name": "Comologno",
+    "zipCode": "6663",
+    "canton": "TI"
+  },
+  {
+    "id": "7562|Compatsch|GR",
+    "name": "Compatsch",
+    "zipCode": "7562",
+    "canton": "GR"
+  },
+  {
+    "id": "6716|Comprovasco|TI",
+    "name": "Comprovasco",
+    "zipCode": "6716",
+    "canton": "TI"
+  },
+  {
+    "id": "1231|Conches|GE",
+    "name": "Conches",
+    "zipCode": "1231",
+    "canton": "GE"
+  },
+  {
+    "id": "1426|Concise|VD",
+    "name": "Concise",
+    "zipCode": "1426",
+    "canton": "VD"
+  },
+  {
+    "id": "1996|Condémines|VS",
+    "name": "Condémines",
+    "zipCode": "1996",
+    "canton": "VS"
+  },
+  {
+    "id": "6954|Condra|TI",
+    "name": "Condra",
+    "zipCode": "6954",
+    "canton": "TI"
+  },
+  {
+    "id": "1232|Confignon|GE",
+    "name": "Confignon",
+    "zipCode": "1232",
+    "canton": "GE"
+  },
+  {
+    "id": "1587|Constantine|VD",
+    "name": "Constantine",
+    "zipCode": "1587",
+    "canton": "VD"
+  },
+  {
+    "id": "7241|Conters im Prättigau|GR",
+    "name": "Conters im Prättigau",
+    "zipCode": "7241",
+    "canton": "GR"
+  },
+  {
+    "id": "1964|Conthey|VS",
+    "name": "Conthey",
+    "zipCode": "1964",
+    "canton": "VS"
+  },
+  {
+    "id": "6594|Contone|TI",
+    "name": "Contone",
+    "zipCode": "6594",
+    "canton": "TI"
+  },
+  {
+    "id": "6646|Contra|TI",
+    "name": "Contra",
+    "zipCode": "6646",
+    "canton": "TI"
+  },
+  {
+    "id": "3974|Conzor|VS",
+    "name": "Conzor",
+    "zipCode": "3974",
+    "canton": "VS"
+  },
+  {
+    "id": "1296|Coppet|VD",
+    "name": "Coppet",
+    "zipCode": "1296",
+    "canton": "VD"
+  },
+  {
+    "id": "2826|Corban|JU",
+    "name": "Corban",
+    "zipCode": "2826",
+    "canton": "JU"
+  },
+  {
+    "id": "6663|Corbella|TI",
+    "name": "Corbella",
+    "zipCode": "6663",
+    "canton": "TI"
+  },
+  {
+    "id": "1856|Corbeyrier|VD",
+    "name": "Corbeyrier",
+    "zipCode": "1856",
+    "canton": "VD"
+  },
+  {
+    "id": "1647|Corbières|FR",
+    "name": "Corbières",
+    "zipCode": "1647",
+    "canton": "FR"
+  },
+  {
+    "id": "6655|Corcapolo|TI",
+    "name": "Corcapolo",
+    "zipCode": "6655",
+    "canton": "TI"
+  },
+  {
+    "id": "1422|Corcelettes|VD",
+    "name": "Corcelettes",
+    "zipCode": "1422",
+    "canton": "VD"
+  },
+  {
+    "id": "1616|Corcelles|FR",
+    "name": "Corcelles",
+    "zipCode": "1616",
+    "canton": "FR"
+  },
+  {
+    "id": "2035|Corcelles|NE",
+    "name": "Corcelles",
+    "zipCode": "2035",
+    "canton": "NE"
+  },
+  {
+    "id": "2747|Corcelles|BE",
+    "name": "Corcelles",
+    "zipCode": "2747",
+    "canton": "BE"
+  },
+  {
+    "id": "1082|Corcelles-le-Jorat|VD",
+    "name": "Corcelles-le-Jorat",
+    "zipCode": "1082",
+    "canton": "VD"
+  },
+  {
+    "id": "1426|Corcelles-près-Concise|VD",
+    "name": "Corcelles-près-Concise",
+    "zipCode": "1426",
+    "canton": "VD"
+  },
+  {
+    "id": "1562|Corcelles-près-Payerne|VD",
+    "name": "Corcelles-près-Payerne",
+    "zipCode": "1562",
+    "canton": "VD"
+  },
+  {
+    "id": "1374|Corcelles-sur-Chavornay|VD",
+    "name": "Corcelles-sur-Chavornay",
+    "zipCode": "1374",
+    "canton": "VD"
+  },
+  {
+    "id": "1792|Cordast|FR",
+    "name": "Cordast",
+    "zipCode": "1792",
+    "canton": "FR"
+  },
+  {
+    "id": "3972|Cordonaz|VS",
+    "name": "Cordonaz",
+    "zipCode": "3972",
+    "canton": "VS"
+  },
+  {
+    "id": "2606|Corgémont|BE",
+    "name": "Corgémont",
+    "zipCode": "2606",
+    "canton": "BE"
+  },
+  {
+    "id": "3960|Corin-de-la-Crête|VS",
+    "name": "Corin-de-la-Crête",
+    "zipCode": "3960",
+    "canton": "VS"
+  },
+  {
+    "id": "6631|Corippo|TI",
+    "name": "Corippo",
+    "zipCode": "6631",
+    "canton": "TI"
+  },
+  {
+    "id": "1754|Corjolens|FR",
+    "name": "Corjolens",
+    "zipCode": "1754",
+    "canton": "FR"
+  },
+  {
+    "id": "1782|Cormagens|FR",
+    "name": "Cormagens",
+    "zipCode": "1782",
+    "canton": "FR"
+  },
+  {
+    "id": "1752|Cormanon|FR",
+    "name": "Cormanon",
+    "zipCode": "1752",
+    "canton": "FR"
+  },
+  {
+    "id": "1721|Cormérod|FR",
+    "name": "Cormérod",
+    "zipCode": "1721",
+    "canton": "FR"
+  },
+  {
+    "id": "1720|Corminboeuf|FR",
+    "name": "Corminboeuf",
+    "zipCode": "1720",
+    "canton": "FR"
+  },
+  {
+    "id": "2036|Cormondrèche|NE",
+    "name": "Cormondrèche",
+    "zipCode": "2036",
+    "canton": "NE"
+  },
+  {
+    "id": "2612|Cormoret|BE",
+    "name": "Cormoret",
+    "zipCode": "2612",
+    "canton": "BE"
+  },
+  {
+    "id": "2087|Cornaux|NE",
+    "name": "Cornaux",
+    "zipCode": "2087",
+    "canton": "NE"
+  },
+  {
+    "id": "1072|Cornes de Cerf|VD",
+    "name": "Cornes de Cerf",
+    "zipCode": "1072",
+    "canton": "VD"
+  },
+  {
+    "id": "2952|Cornol|JU",
+    "name": "Cornol",
+    "zipCode": "2952",
+    "canton": "JU"
+  },
+  {
+    "id": "1727|Corpataux|FR",
+    "name": "Corpataux",
+    "zipCode": "1727",
+    "canton": "FR"
+  },
+  {
+    "id": "1410|Corrençon|VD",
+    "name": "Corrençon",
+    "zipCode": "1410",
+    "canton": "VD"
+  },
+  {
+    "id": "1410|Correvon|VD",
+    "name": "Correvon",
+    "zipCode": "1410",
+    "canton": "VD"
+  },
+  {
+    "id": "1772|Corsalettes|FR",
+    "name": "Corsalettes",
+    "zipCode": "1772",
+    "canton": "FR"
+  },
+  {
+    "id": "1802|Corseaux|VD",
+    "name": "Corseaux",
+    "zipCode": "1802",
+    "canton": "VD"
+  },
+  {
+    "id": "1747|Corserey|FR",
+    "name": "Corserey",
+    "zipCode": "1747",
+    "canton": "FR"
+  },
+  {
+    "id": "1246|Corsier|GE",
+    "name": "Corsier",
+    "zipCode": "1246",
+    "canton": "GE"
+  },
+  {
+    "id": "1804|Corsier-sur-Vevey|VD",
+    "name": "Corsier-sur-Vevey",
+    "zipCode": "1804",
+    "canton": "VD"
+  },
+  {
+    "id": "1252|Corsinge|GE",
+    "name": "Corsinge",
+    "zipCode": "1252",
+    "canton": "GE"
+  },
+  {
+    "id": "1095|Corsy|VD",
+    "name": "Corsy",
+    "zipCode": "1095",
+    "canton": "VD"
+  },
+  {
+    "id": "2016|Cortaillod|NE",
+    "name": "Cortaillod",
+    "zipCode": "2016",
+    "canton": "NE"
+  },
+  {
+    "id": "2607|Cortébert|BE",
+    "name": "Cortébert",
+    "zipCode": "2607",
+    "canton": "BE"
+  },
+  {
+    "id": "6873|Corteglia|TI",
+    "name": "Corteglia",
+    "zipCode": "6873",
+    "canton": "TI"
+  },
+  {
+    "id": "6958|Corticiasca|TI",
+    "name": "Corticiasca",
+    "zipCode": "6958",
+    "canton": "TI"
+  },
+  {
+    "id": "6924|Cortivallo|TI",
+    "name": "Cortivallo",
+    "zipCode": "6924",
+    "canton": "TI"
+  },
+  {
+    "id": "6722|Corzoneso|TI",
+    "name": "Corzoneso",
+    "zipCode": "6722",
+    "canton": "TI"
+  },
+  {
+    "id": "1305|Cossonay-Gare|VD",
+    "name": "Cossonay-Gare",
+    "zipCode": "1305",
+    "canton": "VD"
+  },
+  {
+    "id": "1304|Cossonay-Ville|VD",
+    "name": "Cossonay-Ville",
+    "zipCode": "1304",
+    "canton": "VD"
+  },
+  {
+    "id": "1116|Cottens|VD",
+    "name": "Cottens",
+    "zipCode": "1116",
+    "canton": "VD"
+  },
+  {
+    "id": "1741|Cottens|FR",
+    "name": "Cottens",
+    "zipCode": "1741",
+    "canton": "FR"
+  },
+  {
+    "id": "1585|Cotterd|VD",
+    "name": "Cotterd",
+    "zipCode": "1585",
+    "canton": "VD"
+  },
+  {
+    "id": "1934|Cotterg|VS",
+    "name": "Cotterg",
+    "zipCode": "1934",
+    "canton": "VS"
+  },
+  {
+    "id": "1529|Coumin|FR",
+    "name": "Coumin",
+    "zipCode": "1529",
+    "canton": "FR"
+  },
+  {
+    "id": "2823|Courcelon|JU",
+    "name": "Courcelon",
+    "zipCode": "2823",
+    "canton": "JU"
+  },
+  {
+    "id": "2825|Courchapoix|JU",
+    "name": "Courchapoix",
+    "zipCode": "2825",
+    "canton": "JU"
+  },
+  {
+    "id": "2922|Courchavon|JU",
+    "name": "Courchavon",
+    "zipCode": "2922",
+    "canton": "JU"
+  },
+  {
+    "id": "2853|Courfaivre|JU",
+    "name": "Courfaivre",
+    "zipCode": "2853",
+    "canton": "JU"
+  },
+  {
+    "id": "2950|Courgenay|JU",
+    "name": "Courgenay",
+    "zipCode": "2950",
+    "canton": "JU"
+  },
+  {
+    "id": "1796|Courgevaux|FR",
+    "name": "Courgevaux",
+    "zipCode": "1796",
+    "canton": "FR"
+  },
+  {
+    "id": "1795|Courlevon|FR",
+    "name": "Courlevon",
+    "zipCode": "1795",
+    "canton": "FR"
+  },
+  {
+    "id": "1721|Cournillens|FR",
+    "name": "Cournillens",
+    "zipCode": "1721",
+    "canton": "FR"
+  },
+  {
+    "id": "2830|Courrendlin|JU",
+    "name": "Courrendlin",
+    "zipCode": "2830",
+    "canton": "JU"
+  },
+  {
+    "id": "2822|Courroux|JU",
+    "name": "Courroux",
+    "zipCode": "2822",
+    "canton": "JU"
+  },
+  {
+    "id": "2738|Court|BE",
+    "name": "Court",
+    "zipCode": "2738",
+    "canton": "BE"
+  },
+  {
+    "id": "1791|Courtaman|FR",
+    "name": "Courtaman",
+    "zipCode": "1791",
+    "canton": "FR"
+  },
+  {
+    "id": "2905|Courtedoux|JU",
+    "name": "Courtedoux",
+    "zipCode": "2905",
+    "canton": "JU"
+  },
+  {
+    "id": "2608|Courtelary|BE",
+    "name": "Courtelary",
+    "zipCode": "2608",
+    "canton": "BE"
+  },
+  {
+    "id": "2923|Courtemaîche|JU",
+    "name": "Courtemaîche",
+    "zipCode": "2923",
+    "canton": "JU"
+  },
+  {
+    "id": "2950|Courtemautruy|JU",
+    "name": "Courtemautruy",
+    "zipCode": "2950",
+    "canton": "JU"
+  },
+  {
+    "id": "1784|Courtepin|FR",
+    "name": "Courtepin",
+    "zipCode": "1784",
+    "canton": "FR"
+  },
+  {
+    "id": "2852|Courtételle|JU",
+    "name": "Courtételle",
+    "zipCode": "2852",
+    "canton": "JU"
+  },
+  {
+    "id": "1721|Courtion|FR",
+    "name": "Courtion",
+    "zipCode": "1721",
+    "canton": "FR"
+  },
+  {
+    "id": "1774|Cousset|FR",
+    "name": "Cousset",
+    "zipCode": "1774",
+    "canton": "FR"
+  },
+  {
+    "id": "1795|Coussiberlé|FR",
+    "name": "Coussiberlé",
+    "zipCode": "1795",
+    "canton": "FR"
+  },
+  {
+    "id": "2108|Couvet|NE",
+    "name": "Couvet",
+    "zipCode": "2108",
+    "canton": "NE"
+  },
+  {
+    "id": "6951|Cozzo|TI",
+    "name": "Cozzo",
+    "zipCode": "6951",
+    "canton": "TI"
+  },
+  {
+    "id": "6611|Crana|TI",
+    "name": "Crana",
+    "zipCode": "6611",
+    "canton": "TI"
+  },
+  {
+    "id": "3963|Crans-Montana|VS",
+    "name": "Crans-Montana",
+    "zipCode": "3963",
+    "canton": "VS"
+  },
+  {
+    "id": "1299|Crans-près-Céligny|VD",
+    "name": "Crans-près-Céligny",
+    "zipCode": "1299",
+    "canton": "VD"
+  },
+  {
+    "id": "3963|Crans-sur-Sierre|VS",
+    "name": "Crans-sur-Sierre",
+    "zipCode": "3963",
+    "canton": "VS"
+  },
+  {
+    "id": "1263|Crassier|VD",
+    "name": "Crassier",
+    "zipCode": "1263",
+    "canton": "VD"
+  },
+  {
+    "id": "7505|Crasta|GR",
+    "name": "Crasta",
+    "zipCode": "7505",
+    "canton": "GR"
+  },
+  {
+    "id": "1845|Crebelley|VD",
+    "name": "Crebelley",
+    "zipCode": "1845",
+    "canton": "VD"
+  },
+  {
+    "id": "1071|Cremières|VD",
+    "name": "Cremières",
+    "zipCode": "1071",
+    "canton": "VD"
+  },
+  {
+    "id": "1526|Cremin|VD",
+    "name": "Cremin",
+    "zipCode": "1526",
+    "canton": "VD"
+  },
+  {
+    "id": "2746|Crémines|BE",
+    "name": "Crémines",
+    "zipCode": "2746",
+    "canton": "BE"
+  },
+  {
+    "id": "6705|Cresciano|TI",
+    "name": "Cresciano",
+    "zipCode": "6705",
+    "canton": "TI"
+  },
+  {
+    "id": "1785|Cressier|FR",
+    "name": "Cressier",
+    "zipCode": "1785",
+    "canton": "FR"
+  },
+  {
+    "id": "2088|Cressier|NE",
+    "name": "Cressier",
+    "zipCode": "2088",
+    "canton": "NE"
+  },
+  {
+    "id": "7447|Cresta|GR",
+    "name": "Cresta",
+    "zipCode": "7447",
+    "canton": "GR"
+  },
+  {
+    "id": "1653|Crésuz|FR",
+    "name": "Crésuz",
+    "zipCode": "1653",
+    "canton": "FR"
+  },
+  {
+    "id": "1992|Crêt-à-l'Oeil|VS",
+    "name": "Crêt-à-l'Oeil",
+    "zipCode": "1992",
+    "canton": "VS"
+  },
+  {
+    "id": "2108|Creux-du-Van|NE",
+    "name": "Creux-du-Van",
+    "zipCode": "2108",
+    "canton": "NE"
+  },
+  {
+    "id": "1941|Cries|VS",
+    "name": "Cries",
+    "zipCode": "1941",
+    "canton": "VS"
+  },
+  {
+    "id": "1023|Crissier|VD",
+    "name": "Crissier",
+    "zipCode": "1023",
+    "canton": "VD"
+  },
+  {
+    "id": "6980|Croglio|TI",
+    "name": "Croglio",
+    "zipCode": "6980",
+    "canton": "TI"
+  },
+  {
+    "id": "1406|Cronay|VD",
+    "name": "Cronay",
+    "zipCode": "1406",
+    "canton": "VD"
+  },
+  {
+    "id": "7446|Cröt|GR",
+    "name": "Cröt",
+    "zipCode": "7446",
+    "canton": "GR"
+  },
+  {
+    "id": "1322|Croy|VD",
+    "name": "Croy",
+    "zipCode": "1322",
+    "canton": "VD"
+  },
+  {
+    "id": "7554|Crusch|GR",
+    "name": "Crusch",
+    "zipCode": "7554",
+    "canton": "GR"
+  },
+  {
+    "id": "1148|Cuarnens|VD",
+    "name": "Cuarnens",
+    "zipCode": "1148",
+    "canton": "VD"
+  },
+  {
+    "id": "1404|Cuarny|VD",
+    "name": "Cuarny",
+    "zipCode": "1404",
+    "canton": "VD"
+  },
+  {
+    "id": "1588|Cudrefin|VD",
+    "name": "Cudrefin",
+    "zipCode": "1588",
+    "canton": "VD"
+  },
+  {
+    "id": "6516|Cugnasco|TI",
+    "name": "Cugnasco",
+    "zipCode": "6516",
+    "canton": "TI"
+  },
+  {
+    "id": "1053|Cugy|VD",
+    "name": "Cugy",
+    "zipCode": "1053",
+    "canton": "VD"
+  },
+  {
+    "id": "1482|Cugy|FR",
+    "name": "Cugy",
+    "zipCode": "1482",
+    "canton": "FR"
+  },
+  {
+    "id": "1096|Cully|VD",
+    "name": "Cully",
+    "zipCode": "1096",
+    "canton": "VD"
+  },
+  {
+    "id": "7142|Cumbel|GR",
+    "name": "Cumbel",
+    "zipCode": "7142",
+    "canton": "GR"
+  },
+  {
+    "id": "6722|Cumiasca|TI",
+    "name": "Cumiasca",
+    "zipCode": "6722",
+    "canton": "TI"
+  },
+  {
+    "id": "7176|Cumpadials|GR",
+    "name": "Cumpadials",
+    "zipCode": "7176",
+    "canton": "GR"
+  },
+  {
+    "id": "7452|Cunter|GR",
+    "name": "Cunter",
+    "zipCode": "7452",
+    "canton": "GR"
+  },
+  {
+    "id": "7184|Curaglia|GR",
+    "name": "Curaglia",
+    "zipCode": "7184",
+    "canton": "GR"
+  },
+  {
+    "id": "6963|Cureggia|TI",
+    "name": "Cureggia",
+    "zipCode": "6963",
+    "canton": "TI"
+  },
+  {
+    "id": "6944|Cureglia|TI",
+    "name": "Cureglia",
+    "zipCode": "6944",
+    "canton": "TI"
+  },
+  {
+    "id": "6986|Curio|TI",
+    "name": "Curio",
+    "zipCode": "6986",
+    "canton": "TI"
+  },
+  {
+    "id": "1521|Curtilles|VD",
+    "name": "Curtilles",
+    "zipCode": "1521",
+    "canton": "VD"
+  },
+  {
+    "id": "6959|Curtina|TI",
+    "name": "Curtina",
+    "zipCode": "6959",
+    "canton": "TI"
+  },
+  {
+    "id": "1782|Cutterwil|FR",
+    "name": "Cutterwil",
+    "zipCode": "1782",
+    "canton": "FR"
+  },
+  {
+    "id": "8932|Dachlissen|ZH",
+    "name": "Dachlissen",
+    "zipCode": "8932",
+    "canton": "ZH"
+  },
+  {
+    "id": "8447|Dachsen|ZH",
+    "name": "Dachsen",
+    "zipCode": "8447",
+    "canton": "ZH"
+  },
+  {
+    "id": "8165|Dachsleren|ZH",
+    "name": "Dachsleren",
+    "zipCode": "8165",
+    "canton": "ZH"
+  },
+  {
+    "id": "8471|Dägerlen|ZH",
+    "name": "Dägerlen",
+    "zipCode": "8471",
+    "canton": "ZH"
+  },
+  {
+    "id": "6252|Dagmersellen|LU",
+    "name": "Dagmersellen",
+    "zipCode": "6252",
+    "canton": "LU"
+  },
+  {
+    "id": "1306|Daillens|VD",
+    "name": "Daillens",
+    "zipCode": "1306",
+    "canton": "VD"
+  },
+  {
+    "id": "1976|Daillon|VS",
+    "name": "Daillon",
+    "zipCode": "1976",
+    "canton": "VS"
+  },
+  {
+    "id": "6126|Daiwil|LU",
+    "name": "Daiwil",
+    "zipCode": "6126",
+    "canton": "LU"
+  },
+  {
+    "id": "7240|Dalfazza|GR",
+    "name": "Dalfazza",
+    "zipCode": "7240",
+    "canton": "GR"
+  },
+  {
+    "id": "7424|Dalin|GR",
+    "name": "Dalin",
+    "zipCode": "7424",
+    "canton": "GR"
+  },
+  {
+    "id": "6383|Dallenwil|NW",
+    "name": "Dallenwil",
+    "zipCode": "6383",
+    "canton": "NW"
+  },
+  {
+    "id": "8108|Dällikon|ZH",
+    "name": "Dällikon",
+    "zipCode": "8108",
+    "canton": "ZH"
+  },
+  {
+    "id": "6774|Dalpe|TI",
+    "name": "Dalpe",
+    "zipCode": "6774",
+    "canton": "TI"
+  },
+  {
+    "id": "3268|Dampfwil|BE",
+    "name": "Dampfwil",
+    "zipCode": "3268",
+    "canton": "BE"
+  },
+  {
+    "id": "2933|Damphreux|JU",
+    "name": "Damphreux",
+    "zipCode": "2933",
+    "canton": "JU"
+  },
+  {
+    "id": "2914|Damvant|JU",
+    "name": "Damvant",
+    "zipCode": "2914",
+    "canton": "JU"
+  },
+  {
+    "id": "6717|Dangio|TI",
+    "name": "Dangio",
+    "zipCode": "6717",
+    "canton": "TI"
+  },
+  {
+    "id": "4658|Däniken|SO",
+    "name": "Däniken",
+    "zipCode": "4658",
+    "canton": "SO"
+  },
+  {
+    "id": "8114|Dänikon|ZH",
+    "name": "Dänikon",
+    "zipCode": "8114",
+    "canton": "ZH"
+  },
+  {
+    "id": "7163|Danis|GR",
+    "name": "Danis",
+    "zipCode": "7163",
+    "canton": "GR"
+  },
+  {
+    "id": "1283|Dardagny|GE",
+    "name": "Dardagny",
+    "zipCode": "1283",
+    "canton": "GE"
+  },
+  {
+    "id": "7164|Dardin|GR",
+    "name": "Dardin",
+    "zipCode": "7164",
+    "canton": "GR"
+  },
+  {
+    "id": "3707|Därligen|BE",
+    "name": "Därligen",
+    "zipCode": "3707",
+    "canton": "BE"
+  },
+  {
+    "id": "3973|Darnona|VS",
+    "name": "Darnona",
+    "zipCode": "3973",
+    "canton": "VS"
+  },
+  {
+    "id": "6500|Daro|TI",
+    "name": "Daro",
+    "zipCode": "6500",
+    "canton": "TI"
+  },
+  {
+    "id": "3763|Därstetten|BE",
+    "name": "Därstetten",
+    "zipCode": "3763",
+    "canton": "BE"
+  },
+  {
+    "id": "7166|Darvella|GR",
+    "name": "Darvella",
+    "zipCode": "7166",
+    "canton": "GR"
+  },
+  {
+    "id": "8421|Dättlikon|ZH",
+    "name": "Dättlikon",
+    "zipCode": "8421",
+    "canton": "ZH"
+  },
+  {
+    "id": "8400|Dättnau|ZH",
+    "name": "Dättnau",
+    "zipCode": "8400",
+    "canton": "ZH"
+  },
+  {
+    "id": "5405|Dättwil|AG",
+    "name": "Dättwil",
+    "zipCode": "5405",
+    "canton": "AG"
+  },
+  {
+    "id": "8452|Dätwil|ZH",
+    "name": "Dätwil",
+    "zipCode": "8452",
+    "canton": "ZH"
+  },
+  {
+    "id": "6964|Davesco|TI",
+    "name": "Davesco",
+    "zipCode": "6964",
+    "canton": "TI"
+  },
+  {
+    "id": "1891|Daviaz|VS",
+    "name": "Daviaz",
+    "zipCode": "1891",
+    "canton": "VS"
+  },
+  {
+    "id": "7260|Davos Dorf|GR",
+    "name": "Davos Dorf",
+    "zipCode": "7260",
+    "canton": "GR"
+  },
+  {
+    "id": "7270|Davos Platz|GR",
+    "name": "Davos Platz",
+    "zipCode": "7270",
+    "canton": "GR"
+  },
+  {
+    "id": "7145|Degen|GR",
+    "name": "Degen",
+    "zipCode": "7145",
+    "canton": "GR"
+  },
+  {
+    "id": "5426|Degermoos|AG",
+    "name": "Degermoos",
+    "zipCode": "5426",
+    "canton": "AG"
+  },
+  {
+    "id": "9113|Degersheim|SG",
+    "name": "Degersheim",
+    "zipCode": "9113",
+    "canton": "SG"
+  },
+  {
+    "id": "6777|Deggio|TI",
+    "name": "Deggio",
+    "zipCode": "6777",
+    "canton": "TI"
+  },
+  {
+    "id": "3993|Deisch|VS",
+    "name": "Deisch",
+    "zipCode": "3993",
+    "canton": "VS"
+  },
+  {
+    "id": "3053|Deisswil bei Münchenbuchsee|BE",
+    "name": "Deisswil bei Münchenbuchsee",
+    "zipCode": "3053",
+    "canton": "BE"
+  },
+  {
+    "id": "3066|Deisswil bei Stettlen|BE",
+    "name": "Deisswil bei Stettlen",
+    "zipCode": "3066",
+    "canton": "BE"
+  },
+  {
+    "id": "4543|Deitingen|SO",
+    "name": "Deitingen",
+    "zipCode": "4543",
+    "canton": "SO"
+  },
+  {
+    "id": "2800|Delémont|JU",
+    "name": "Delémont",
+    "zipCode": "2800",
+    "canton": "JU"
+  },
+  {
+    "id": "1567|Delley|FR",
+    "name": "Delley",
+    "zipCode": "1567",
+    "canton": "FR"
+  },
+  {
+    "id": "1415|Démoret|VD",
+    "name": "Démoret",
+    "zipCode": "1415",
+    "canton": "VD"
+  },
+  {
+    "id": "1135|Denens|VD",
+    "name": "Denens",
+    "zipCode": "1135",
+    "canton": "VD"
+  },
+  {
+    "id": "1410|Denezy|VD",
+    "name": "Denezy",
+    "zipCode": "1410",
+    "canton": "VD"
+  },
+  {
+    "id": "1026|Denges|VD",
+    "name": "Denges",
+    "zipCode": "1026",
+    "canton": "VD"
+  },
+  {
+    "id": "5026|Densbüren|AG",
+    "name": "Densbüren",
+    "zipCode": "5026",
+    "canton": "AG"
+  },
+  {
+    "id": "3076|Dentenberg|BE",
+    "name": "Dentenberg",
+    "zipCode": "3076",
+    "canton": "BE"
+  },
+  {
+    "id": "1976|Derborence|VS",
+    "name": "Derborence",
+    "zipCode": "1976",
+    "canton": "VS"
+  },
+  {
+    "id": "4552|Derendingen|SO",
+    "name": "Derendingen",
+    "zipCode": "4552",
+    "canton": "SO"
+  },
+  {
+    "id": "3036|Detligen|BE",
+    "name": "Detligen",
+    "zipCode": "3036",
+    "canton": "BE"
+  },
+  {
+    "id": "4537|Dettenbühl|BE",
+    "name": "Dettenbühl",
+    "zipCode": "4537",
+    "canton": "BE"
+  },
+  {
+    "id": "8484|Dettenried|ZH",
+    "name": "Dettenried",
+    "zipCode": "8484",
+    "canton": "ZH"
+  },
+  {
+    "id": "8505|Dettighofen|TG",
+    "name": "Dettighofen",
+    "zipCode": "8505",
+    "canton": "TG"
+  },
+  {
+    "id": "8574|Dettighofen|TG",
+    "name": "Dettighofen",
+    "zipCode": "8574",
+    "canton": "TG"
+  },
+  {
+    "id": "2802|Develier|JU",
+    "name": "Develier",
+    "zipCode": "2802",
+    "canton": "JU"
+  },
+  {
+    "id": "8354|Dickbuch|ZH",
+    "name": "Dickbuch",
+    "zipCode": "8354",
+    "canton": "ZH"
+  },
+  {
+    "id": "9115|Dicken bei Degersheim|SG",
+    "name": "Dicken bei Degersheim",
+    "zipCode": "9115",
+    "canton": "SG"
+  },
+  {
+    "id": "6074|Diechtersmatt|OW",
+    "name": "Diechtersmatt",
+    "zipCode": "6074",
+    "canton": "OW"
+  },
+  {
+    "id": "4457|Diegten|BL",
+    "name": "Diegten",
+    "zipCode": "4457",
+    "canton": "BL"
+  },
+  {
+    "id": "8157|Dielsdorf|ZH",
+    "name": "Dielsdorf",
+    "zipCode": "8157",
+    "canton": "ZH"
+  },
+  {
+    "id": "8733|Diemberg|SG",
+    "name": "Diemberg",
+    "zipCode": "8733",
+    "canton": "SG"
+  },
+  {
+    "id": "3053|Diemerswil|BE",
+    "name": "Diemerswil",
+    "zipCode": "3053",
+    "canton": "BE"
+  },
+  {
+    "id": "3754|Diemtigen|BE",
+    "name": "Diemtigen",
+    "zipCode": "3754",
+    "canton": "BE"
+  },
+  {
+    "id": "4442|Diepflingen|BL",
+    "name": "Diepflingen",
+    "zipCode": "4442",
+    "canton": "BL"
+  },
+  {
+    "id": "9444|Diepoldsau|SG",
+    "name": "Diepoldsau",
+    "zipCode": "9444",
+    "canton": "SG"
+  },
+  {
+    "id": "6036|Dierikon|LU",
+    "name": "Dierikon",
+    "zipCode": "6036",
+    "canton": "LU"
+  },
+  {
+    "id": "8777|Diesbach|GL",
+    "name": "Diesbach",
+    "zipCode": "8777",
+    "canton": "GL"
+  },
+  {
+    "id": "3264|Diessbach bei Büren|BE",
+    "name": "Diessbach bei Büren",
+    "zipCode": "3264",
+    "canton": "BE"
+  },
+  {
+    "id": "2517|Diesse|BE",
+    "name": "Diesse",
+    "zipCode": "2517",
+    "canton": "BE"
+  },
+  {
+    "id": "8253|Diessenhofen|TG",
+    "name": "Diessenhofen",
+    "zipCode": "8253",
+    "canton": "TG"
+  },
+  {
+    "id": "9526|Dietenwil|SG",
+    "name": "Dietenwil",
+    "zipCode": "9526",
+    "canton": "SG"
+  },
+  {
+    "id": "3256|Dieterswil|BE",
+    "name": "Dieterswil",
+    "zipCode": "3256",
+    "canton": "BE"
+  },
+  {
+    "id": "9615|Dietfurt|SG",
+    "name": "Dietfurt",
+    "zipCode": "9615",
+    "canton": "SG"
+  },
+  {
+    "id": "8953|Dietikon|ZH",
+    "name": "Dietikon",
+    "zipCode": "8953",
+    "canton": "ZH"
+  },
+  {
+    "id": "8524|Dietingen|TG",
+    "name": "Dietingen",
+    "zipCode": "8524",
+    "canton": "TG"
+  },
+  {
+    "id": "3184|Dietisberg|FR",
+    "name": "Dietisberg",
+    "zipCode": "3184",
+    "canton": "FR"
+  },
+  {
+    "id": "4448|Dietisberg|BL",
+    "name": "Dietisberg",
+    "zipCode": "4448",
+    "canton": "BL"
+  },
+  {
+    "id": "8305|Dietlikon|ZH",
+    "name": "Dietlikon",
+    "zipCode": "8305",
+    "canton": "ZH"
+  },
+  {
+    "id": "6000|Dietschiberg|LU",
+    "name": "Dietschiberg",
+    "zipCode": "6000",
+    "canton": "LU"
+  },
+  {
+    "id": "9533|Dietschwil|SG",
+    "name": "Dietschwil",
+    "zipCode": "9533",
+    "canton": "SG"
+  },
+  {
+    "id": "6042|Dietwil|AG",
+    "name": "Dietwil",
+    "zipCode": "6042",
+    "canton": "AG"
+  },
+  {
+    "id": "8637|Diezikon|ZH",
+    "name": "Diezikon",
+    "zipCode": "8637",
+    "canton": "ZH"
+  },
+  {
+    "id": "7014|Digg|GR",
+    "name": "Digg",
+    "zipCode": "7014",
+    "canton": "GR"
+  },
+  {
+    "id": "8500|Dingenhart|TG",
+    "name": "Dingenhart",
+    "zipCode": "8500",
+    "canton": "TG"
+  },
+  {
+    "id": "8474|Dinhard|ZH",
+    "name": "Dinhard",
+    "zipCode": "8474",
+    "canton": "ZH"
+  },
+  {
+    "id": "6967|Dino|TI",
+    "name": "Dino",
+    "zipCode": "6967",
+    "canton": "TI"
+  },
+  {
+    "id": "5606|Dintikon|AG",
+    "name": "Dintikon",
+    "zipCode": "5606",
+    "canton": "AG"
+  },
+  {
+    "id": "3963|Diogne|VS",
+    "name": "Diogne",
+    "zipCode": "3963",
+    "canton": "VS"
+  },
+  {
+    "id": "1965|Diolly|VS",
+    "name": "Diolly",
+    "zipCode": "1965",
+    "canton": "VS"
+  },
+  {
+    "id": "8573|Dippishausen|TG",
+    "name": "Dippishausen",
+    "zipCode": "8573",
+    "canton": "TG"
+  },
+  {
+    "id": "7260|Dischma|GR",
+    "name": "Dischma",
+    "zipCode": "7260",
+    "canton": "GR"
+  },
+  {
+    "id": "7180|Disentis/Mustér|GR",
+    "name": "Disentis/Mustér",
+    "zipCode": "7180",
+    "canton": "GR"
+  },
+  {
+    "id": "7180|Disla|GR",
+    "name": "Disla",
+    "zipCode": "7180",
+    "canton": "GR"
+  },
+  {
+    "id": "4243|Dittingen|BL",
+    "name": "Dittingen",
+    "zipCode": "4243",
+    "canton": "BL"
+  },
+  {
+    "id": "1304|Dizy|VD",
+    "name": "Dizy",
+    "zipCode": "1304",
+    "canton": "VD"
+  },
+  {
+    "id": "7013|Domat/Ems|GR",
+    "name": "Domat/Ems",
+    "zipCode": "7013",
+    "canton": "GR"
+  },
+  {
+    "id": "2056|Dombresson|NE",
+    "name": "Dombresson",
+    "zipCode": "2056",
+    "canton": "NE"
+  },
+  {
+    "id": "1564|Domdidier|FR",
+    "name": "Domdidier",
+    "zipCode": "1564",
+    "canton": "FR"
+  },
+  {
+    "id": "1041|Dommartin|VD",
+    "name": "Dommartin",
+    "zipCode": "1041",
+    "canton": "VD"
+  },
+  {
+    "id": "1682|Dompierre|VD",
+    "name": "Dompierre",
+    "zipCode": "1682",
+    "canton": "VD"
+  },
+  {
+    "id": "1563|Dompierre FR|FR",
+    "name": "Dompierre FR",
+    "zipCode": "1563",
+    "canton": "FR"
+  },
+  {
+    "id": "7433|Donat|GR",
+    "name": "Donat",
+    "zipCode": "7433",
+    "canton": "GR"
+  },
+  {
+    "id": "1580|Donatyre|VD",
+    "name": "Donatyre",
+    "zipCode": "1580",
+    "canton": "VD"
+  },
+  {
+    "id": "6715|Dongio|TI",
+    "name": "Dongio",
+    "zipCode": "6715",
+    "canton": "TI"
+  },
+  {
+    "id": "1407|Donneloye|VD",
+    "name": "Donneloye",
+    "zipCode": "1407",
+    "canton": "VD"
+  },
+  {
+    "id": "8583|Donzhausen|TG",
+    "name": "Donzhausen",
+    "zipCode": "8583",
+    "canton": "TG"
+  },
+  {
+    "id": "6112|Doppleschwand|LU",
+    "name": "Doppleschwand",
+    "zipCode": "6112",
+    "canton": "LU"
+  },
+  {
+    "id": "1905|Dorénaz|VS",
+    "name": "Dorénaz",
+    "zipCode": "1905",
+    "canton": "VS"
+  },
+  {
+    "id": "8458|Dorf|ZH",
+    "name": "Dorf",
+    "zipCode": "8458",
+    "canton": "ZH"
+  },
+  {
+    "id": "8942|Dörfli|ZH",
+    "name": "Dörfli",
+    "zipCode": "8942",
+    "canton": "ZH"
+  },
+  {
+    "id": "8239|Dörflingen|SH",
+    "name": "Dörflingen",
+    "zipCode": "8239",
+    "canton": "SH"
+  },
+  {
+    "id": "4143|Dornach|SO",
+    "name": "Dornach",
+    "zipCode": "4143",
+    "canton": "SO"
+  },
+  {
+    "id": "4147|Dornachbrugg|BL",
+    "name": "Dornachbrugg",
+    "zipCode": "4147",
+    "canton": "BL"
+  },
+  {
+    "id": "8777|Dornhaus|GL",
+    "name": "Dornhaus",
+    "zipCode": "8777",
+    "canton": "GL"
+  },
+  {
+    "id": "8566|Dotnacht|TG",
+    "name": "Dotnacht",
+    "zipCode": "8566",
+    "canton": "TG"
+  },
+  {
+    "id": "6718|Dottero|TI",
+    "name": "Dottero",
+    "zipCode": "6718",
+    "canton": "TI"
+  },
+  {
+    "id": "5605|Dottikon|AG",
+    "name": "Dottikon",
+    "zipCode": "5605",
+    "canton": "AG"
+  },
+  {
+    "id": "5312|Döttingen|AG",
+    "name": "Döttingen",
+    "zipCode": "5312",
+    "canton": "AG"
+  },
+  {
+    "id": "3293|Dotzigen|BE",
+    "name": "Dotzigen",
+    "zipCode": "3293",
+    "canton": "BE"
+  },
+  {
+    "id": "8582|Dozwil|TG",
+    "name": "Dozwil",
+    "zipCode": "8582",
+    "canton": "TG"
+  },
+  {
+    "id": "1945|Dranse|VS",
+    "name": "Dranse",
+    "zipCode": "1945",
+    "canton": "VS"
+  },
+  {
+    "id": "9612|Dreien|SG",
+    "name": "Dreien",
+    "zipCode": "9612",
+    "canton": "SG"
+  },
+  {
+    "id": "1680|Drognens|FR",
+    "name": "Drognens",
+    "zipCode": "1680",
+    "canton": "FR"
+  },
+  {
+    "id": "1965|Drône|VS",
+    "name": "Drône",
+    "zipCode": "1965",
+    "canton": "VS"
+  },
+  {
+    "id": "6809|Drossa|TI",
+    "name": "Drossa",
+    "zipCode": "6809",
+    "canton": "TI"
+  },
+  {
+    "id": "8600|Dübendorf|ZH",
+    "name": "Dübendorf",
+    "zipCode": "8600",
+    "canton": "ZH"
+  },
+  {
+    "id": "3186|Düdingen|FR",
+    "name": "Düdingen",
+    "zipCode": "3186",
+    "canton": "FR"
+  },
+  {
+    "id": "4202|Duggingen|BL",
+    "name": "Duggingen",
+    "zipCode": "4202",
+    "canton": "BL"
+  },
+  {
+    "id": "1912|Dugny|VS",
+    "name": "Dugny",
+    "zipCode": "1912",
+    "canton": "VS"
+  },
+  {
+    "id": "1266|Duillier|VD",
+    "name": "Duillier",
+    "zipCode": "1266",
+    "canton": "VD"
+  },
+  {
+    "id": "4657|Dulliken|SO",
+    "name": "Dulliken",
+    "zipCode": "4657",
+    "canton": "SO"
+  },
+  {
+    "id": "1195|Dully|VD",
+    "name": "Dully",
+    "zipCode": "1195",
+    "canton": "VD"
+  },
+  {
+    "id": "8585|Dünnershaus|TG",
+    "name": "Dünnershaus",
+    "zipCode": "8585",
+    "canton": "TG"
+  },
+  {
+    "id": "6702|Duno|TI",
+    "name": "Duno",
+    "zipCode": "6702",
+    "canton": "TI"
+  },
+  {
+    "id": "8635|Dürnten|ZH",
+    "name": "Dürnten",
+    "zipCode": "8635",
+    "canton": "ZH"
+  },
+  {
+    "id": "5724|Dürrenäsch|AG",
+    "name": "Dürrenäsch",
+    "zipCode": "5724",
+    "canton": "AG"
+  },
+  {
+    "id": "3600|Dürrenast|BE",
+    "name": "Dürrenast",
+    "zipCode": "3600",
+    "canton": "BE"
+  },
+  {
+    "id": "3465|Dürrenroth|BE",
+    "name": "Dürrenroth",
+    "zipCode": "3465",
+    "canton": "BE"
+  },
+  {
+    "id": "8335|Dürstelen|ZH",
+    "name": "Dürstelen",
+    "zipCode": "8335",
+    "canton": "ZH"
+  },
+  {
+    "id": "8374|Dussnang|TG",
+    "name": "Dussnang",
+    "zipCode": "8374",
+    "canton": "TG"
+  },
+  {
+    "id": "7112|Duvin|GR",
+    "name": "Duvin",
+    "zipCode": "7112",
+    "canton": "GR"
+  },
+  {
+    "id": "1236|Eaumorte|GE",
+    "name": "Eaumorte",
+    "zipCode": "1236",
+    "canton": "GE"
+  },
+  {
+    "id": "6245|Ebersecken|LU",
+    "name": "Ebersecken",
+    "zipCode": "6245",
+    "canton": "LU"
+  },
+  {
+    "id": "6276|Ebersol|LU",
+    "name": "Ebersol",
+    "zipCode": "6276",
+    "canton": "LU"
+  },
+  {
+    "id": "9122|Ebersol|SG",
+    "name": "Ebersol",
+    "zipCode": "9122",
+    "canton": "SG"
+  },
+  {
+    "id": "9220|Eberswil|TG",
+    "name": "Eberswil",
+    "zipCode": "9220",
+    "canton": "TG"
+  },
+  {
+    "id": "8925|Ebertswil|ZH",
+    "name": "Ebertswil",
+    "zipCode": "8925",
+    "canton": "ZH"
+  },
+  {
+    "id": "6030|Ebikon|LU",
+    "name": "Ebikon",
+    "zipCode": "6030",
+    "canton": "LU"
+  },
+  {
+    "id": "3855|Ebligen|BE",
+    "name": "Ebligen",
+    "zipCode": "3855",
+    "canton": "BE"
+  },
+  {
+    "id": "8123|Ebmatingen|ZH",
+    "name": "Ebmatingen",
+    "zipCode": "8123",
+    "canton": "ZH"
+  },
+  {
+    "id": "9642|Ebnat-Kappel|SG",
+    "name": "Ebnat-Kappel",
+    "zipCode": "9642",
+    "canton": "SG"
+  },
+  {
+    "id": "6163|Ebnet|LU",
+    "name": "Ebnet",
+    "zipCode": "6163",
+    "canton": "LU"
+  },
+  {
+    "id": "1040|Echallens|VD",
+    "name": "Echallens",
+    "zipCode": "1040",
+    "canton": "VD"
+  },
+  {
+    "id": "1026|Echandens|VD",
+    "name": "Echandens",
+    "zipCode": "1026",
+    "canton": "VD"
+  },
+  {
+    "id": "1646|Echarlens|FR",
+    "name": "Echarlens",
+    "zipCode": "1646",
+    "canton": "FR"
+  },
+  {
+    "id": "1112|Echichens|VD",
+    "name": "Echichens",
+    "zipCode": "1112",
+    "canton": "VD"
+  },
+  {
+    "id": "1376|Eclagnens|VD",
+    "name": "Eclagnens",
+    "zipCode": "1376",
+    "canton": "VD"
+  },
+  {
+    "id": "1312|Eclépens|VD",
+    "name": "Eclépens",
+    "zipCode": "1312",
+    "canton": "VD"
+  },
+  {
+    "id": "1908|Ecône|VS",
+    "name": "Ecône",
+    "zipCode": "1908",
+    "canton": "VS"
+  },
+  {
+    "id": "1612|Ecoteaux|VD",
+    "name": "Ecoteaux",
+    "zipCode": "1612",
+    "canton": "VD"
+  },
+  {
+    "id": "1024|Ecublens|VD",
+    "name": "Ecublens",
+    "zipCode": "1024",
+    "canton": "VD"
+  },
+  {
+    "id": "1673|Ecublens|FR",
+    "name": "Ecublens",
+    "zipCode": "1673",
+    "canton": "FR"
+  },
+  {
+    "id": "1730|Ecuvillens|FR",
+    "name": "Ecuvillens",
+    "zipCode": "1730",
+    "canton": "FR"
+  },
+  {
+    "id": "2813|Ederswiler|JU",
+    "name": "Ederswiler",
+    "zipCode": "2813",
+    "canton": "JU"
+  },
+  {
+    "id": "6073|Edisried|OW",
+    "name": "Edisried",
+    "zipCode": "6073",
+    "canton": "OW"
+  },
+  {
+    "id": "6313|Edlibach|ZG",
+    "name": "Edlibach",
+    "zipCode": "6313",
+    "canton": "ZG"
+  },
+  {
+    "id": "5078|Effingen|AG",
+    "name": "Effingen",
+    "zipCode": "5078",
+    "canton": "AG"
+  },
+  {
+    "id": "8307|Effretikon|ZH",
+    "name": "Effretikon",
+    "zipCode": "8307",
+    "canton": "ZH"
+  },
+  {
+    "id": "5225|Egenwil|AG",
+    "name": "Egenwil",
+    "zipCode": "5225",
+    "canton": "AG"
+  },
+  {
+    "id": "4622|Egerkingen|SO",
+    "name": "Egerkingen",
+    "zipCode": "4622",
+    "canton": "SO"
+  },
+  {
+    "id": "8847|Egg|SZ",
+    "name": "Egg",
+    "zipCode": "8847",
+    "canton": "SZ"
+  },
+  {
+    "id": "9231|Egg bei Flawil|SG",
+    "name": "Egg bei Flawil",
+    "zipCode": "9231",
+    "canton": "SG"
+  },
+  {
+    "id": "8132|Egg bei Zürich|ZH",
+    "name": "Egg bei Zürich",
+    "zipCode": "8132",
+    "canton": "ZH"
+  },
+  {
+    "id": "3991|Egga|VS",
+    "name": "Egga",
+    "zipCode": "3991",
+    "canton": "VS"
+  },
+  {
+    "id": "7134|Egga|GR",
+    "name": "Egga",
+    "zipCode": "7134",
+    "canton": "GR"
+  },
+  {
+    "id": "5445|Eggenwil|AG",
+    "name": "Eggenwil",
+    "zipCode": "5445",
+    "canton": "AG"
+  },
+  {
+    "id": "3939|Eggerberg|VS",
+    "name": "Eggerberg",
+    "zipCode": "3939",
+    "canton": "VS"
+  },
+  {
+    "id": "9034|Eggersriet|SG",
+    "name": "Eggersriet",
+    "zipCode": "9034",
+    "canton": "SG"
+  },
+  {
+    "id": "9050|Eggerstanden|AI",
+    "name": "Eggerstanden",
+    "zipCode": "9050",
+    "canton": "AI"
+  },
+  {
+    "id": "8585|Eggethof|TG",
+    "name": "Eggethof",
+    "zipCode": "8585",
+    "canton": "TG"
+  },
+  {
+    "id": "8523|Egghof|ZH",
+    "name": "Egghof",
+    "zipCode": "8523",
+    "canton": "ZH"
+  },
+  {
+    "id": "3537|Eggiwil|BE",
+    "name": "Eggiwil",
+    "zipCode": "3537",
+    "canton": "BE"
+  },
+  {
+    "id": "8193|Eglisau|ZH",
+    "name": "Eglisau",
+    "zipCode": "8193",
+    "canton": "ZH"
+  },
+  {
+    "id": "5704|Egliswil|AG",
+    "name": "Egliswil",
+    "zipCode": "5704",
+    "canton": "AG"
+  },
+  {
+    "id": "9322|Egnach|TG",
+    "name": "Egnach",
+    "zipCode": "9322",
+    "canton": "TG"
+  },
+  {
+    "id": "6243|Egolzwil|LU",
+    "name": "Egolzwil",
+    "zipCode": "6243",
+    "canton": "LU"
+  },
+  {
+    "id": "7104|Egschi|GR",
+    "name": "Egschi",
+    "zipCode": "7104",
+    "canton": "GR"
+  },
+  {
+    "id": "8489|Ehrikon|ZH",
+    "name": "Ehrikon",
+    "zipCode": "8489",
+    "canton": "ZH"
+  },
+  {
+    "id": "4658|Eich|SO",
+    "name": "Eich",
+    "zipCode": "4658",
+    "canton": "SO"
+  },
+  {
+    "id": "6205|Eich|LU",
+    "name": "Eich",
+    "zipCode": "6205",
+    "canton": "LU"
+  },
+  {
+    "id": "9453|Eichberg|SG",
+    "name": "Eichberg",
+    "zipCode": "9453",
+    "canton": "SG"
+  },
+  {
+    "id": "3254|Eichholz bei Messen|BE",
+    "name": "Eichholz bei Messen",
+    "zipCode": "3254",
+    "canton": "BE"
+  },
+  {
+    "id": "3254|Eichholz bei Messen|SO",
+    "name": "Eichholz bei Messen",
+    "zipCode": "3254",
+    "canton": "SO"
+  },
+  {
+    "id": "8400|Eidberg|ZH",
+    "name": "Eidberg",
+    "zipCode": "8400",
+    "canton": "ZH"
+  },
+  {
+    "id": "5314|Eien|AG",
+    "name": "Eien",
+    "zipCode": "5314",
+    "canton": "AG"
+  },
+  {
+    "id": "6013|Eigenthal|LU",
+    "name": "Eigenthal",
+    "zipCode": "6013",
+    "canton": "LU"
+  },
+  {
+    "id": "3823|Eigergletscher|BE",
+    "name": "Eigergletscher",
+    "zipCode": "3823",
+    "canton": "BE"
+  },
+  {
+    "id": "5074|Eiken|AG",
+    "name": "Eiken",
+    "zipCode": "5074",
+    "canton": "AG"
+  },
+  {
+    "id": "3646|Einigen|BE",
+    "name": "Einigen",
+    "zipCode": "3646",
+    "canton": "BE"
+  },
+  {
+    "id": "8840|Einsiedeln|SZ",
+    "name": "Einsiedeln",
+    "zipCode": "8840",
+    "canton": "SZ"
+  },
+  {
+    "id": "3943|Eischoll|VS",
+    "name": "Eischoll",
+    "zipCode": "3943",
+    "canton": "VS"
+  },
+  {
+    "id": "1969|Eison|VS",
+    "name": "Eison",
+    "zipCode": "1969",
+    "canton": "VS"
+  },
+  {
+    "id": "3922|Eisten|VS",
+    "name": "Eisten",
+    "zipCode": "3922",
+    "canton": "VS"
+  },
+  {
+    "id": "3919|Eisten (Lötschen)|VS",
+    "name": "Eisten (Lötschen)",
+    "zipCode": "3919",
+    "canton": "VS"
+  },
+  {
+    "id": "5077|Elfingen|AG",
+    "name": "Elfingen",
+    "zipCode": "5077",
+    "canton": "AG"
+  },
+  {
+    "id": "8353|Elgg|ZH",
+    "name": "Elgg",
+    "zipCode": "8353",
+    "canton": "ZH"
+  },
+  {
+    "id": "8566|Ellighausen|TG",
+    "name": "Ellighausen",
+    "zipCode": "8566",
+    "canton": "TG"
+  },
+  {
+    "id": "8464|Ellikon am Rhein|ZH",
+    "name": "Ellikon am Rhein",
+    "zipCode": "8464",
+    "canton": "ZH"
+  },
+  {
+    "id": "8548|Ellikon an der Thur|ZH",
+    "name": "Ellikon an der Thur",
+    "zipCode": "8548",
+    "canton": "ZH"
+  },
+  {
+    "id": "8767|Elm|GL",
+    "name": "Elm",
+    "zipCode": "8767",
+    "canton": "GL"
+  },
+  {
+    "id": "8352|Elsau|ZH",
+    "name": "Elsau",
+    "zipCode": "8352",
+    "canton": "ZH"
+  },
+  {
+    "id": "3184|Elswil|FR",
+    "name": "Elswil",
+    "zipCode": "3184",
+    "canton": "FR"
+  },
+  {
+    "id": "3926|Embd|VS",
+    "name": "Embd",
+    "zipCode": "3926",
+    "canton": "VS"
+  },
+  {
+    "id": "8424|Embrach|ZH",
+    "name": "Embrach",
+    "zipCode": "8424",
+    "canton": "ZH"
+  },
+  {
+    "id": "8424|Embrach-Embraport|ZH",
+    "name": "Embrach-Embraport",
+    "zipCode": "8424",
+    "canton": "ZH"
+  },
+  {
+    "id": "3711|Emdthal|BE",
+    "name": "Emdthal",
+    "zipCode": "3711",
+    "canton": "BE"
+  },
+  {
+    "id": "6032|Emmen|LU",
+    "name": "Emmen",
+    "zipCode": "6032",
+    "canton": "LU"
+  },
+  {
+    "id": "6020|Emmenbrücke|LU",
+    "name": "Emmenbrücke",
+    "zipCode": "6020",
+    "canton": "LU"
+  },
+  {
+    "id": "3543|Emmenmatt|BE",
+    "name": "Emmenmatt",
+    "zipCode": "3543",
+    "canton": "BE"
+  },
+  {
+    "id": "6020|Emmenweid|LU",
+    "name": "Emmenweid",
+    "zipCode": "6020",
+    "canton": "LU"
+  },
+  {
+    "id": "6376|Emmetten|NW",
+    "name": "Emmetten",
+    "zipCode": "6376",
+    "canton": "NW"
+  },
+  {
+    "id": "8280|Emmishofen|TG",
+    "name": "Emmishofen",
+    "zipCode": "8280",
+    "canton": "TG"
+  },
+  {
+    "id": "8181|Endhöri|ZH",
+    "name": "Endhöri",
+    "zipCode": "8181",
+    "canton": "ZH"
+  },
+  {
+    "id": "5304|Endingen|AG",
+    "name": "Endingen",
+    "zipCode": "5304",
+    "canton": "AG"
+  },
+  {
+    "id": "3655|Endorf|BE",
+    "name": "Endorf",
+    "zipCode": "3655",
+    "canton": "BE"
+  },
+  {
+    "id": "8000|Enge|ZH",
+    "name": "Enge",
+    "zipCode": "8000",
+    "canton": "ZH"
+  },
+  {
+    "id": "6390|Engelberg|OW",
+    "name": "Engelberg",
+    "zipCode": "6390",
+    "canton": "OW"
+  },
+  {
+    "id": "5746|Engelberg bei Walterswil|SO",
+    "name": "Engelberg bei Walterswil",
+    "zipCode": "5746",
+    "canton": "SO"
+  },
+  {
+    "id": "9032|Engelburg|SG",
+    "name": "Engelburg",
+    "zipCode": "9032",
+    "canton": "SG"
+  },
+  {
+    "id": "8566|Engelswilen|TG",
+    "name": "Engelswilen",
+    "zipCode": "8566",
+    "canton": "TG"
+  },
+  {
+    "id": "2073|Enges|NE",
+    "name": "Enges",
+    "zipCode": "2073",
+    "canton": "NE"
+  },
+  {
+    "id": "9050|Enggenhütten|AI",
+    "name": "Enggenhütten",
+    "zipCode": "9050",
+    "canton": "AI"
+  },
+  {
+    "id": "3077|Enggistein|BE",
+    "name": "Enggistein",
+    "zipCode": "3077",
+    "canton": "BE"
+  },
+  {
+    "id": "4208|Engi|SO",
+    "name": "Engi",
+    "zipCode": "4208",
+    "canton": "SO"
+  },
+  {
+    "id": "8765|Engi|GL",
+    "name": "Engi",
+    "zipCode": "8765",
+    "canton": "GL"
+  },
+  {
+    "id": "8586|Engishofen|TG",
+    "name": "Engishofen",
+    "zipCode": "8586",
+    "canton": "TG"
+  },
+  {
+    "id": "3086|Englisberg|BE",
+    "name": "Englisberg",
+    "zipCode": "3086",
+    "canton": "BE"
+  },
+  {
+    "id": "2063|Engollon|NE",
+    "name": "Engollon",
+    "zipCode": "2063",
+    "canton": "NE"
+  },
+  {
+    "id": "8556|Engwang|TG",
+    "name": "Engwang",
+    "zipCode": "8556",
+    "canton": "TG"
+  },
+  {
+    "id": "8564|Engwilen|TG",
+    "name": "Engwilen",
+    "zipCode": "8564",
+    "canton": "TG"
+  },
+  {
+    "id": "8755|Ennenda|GL",
+    "name": "Ennenda",
+    "zipCode": "8755",
+    "canton": "GL"
+  },
+  {
+    "id": "8586|Ennetaach|TG",
+    "name": "Ennetaach",
+    "zipCode": "8586",
+    "canton": "TG"
+  },
+  {
+    "id": "5408|Ennetbaden|AG",
+    "name": "Ennetbaden",
+    "zipCode": "5408",
+    "canton": "AG"
+  },
+  {
+    "id": "9651|Ennetbühl|SG",
+    "name": "Ennetbühl",
+    "zipCode": "9651",
+    "canton": "SG"
+  },
+  {
+    "id": "8755|Ennetbühls|GL",
+    "name": "Ennetbühls",
+    "zipCode": "8755",
+    "canton": "GL"
+  },
+  {
+    "id": "6373|Ennetbürgen|NW",
+    "name": "Ennetbürgen",
+    "zipCode": "6373",
+    "canton": "NW"
+  },
+  {
+    "id": "8756|Ennetlinth|GL",
+    "name": "Ennetlinth",
+    "zipCode": "8756",
+    "canton": "GL"
+  },
+  {
+    "id": "6372|Ennetmoos|NW",
+    "name": "Ennetmoos",
+    "zipCode": "6372",
+    "canton": "NW"
+  },
+  {
+    "id": "5300|Ennetturgi|AG",
+    "name": "Ennetturgi",
+    "zipCode": "5300",
+    "canton": "AG"
+  },
+  {
+    "id": "1667|Enney|FR",
+    "name": "Enney",
+    "zipCode": "1667",
+    "canton": "FR"
+  },
+  {
+    "id": "6162|Entlebuch|LU",
+    "name": "Entlebuch",
+    "zipCode": "6162",
+    "canton": "LU"
+  },
+  {
+    "id": "2400|Entre-deux-Monts|NE",
+    "name": "Entre-deux-Monts",
+    "zipCode": "2400",
+    "canton": "NE"
+  },
+  {
+    "id": "2829|Envelier|JU",
+    "name": "Envelier",
+    "zipCode": "2829",
+    "canton": "JU"
+  },
+  {
+    "id": "1323|Envy|VD",
+    "name": "Envy",
+    "zipCode": "1323",
+    "canton": "VD"
+  },
+  {
+    "id": "2074|Epagnier|NE",
+    "name": "Epagnier",
+    "zipCode": "2074",
+    "canton": "NE"
+  },
+  {
+    "id": "1663|Epagny|FR",
+    "name": "Epagny",
+    "zipCode": "1663",
+    "canton": "FR"
+  },
+  {
+    "id": "1066|Epalinges|VD",
+    "name": "Epalinges",
+    "zipCode": "1066",
+    "canton": "VD"
+  },
+  {
+    "id": "1417|Epautheyres|VD",
+    "name": "Epautheyres",
+    "zipCode": "1417",
+    "canton": "VD"
+  },
+  {
+    "id": "2885|Epauvillers|JU",
+    "name": "Epauvillers",
+    "zipCode": "2885",
+    "canton": "JU"
+  },
+  {
+    "id": "1434|Ependes|VD",
+    "name": "Ependes",
+    "zipCode": "1434",
+    "canton": "VD"
+  },
+  {
+    "id": "1731|Ependes|FR",
+    "name": "Ependes",
+    "zipCode": "1731",
+    "canton": "FR"
+  },
+  {
+    "id": "1098|Epesses|VD",
+    "name": "Epesses",
+    "zipCode": "1098",
+    "canton": "VD"
+  },
+  {
+    "id": "1890|Epinassey|VS",
+    "name": "Epinassey",
+    "zipCode": "1890",
+    "canton": "VS"
+  },
+  {
+    "id": "2886|Epiquerez|JU",
+    "name": "Epiquerez",
+    "zipCode": "2886",
+    "canton": "JU"
+  },
+  {
+    "id": "5012|Eppenberg|SO",
+    "name": "Eppenberg",
+    "zipCode": "5012",
+    "canton": "SO"
+  },
+  {
+    "id": "8586|Eppishusen|TG",
+    "name": "Eppishusen",
+    "zipCode": "8586",
+    "canton": "TG"
+  },
+  {
+    "id": "3272|Epsach|BE",
+    "name": "Epsach",
+    "zipCode": "3272",
+    "canton": "BE"
+  },
+  {
+    "id": "4458|Eptingen|BL",
+    "name": "Eptingen",
+    "zipCode": "4458",
+    "canton": "BL"
+  },
+  {
+    "id": "1976|Erde|VS",
+    "name": "Erde",
+    "zipCode": "1976",
+    "canton": "VS"
+  },
+  {
+    "id": "3979|Erdesson|VS",
+    "name": "Erdesson",
+    "zipCode": "3979",
+    "canton": "VS"
+  },
+  {
+    "id": "9315|Erdhusen|TG",
+    "name": "Erdhusen",
+    "zipCode": "9315",
+    "canton": "TG"
+  },
+  {
+    "id": "3947|Ergisch|VS",
+    "name": "Ergisch",
+    "zipCode": "3947",
+    "canton": "VS"
+  },
+  {
+    "id": "4952|Eriswil|BE",
+    "name": "Eriswil",
+    "zipCode": "4952",
+    "canton": "BE"
+  },
+  {
+    "id": "3619|Eriz|BE",
+    "name": "Eriz",
+    "zipCode": "3619",
+    "canton": "BE"
+  },
+  {
+    "id": "3235|Erlach|BE",
+    "name": "Erlach",
+    "zipCode": "3235",
+    "canton": "BE"
+  },
+  {
+    "id": "8586|Erlen|TG",
+    "name": "Erlen",
+    "zipCode": "8586",
+    "canton": "TG"
+  },
+  {
+    "id": "8703|Erlenbach|ZH",
+    "name": "Erlenbach",
+    "zipCode": "8703",
+    "canton": "ZH"
+  },
+  {
+    "id": "3762|Erlenbach im Simmental|BE",
+    "name": "Erlenbach im Simmental",
+    "zipCode": "3762",
+    "canton": "BE"
+  },
+  {
+    "id": "5018|Erlinsbach|AG",
+    "name": "Erlinsbach",
+    "zipCode": "5018",
+    "canton": "AG"
+  },
+  {
+    "id": "5015|Erlinsbach (SO)|SO",
+    "name": "Erlinsbach (SO)",
+    "zipCode": "5015",
+    "canton": "SO"
+  },
+  {
+    "id": "8340|Erlosen|ZH",
+    "name": "Erlosen",
+    "zipCode": "8340",
+    "canton": "ZH"
+  },
+  {
+    "id": "8272|Ermatingen|TG",
+    "name": "Ermatingen",
+    "zipCode": "8272",
+    "canton": "TG"
+  },
+  {
+    "id": "6294|Ermensee|LU",
+    "name": "Ermensee",
+    "zipCode": "6294",
+    "canton": "LU"
+  },
+  {
+    "id": "8734|Ermenswil|SG",
+    "name": "Ermenswil",
+    "zipCode": "8734",
+    "canton": "SG"
+  },
+  {
+    "id": "3995|Ernen|VS",
+    "name": "Ernen",
+    "zipCode": "3995",
+    "canton": "VS"
+  },
+  {
+    "id": "8725|Ernetschwil|SG",
+    "name": "Ernetschwil",
+    "zipCode": "8725",
+    "canton": "SG"
+  },
+  {
+    "id": "3957|Erschmatt|VS",
+    "name": "Erschmatt",
+    "zipCode": "3957",
+    "canton": "VS"
+  },
+  {
+    "id": "4228|Erschwil|SO",
+    "name": "Erschwil",
+    "zipCode": "4228",
+    "canton": "SO"
+  },
+  {
+    "id": "3423|Ersigen|BE",
+    "name": "Ersigen",
+    "zipCode": "3423",
+    "canton": "BE"
+  },
+  {
+    "id": "6418|Erste Altmatt|SZ",
+    "name": "Erste Altmatt",
+    "zipCode": "6418",
+    "canton": "SZ"
+  },
+  {
+    "id": "6472|Erstfeld|UR",
+    "name": "Erstfeld",
+    "zipCode": "6472",
+    "canton": "UR"
+  },
+  {
+    "id": "8500|Erzenholz|TG",
+    "name": "Erzenholz",
+    "zipCode": "8500",
+    "canton": "TG"
+  },
+  {
+    "id": "6274|Eschenbach|LU",
+    "name": "Eschenbach",
+    "zipCode": "6274",
+    "canton": "LU"
+  },
+  {
+    "id": "8733|Eschenbach|SG",
+    "name": "Eschenbach",
+    "zipCode": "8733",
+    "canton": "SG"
+  },
+  {
+    "id": "8180|Eschenmosen|ZH",
+    "name": "Eschenmosen",
+    "zipCode": "8180",
+    "canton": "ZH"
+  },
+  {
+    "id": "8264|Eschenz|TG",
+    "name": "Eschenz",
+    "zipCode": "8264",
+    "canton": "TG"
+  },
+  {
+    "id": "2743|Eschert|BE",
+    "name": "Eschert",
+    "zipCode": "2743",
+    "canton": "BE"
+  },
+  {
+    "id": "3766|Eschi|BE",
+    "name": "Eschi",
+    "zipCode": "3766",
+    "canton": "BE"
+  },
+  {
+    "id": "1673|Eschiens|FR",
+    "name": "Eschiens",
+    "zipCode": "1673",
+    "canton": "FR"
+  },
+  {
+    "id": "8553|Eschikofen|TG",
+    "name": "Eschikofen",
+    "zipCode": "8553",
+    "canton": "TG"
+  },
+  {
+    "id": "8315|Eschikon|ZH",
+    "name": "Eschikon",
+    "zipCode": "8315",
+    "canton": "ZH"
+  },
+  {
+    "id": "8360|Eschlikon|TG",
+    "name": "Eschlikon",
+    "zipCode": "8360",
+    "canton": "TG"
+  },
+  {
+    "id": "8474|Eschlikon|ZH",
+    "name": "Eschlikon",
+    "zipCode": "8474",
+    "canton": "ZH"
+  },
+  {
+    "id": "6182|Escholzmatt|LU",
+    "name": "Escholzmatt",
+    "zipCode": "6182",
+    "canton": "LU"
+  },
+  {
+    "id": "1670|Esmonts|FR",
+    "name": "Esmonts",
+    "zipCode": "1670",
+    "canton": "FR"
+  },
+  {
+    "id": "1724|Essert|FR",
+    "name": "Essert",
+    "zipCode": "1724",
+    "canton": "FR"
+  },
+  {
+    "id": "1435|Essert-Pittet|VD",
+    "name": "Essert-Pittet",
+    "zipCode": "1435",
+    "canton": "VD"
+  },
+  {
+    "id": "1443|Essert-sous-Champvent|VD",
+    "name": "Essert-sous-Champvent",
+    "zipCode": "1443",
+    "canton": "VD"
+  },
+  {
+    "id": "1078|Essertes|VD",
+    "name": "Essertes",
+    "zipCode": "1078",
+    "canton": "VD"
+  },
+  {
+    "id": "2886|Essertfallon|JU",
+    "name": "Essertfallon",
+    "zipCode": "2886",
+    "canton": "JU"
+  },
+  {
+    "id": "1186|Essertines-sur-Rolle|VD",
+    "name": "Essertines-sur-Rolle",
+    "zipCode": "1186",
+    "canton": "VD"
+  },
+  {
+    "id": "1417|Essertines-sur-Yverdon|VD",
+    "name": "Essertines-sur-Yverdon",
+    "zipCode": "1417",
+    "canton": "VD"
+  },
+  {
+    "id": "8133|Esslingen|ZH",
+    "name": "Esslingen",
+    "zipCode": "8133",
+    "canton": "ZH"
+  },
+  {
+    "id": "1665|Estavannens|FR",
+    "name": "Estavannens",
+    "zipCode": "1665",
+    "canton": "FR"
+  },
+  {
+    "id": "1695|Estavayer-le-Gibloux|FR",
+    "name": "Estavayer-le-Gibloux",
+    "zipCode": "1695",
+    "canton": "FR"
+  },
+  {
+    "id": "1470|Estavayer-le-Lac|FR",
+    "name": "Estavayer-le-Lac",
+    "zipCode": "1470",
+    "canton": "FR"
+  },
+  {
+    "id": "1687|Estévenens|FR",
+    "name": "Estévenens",
+    "zipCode": "1687",
+    "canton": "FR"
+  },
+  {
+    "id": "1037|Etagnières|VD",
+    "name": "Etagnières",
+    "zipCode": "1037",
+    "canton": "VD"
+  },
+  {
+    "id": "1941|Etiez|VS",
+    "name": "Etiez",
+    "zipCode": "1941",
+    "canton": "VS"
+  },
+  {
+    "id": "1163|Etoy|VD",
+    "name": "Etoy",
+    "zipCode": "1163",
+    "canton": "VD"
+  },
+  {
+    "id": "1551|Etrabloz|VD",
+    "name": "Etrabloz",
+    "zipCode": "1551",
+    "canton": "VD"
+  },
+  {
+    "id": "8356|Ettenhausen|TG",
+    "name": "Ettenhausen",
+    "zipCode": "8356",
+    "canton": "TG"
+  },
+  {
+    "id": "8620|Ettenhausen|ZH",
+    "name": "Ettenhausen",
+    "zipCode": "8620",
+    "canton": "ZH"
+  },
+  {
+    "id": "8314|Ettenhausen bei Kyburg|ZH",
+    "name": "Ettenhausen bei Kyburg",
+    "zipCode": "8314",
+    "canton": "ZH"
+  },
+  {
+    "id": "4107|Ettingen|BL",
+    "name": "Ettingen",
+    "zipCode": "4107",
+    "canton": "BL"
+  },
+  {
+    "id": "6218|Ettiswil|LU",
+    "name": "Ettiswil",
+    "zipCode": "6218",
+    "canton": "LU"
+  },
+  {
+    "id": "8847|Etzel|SZ",
+    "name": "Etzel",
+    "zipCode": "8847",
+    "canton": "SZ"
+  },
+  {
+    "id": "8835|Etzel Kulm|SZ",
+    "name": "Etzel Kulm",
+    "zipCode": "8835",
+    "canton": "SZ"
+  },
+  {
+    "id": "3306|Etzelkofen|BE",
+    "name": "Etzelkofen",
+    "zipCode": "3306",
+    "canton": "BE"
+  },
+  {
+    "id": "6231|Etzelwil|LU",
+    "name": "Etzelwil",
+    "zipCode": "6231",
+    "canton": "LU"
+  },
+  {
+    "id": "5275|Etzgen|AG",
+    "name": "Etzgen",
+    "zipCode": "5275",
+    "canton": "AG"
+  },
+  {
+    "id": "4554|Etziken|SO",
+    "name": "Etziken",
+    "zipCode": "4554",
+    "canton": "SO"
+  },
+  {
+    "id": "5317|Etzwil|AG",
+    "name": "Etzwil",
+    "zipCode": "5317",
+    "canton": "AG"
+  },
+  {
+    "id": "8259|Etzwilen|TG",
+    "name": "Etzwilen",
+    "zipCode": "8259",
+    "canton": "TG"
+  },
+  {
+    "id": "8508|Eugerswil|TG",
+    "name": "Eugerswil",
+    "zipCode": "8508",
+    "canton": "TG"
+  },
+  {
+    "id": "1982|Euseigne|VS",
+    "name": "Euseigne",
+    "zipCode": "1982",
+    "canton": "VS"
+  },
+  {
+    "id": "8844|Euthal|SZ",
+    "name": "Euthal",
+    "zipCode": "8844",
+    "canton": "SZ"
+  },
+  {
+    "id": "2533|Evilard|BE",
+    "name": "Evilard",
+    "zipCode": "2533",
+    "canton": "BE"
+  },
+  {
+    "id": "1902|Evionnaz|VS",
+    "name": "Evionnaz",
+    "zipCode": "1902",
+    "canton": "VS"
+  },
+  {
+    "id": "1983|Evolène|VS",
+    "name": "Evolène",
+    "zipCode": "1983",
+    "canton": "VS"
+  },
+  {
+    "id": "1866|Exergillod|VD",
+    "name": "Exergillod",
+    "zipCode": "1866",
+    "canton": "VD"
+  },
+  {
+    "id": "3400|Ey bei Kirchberg|BE",
+    "name": "Ey bei Kirchberg",
+    "zipCode": "3400",
+    "canton": "BE"
+  },
+  {
+    "id": "3063|Eyfeld|BE",
+    "name": "Eyfeld",
+    "zipCode": "3063",
+    "canton": "BE"
+  },
+  {
+    "id": "3930|Eyholz|VS",
+    "name": "Eyholz",
+    "zipCode": "3930",
+    "canton": "VS"
+  },
+  {
+    "id": "3000|Eymatt|BE",
+    "name": "Eymatt",
+    "zipCode": "3000",
+    "canton": "BE"
+  },
+  {
+    "id": "1262|Eysins|VD",
+    "name": "Eysins",
+    "zipCode": "1262",
+    "canton": "VD"
+  },
+  {
+    "id": "3919|Fafleralp|VS",
+    "name": "Fafleralp",
+    "zipCode": "3919",
+    "canton": "VS"
+  },
+  {
+    "id": "8630|Fägswil|ZH",
+    "name": "Fägswil",
+    "zipCode": "8630",
+    "canton": "ZH"
+  },
+  {
+    "id": "8109|Fahr|AG",
+    "name": "Fahr",
+    "zipCode": "8109",
+    "canton": "AG"
+  },
+  {
+    "id": "8525|Fahrhof|TG",
+    "name": "Fahrhof",
+    "zipCode": "8525",
+    "canton": "TG"
+  },
+  {
+    "id": "3617|Fahrni|BE",
+    "name": "Fahrni",
+    "zipCode": "3617",
+    "canton": "BE"
+  },
+  {
+    "id": "5615|Fahrwangen|AG",
+    "name": "Fahrwangen",
+    "zipCode": "5615",
+    "canton": "AG"
+  },
+  {
+    "id": "8951|Fahrweid|ZH",
+    "name": "Fahrweid",
+    "zipCode": "8951",
+    "canton": "ZH"
+  },
+  {
+    "id": "2916|Fahy|JU",
+    "name": "Fahy",
+    "zipCode": "2916",
+    "canton": "JU"
+  },
+  {
+    "id": "6760|Faido|TI",
+    "name": "Faido",
+    "zipCode": "6760",
+    "canton": "TI"
+  },
+  {
+    "id": "6760|Faido Stazione|TI",
+    "name": "Faido Stazione",
+    "zipCode": "6760",
+    "canton": "TI"
+  },
+  {
+    "id": "7226|Fajauna|GR",
+    "name": "Fajauna",
+    "zipCode": "7226",
+    "canton": "GR"
+  },
+  {
+    "id": "7153|Falera|GR",
+    "name": "Falera",
+    "zipCode": "7153",
+    "canton": "GR"
+  },
+  {
+    "id": "8117|Fällanden|ZH",
+    "name": "Fällanden",
+    "zipCode": "8117",
+    "canton": "ZH"
+  },
+  {
+    "id": "8636|Faltigberg|ZH",
+    "name": "Faltigberg",
+    "zipCode": "8636",
+    "canton": "ZH"
+  },
+  {
+    "id": "7215|Fanas|GR",
+    "name": "Fanas",
+    "zipCode": "7215",
+    "canton": "GR"
+  },
+  {
+    "id": "3961|Fang|VS",
+    "name": "Fang",
+    "zipCode": "3961",
+    "canton": "VS"
+  },
+  {
+    "id": "3557|Fankhaus (Trub)|BE",
+    "name": "Fankhaus (Trub)",
+    "zipCode": "3557",
+    "canton": "BE"
+  },
+  {
+    "id": "1595|Faoug|VD",
+    "name": "Faoug",
+    "zipCode": "1595",
+    "canton": "VD"
+  },
+  {
+    "id": "7433|Fardün|GR",
+    "name": "Fardün",
+    "zipCode": "7433",
+    "canton": "GR"
+  },
+  {
+    "id": "4539|Farnern|BE",
+    "name": "Farnern",
+    "zipCode": "4539",
+    "canton": "BE"
+  },
+  {
+    "id": "1726|Farvagny|FR",
+    "name": "Farvagny",
+    "zipCode": "1726",
+    "canton": "FR"
+  },
+  {
+    "id": "1726|Farvagny-le-Grand|FR",
+    "name": "Farvagny-le-Grand",
+    "zipCode": "1726",
+    "canton": "FR"
+  },
+  {
+    "id": "1726|Farvagny-le-Petit|FR",
+    "name": "Farvagny-le-Petit",
+    "zipCode": "1726",
+    "canton": "FR"
+  },
+  {
+    "id": "3705|Faulensee|BE",
+    "name": "Faulensee",
+    "zipCode": "3705",
+    "canton": "BE"
+  },
+  {
+    "id": "1173|Féchy|VD",
+    "name": "Féchy",
+    "zipCode": "1173",
+    "canton": "VD"
+  },
+  {
+    "id": "8320|Fehraltorf|ZH",
+    "name": "Fehraltorf",
+    "zipCode": "8320",
+    "canton": "ZH"
+  },
+  {
+    "id": "4232|Fehren|SO",
+    "name": "Fehren",
+    "zipCode": "4232",
+    "canton": "SO"
+  },
+  {
+    "id": "5316|Fehrenthal|AG",
+    "name": "Fehrenthal",
+    "zipCode": "5316",
+    "canton": "AG"
+  },
+  {
+    "id": "8552|Felben|TG",
+    "name": "Felben",
+    "zipCode": "8552",
+    "canton": "TG"
+  },
+  {
+    "id": "8266|Feldbach|TG",
+    "name": "Feldbach",
+    "zipCode": "8266",
+    "canton": "TG"
+  },
+  {
+    "id": "8714|Feldbach|ZH",
+    "name": "Feldbach",
+    "zipCode": "8714",
+    "canton": "ZH"
+  },
+  {
+    "id": "4532|Feldbrunnen|SO",
+    "name": "Feldbrunnen",
+    "zipCode": "4532",
+    "canton": "SO"
+  },
+  {
+    "id": "7404|Feldis/Veulden|GR",
+    "name": "Feldis/Veulden",
+    "zipCode": "7404",
+    "canton": "GR"
+  },
+  {
+    "id": "8706|Feldmeilen|ZH",
+    "name": "Feldmeilen",
+    "zipCode": "8706",
+    "canton": "ZH"
+  },
+  {
+    "id": "9425|Feldmoos|SG",
+    "name": "Feldmoos",
+    "zipCode": "9425",
+    "canton": "SG"
+  },
+  {
+    "id": "7012|Felsberg|GR",
+    "name": "Felsberg",
+    "zipCode": "7012",
+    "canton": "GR"
+  },
+  {
+    "id": "3000|Felsenau|BE",
+    "name": "Felsenau",
+    "zipCode": "3000",
+    "canton": "BE"
+  },
+  {
+    "id": "5316|Felsenau|AG",
+    "name": "Felsenau",
+    "zipCode": "5316",
+    "canton": "AG"
+  },
+  {
+    "id": "8143|Felsenegg|ZH",
+    "name": "Felsenegg",
+    "zipCode": "8143",
+    "canton": "ZH"
+  },
+  {
+    "id": "1880|Fenalet-sur-Bex|VD",
+    "name": "Fenalet-sur-Bex",
+    "zipCode": "1880",
+    "canton": "VD"
+  },
+  {
+    "id": "3178|Fendringen|FR",
+    "name": "Fendringen",
+    "zipCode": "3178",
+    "canton": "FR"
+  },
+  {
+    "id": "1809|Fenil-sur-Corsier|VD",
+    "name": "Fenil-sur-Corsier",
+    "zipCode": "1809",
+    "canton": "VD"
+  },
+  {
+    "id": "2063|Fenin|NE",
+    "name": "Fenin",
+    "zipCode": "2063",
+    "canton": "NE"
+  },
+  {
+    "id": "5645|Fenkrieden|AG",
+    "name": "Fenkrieden",
+    "zipCode": "5645",
+    "canton": "AG"
+  },
+  {
+    "id": "3916|Ferden|VS",
+    "name": "Ferden",
+    "zipCode": "3916",
+    "canton": "VS"
+  },
+  {
+    "id": "3206|Ferenbalm|BE",
+    "name": "Ferenbalm",
+    "zipCode": "3206",
+    "canton": "BE"
+  },
+  {
+    "id": "3208|Ferenbalm Station|BE",
+    "name": "Ferenbalm Station",
+    "zipCode": "3208",
+    "canton": "BE"
+  },
+  {
+    "id": "3066|Ferenberg bei Stettlen|BE",
+    "name": "Ferenberg bei Stettlen",
+    "zipCode": "3066",
+    "canton": "BE"
+  },
+  {
+    "id": "1076|Ferlens|VD",
+    "name": "Ferlens",
+    "zipCode": "1076",
+    "canton": "VD"
+  },
+  {
+    "id": "1984|Ferpècle|VS",
+    "name": "Ferpècle",
+    "zipCode": "1984",
+    "canton": "VS"
+  },
+  {
+    "id": "1724|Ferpicloz|FR",
+    "name": "Ferpicloz",
+    "zipCode": "1724",
+    "canton": "FR"
+  },
+  {
+    "id": "6277|Ferren|LU",
+    "name": "Ferren",
+    "zipCode": "6277",
+    "canton": "LU"
+  },
+  {
+    "id": "1944|Ferret|VS",
+    "name": "Ferret",
+    "zipCode": "1944",
+    "canton": "VS"
+  },
+  {
+    "id": "1313|Ferreyres|VD",
+    "name": "Ferreyres",
+    "zipCode": "1313",
+    "canton": "VD"
+  },
+  {
+    "id": "3956|Feschel|VS",
+    "name": "Feschel",
+    "zipCode": "3956",
+    "canton": "VS"
+  },
+  {
+    "id": "6938|Fescoggia|TI",
+    "name": "Fescoggia",
+    "zipCode": "6938",
+    "canton": "TI"
+  },
+  {
+    "id": "1532|Fétigny|FR",
+    "name": "Fétigny",
+    "zipCode": "1532",
+    "canton": "FR"
+  },
+  {
+    "id": "8245|Feuerthalen|ZH",
+    "name": "Feuerthalen",
+    "zipCode": "8245",
+    "canton": "ZH"
+  },
+  {
+    "id": "8835|Feusisberg|SZ",
+    "name": "Feusisberg",
+    "zipCode": "8835",
+    "canton": "SZ"
+  },
+  {
+    "id": "3784|Feutersoey|BE",
+    "name": "Feutersoey",
+    "zipCode": "3784",
+    "canton": "BE"
+  },
+  {
+    "id": "7514|Fex|GR",
+    "name": "Fex",
+    "zipCode": "7514",
+    "canton": "GR"
+  },
+  {
+    "id": "1044|Fey|VD",
+    "name": "Fey",
+    "zipCode": "1044",
+    "canton": "VD"
+  },
+  {
+    "id": "1996|Fey|VS",
+    "name": "Fey",
+    "zipCode": "1996",
+    "canton": "VS"
+  },
+  {
+    "id": "1854|Feydey|VD",
+    "name": "Feydey",
+    "zipCode": "1854",
+    "canton": "VD"
+  },
+  {
+    "id": "1609|Fiaugères|FR",
+    "name": "Fiaugères",
+    "zipCode": "1609",
+    "canton": "FR"
+  },
+  {
+    "id": "7019|Fidaz|GR",
+    "name": "Fidaz",
+    "zipCode": "7019",
+    "canton": "GR"
+  },
+  {
+    "id": "7235|Fideris|GR",
+    "name": "Fideris",
+    "zipCode": "7235",
+    "canton": "GR"
+  },
+  {
+    "id": "7235|Fideris Station|GR",
+    "name": "Fideris Station",
+    "zipCode": "7235",
+    "canton": "GR"
+  },
+  {
+    "id": "3984|Fiesch|VS",
+    "name": "Fiesch",
+    "zipCode": "3984",
+    "canton": "VS"
+  },
+  {
+    "id": "3984|Fieschertal|VS",
+    "name": "Fieschertal",
+    "zipCode": "3984",
+    "canton": "VS"
+  },
+  {
+    "id": "6772|Fiesso|TI",
+    "name": "Fiesso",
+    "zipCode": "6772",
+    "canton": "TI"
+  },
+  {
+    "id": "1420|Fiez|VD",
+    "name": "Fiez",
+    "zipCode": "1420",
+    "canton": "VD"
+  },
+  {
+    "id": "6760|Figgione|TI",
+    "name": "Figgione",
+    "zipCode": "6760",
+    "canton": "TI"
+  },
+  {
+    "id": "6918|Figino|TI",
+    "name": "Figino",
+    "zipCode": "6918",
+    "canton": "TI"
+  },
+  {
+    "id": "3983|Filet|VS",
+    "name": "Filet",
+    "zipCode": "3983",
+    "canton": "VS"
+  },
+  {
+    "id": "7477|Filisur|GR",
+    "name": "Filisur",
+    "zipCode": "7477",
+    "canton": "GR"
+  },
+  {
+    "id": "3185|Fillistorf|FR",
+    "name": "Fillistorf",
+    "zipCode": "3185",
+    "canton": "FR"
+  },
+  {
+    "id": "8757|Filzbach|GL",
+    "name": "Filzbach",
+    "zipCode": "8757",
+    "canton": "GL"
+  },
+  {
+    "id": "8514|Fimmelsberg|TG",
+    "name": "Fimmelsberg",
+    "zipCode": "8514",
+    "canton": "TG"
+  },
+  {
+    "id": "1925|Finhaut|VS",
+    "name": "Finhaut",
+    "zipCode": "1925",
+    "canton": "VS"
+  },
+  {
+    "id": "2577|Finsterhennen|BE",
+    "name": "Finsterhennen",
+    "zipCode": "2577",
+    "canton": "BE"
+  },
+  {
+    "id": "6313|Finstersee|ZG",
+    "name": "Finstersee",
+    "zipCode": "6313",
+    "canton": "ZG"
+  },
+  {
+    "id": "6162|Finsterwald|LU",
+    "name": "Finsterwald",
+    "zipCode": "6162",
+    "canton": "LU"
+  },
+  {
+    "id": "1948|Fionnay|VS",
+    "name": "Fionnay",
+    "zipCode": "1948",
+    "canton": "VS"
+  },
+  {
+    "id": "8307|First|ZH",
+    "name": "First",
+    "zipCode": "8307",
+    "canton": "ZH"
+  },
+  {
+    "id": "5525|Fischbach|AG",
+    "name": "Fischbach",
+    "zipCode": "5525",
+    "canton": "AG"
+  },
+  {
+    "id": "6145|Fischbach|LU",
+    "name": "Fischbach",
+    "zipCode": "6145",
+    "canton": "LU"
+  },
+  {
+    "id": "8558|Fischbach|TG",
+    "name": "Fischbach",
+    "zipCode": "8558",
+    "canton": "TG"
+  },
+  {
+    "id": "8497|Fischenthal|ZH",
+    "name": "Fischenthal",
+    "zipCode": "8497",
+    "canton": "ZH"
+  },
+  {
+    "id": "8376|Fischingen|TG",
+    "name": "Fischingen",
+    "zipCode": "8376",
+    "canton": "TG"
+  },
+  {
+    "id": "5467|Fisibach|AG",
+    "name": "Fisibach",
+    "zipCode": "5467",
+    "canton": "AG"
+  },
+  {
+    "id": "5442|Fislisbach|AG",
+    "name": "Fislisbach",
+    "zipCode": "5442",
+    "canton": "AG"
+  },
+  {
+    "id": "8416|Flaach|ZH",
+    "name": "Flaach",
+    "zipCode": "8416",
+    "canton": "ZH"
+  },
+  {
+    "id": "3175|Flamatt|FR",
+    "name": "Flamatt",
+    "zipCode": "3175",
+    "canton": "FR"
+  },
+  {
+    "id": "3978|Flanthey|VS",
+    "name": "Flanthey",
+    "zipCode": "3978",
+    "canton": "VS"
+  },
+  {
+    "id": "7306|Fläsch|GR",
+    "name": "Fläsch",
+    "zipCode": "7306",
+    "canton": "GR"
+  },
+  {
+    "id": "9230|Flawil|SG",
+    "name": "Flawil",
+    "zipCode": "9230",
+    "canton": "SG"
+  },
+  {
+    "id": "4852|Fleckenhausen|AG",
+    "name": "Fleckenhausen",
+    "zipCode": "4852",
+    "canton": "AG"
+  },
+  {
+    "id": "1659|Flendruz|VD",
+    "name": "Flendruz",
+    "zipCode": "1659",
+    "canton": "VD"
+  },
+  {
+    "id": "7426|Flerden|GR",
+    "name": "Flerden",
+    "zipCode": "7426",
+    "canton": "GR"
+  },
+  {
+    "id": "2114|Fleurier|NE",
+    "name": "Fleurier",
+    "zipCode": "2114",
+    "canton": "NE"
+  },
+  {
+    "id": "7017|Flims|GR",
+    "name": "Flims",
+    "zipCode": "7017",
+    "canton": "GR"
+  },
+  {
+    "id": "7017|Flims Dorf|GR",
+    "name": "Flims Dorf",
+    "zipCode": "7017",
+    "canton": "GR"
+  },
+  {
+    "id": "7018|Flims Waldhaus|GR",
+    "name": "Flims Waldhaus",
+    "zipCode": "7018",
+    "canton": "GR"
+  },
+  {
+    "id": "7137|Flond|GR",
+    "name": "Flond",
+    "zipCode": "7137",
+    "canton": "GR"
+  },
+  {
+    "id": "6454|Flüelen|UR",
+    "name": "Flüelen",
+    "zipCode": "6454",
+    "canton": "UR"
+  },
+  {
+    "id": "6073|Flüeli-Ranft|OW",
+    "name": "Flüeli-Ranft",
+    "zipCode": "6073",
+    "canton": "OW"
+  },
+  {
+    "id": "3065|Flugbrunnen|BE",
+    "name": "Flugbrunnen",
+    "zipCode": "3065",
+    "canton": "BE"
+  },
+  {
+    "id": "4112|Flüh|SO",
+    "name": "Flüh",
+    "zipCode": "4112",
+    "canton": "SO"
+  },
+  {
+    "id": "6173|Flühli|LU",
+    "name": "Flühli",
+    "zipCode": "6173",
+    "canton": "LU"
+  },
+  {
+    "id": "4534|Flumenthal|SO",
+    "name": "Flumenthal",
+    "zipCode": "4534",
+    "canton": "SO"
+  },
+  {
+    "id": "8890|Flums|SG",
+    "name": "Flums",
+    "zipCode": "8890",
+    "canton": "SG"
+  },
+  {
+    "id": "8000|Fluntern|ZH",
+    "name": "Fluntern",
+    "zipCode": "8000",
+    "canton": "ZH"
+  },
+  {
+    "id": "8247|Flurlingen|ZH",
+    "name": "Flurlingen",
+    "zipCode": "8247",
+    "canton": "ZH"
+  },
+  {
+    "id": "8872|Fly|SG",
+    "name": "Fly",
+    "zipCode": "8872",
+    "canton": "SG"
+  },
+  {
+    "id": "7057|Fondei|GR",
+    "name": "Fondei",
+    "zipCode": "7057",
+    "canton": "GR"
+  },
+  {
+    "id": "1473|Font|FR",
+    "name": "Font",
+    "zipCode": "1473",
+    "canton": "FR"
+  },
+  {
+    "id": "1945|Fontaine Dessous|VS",
+    "name": "Fontaine Dessous",
+    "zipCode": "1945",
+    "canton": "VS"
+  },
+  {
+    "id": "1945|Fontaine Dessus|VS",
+    "name": "Fontaine Dessus",
+    "zipCode": "1945",
+    "canton": "VS"
+  },
+  {
+    "id": "2052|Fontainemelon|NE",
+    "name": "Fontainemelon",
+    "zipCode": "2052",
+    "canton": "NE"
+  },
+  {
+    "id": "2046|Fontaines|NE",
+    "name": "Fontaines",
+    "zipCode": "2046",
+    "canton": "NE"
+  },
+  {
+    "id": "1421|Fontaines-sur-Grandson|VD",
+    "name": "Fontaines-sur-Grandson",
+    "zipCode": "1421",
+    "canton": "VD"
+  },
+  {
+    "id": "7553|Fontana|GR",
+    "name": "Fontana",
+    "zipCode": "7553",
+    "canton": "GR"
+  },
+  {
+    "id": "6834|Fontanella|TI",
+    "name": "Fontanella",
+    "zipCode": "6834",
+    "canton": "TI"
+  },
+  {
+    "id": "1423|Fontanezier|VD",
+    "name": "Fontanezier",
+    "zipCode": "1423",
+    "canton": "VD"
+  },
+  {
+    "id": "6110|Fontannen bei Wolhusen|LU",
+    "name": "Fontannen bei Wolhusen",
+    "zipCode": "6110",
+    "canton": "LU"
+  },
+  {
+    "id": "1860|Fontanney|VD",
+    "name": "Fontanney",
+    "zipCode": "1860",
+    "canton": "VD"
+  },
+  {
+    "id": "2902|Fontenais|JU",
+    "name": "Fontenais",
+    "zipCode": "2902",
+    "canton": "JU"
+  },
+  {
+    "id": "1934|Fontenelle|VS",
+    "name": "Fontenelle",
+    "zipCode": "1934",
+    "canton": "VS"
+  },
+  {
+    "id": "9476|Fontnas|SG",
+    "name": "Fontnas",
+    "zipCode": "9476",
+    "canton": "SG"
+  },
+  {
+    "id": "8127|Forch|ZH",
+    "name": "Forch",
+    "zipCode": "8127",
+    "canton": "ZH"
+  },
+  {
+    "id": "1867|Forchex|VD",
+    "name": "Forchex",
+    "zipCode": "1867",
+    "canton": "VD"
+  },
+  {
+    "id": "1475|Forel|FR",
+    "name": "Forel",
+    "zipCode": "1475",
+    "canton": "FR"
+  },
+  {
+    "id": "1072|Forel (Lavaux)|VD",
+    "name": "Forel (Lavaux)",
+    "zipCode": "1072",
+    "canton": "VD"
+  },
+  {
+    "id": "1526|Forel-sur-Lucens|VD",
+    "name": "Forel-sur-Lucens",
+    "zipCode": "1526",
+    "canton": "VD"
+  },
+  {
+    "id": "1782|Formangueires|FR",
+    "name": "Formangueires",
+    "zipCode": "1782",
+    "canton": "FR"
+  },
+  {
+    "id": "6996|Fornasette|TI",
+    "name": "Fornasette",
+    "zipCode": "6996",
+    "canton": "TI"
+  },
+  {
+    "id": "2717|Fornet-Dessous|BE",
+    "name": "Fornet-Dessous",
+    "zipCode": "2717",
+    "canton": "BE"
+  },
+  {
+    "id": "2718|Fornet-Dessus|JU",
+    "name": "Fornet-Dessus",
+    "zipCode": "2718",
+    "canton": "JU"
+  },
+  {
+    "id": "1945|Fornex|VS",
+    "name": "Fornex",
+    "zipCode": "1945",
+    "canton": "VS"
+  },
+  {
+    "id": "6690|Foroglio|TI",
+    "name": "Foroglio",
+    "zipCode": "6690",
+    "canton": "TI"
+  },
+  {
+    "id": "9450|Forst|SG",
+    "name": "Forst",
+    "zipCode": "9450",
+    "canton": "SG"
+  },
+  {
+    "id": "3636|Forst bei Längenbühl|BE",
+    "name": "Forst bei Längenbühl",
+    "zipCode": "3636",
+    "canton": "BE"
+  },
+  {
+    "id": "1966|Fortunoz|VS",
+    "name": "Fortunoz",
+    "zipCode": "1966",
+    "canton": "VS"
+  },
+  {
+    "id": "6574|Fosano|TI",
+    "name": "Fosano",
+    "zipCode": "6574",
+    "canton": "TI"
+  },
+  {
+    "id": "1225|Fossard|GE",
+    "name": "Fossard",
+    "zipCode": "1225",
+    "canton": "GE"
+  },
+  {
+    "id": "1297|Founex|VD",
+    "name": "Founex",
+    "zipCode": "1297",
+    "canton": "VD"
+  },
+  {
+    "id": "1489|Franex|FR",
+    "name": "Franex",
+    "zipCode": "1489",
+    "canton": "FR"
+  },
+  {
+    "id": "3284|Fräschels|FR",
+    "name": "Fräschels",
+    "zipCode": "3284",
+    "canton": "FR"
+  },
+  {
+    "id": "6636|Frasco|TI",
+    "name": "Frasco",
+    "zipCode": "6636",
+    "canton": "TI"
+  },
+  {
+    "id": "9320|Frasnacht|TG",
+    "name": "Frasnacht",
+    "zipCode": "9320",
+    "canton": "TG"
+  },
+  {
+    "id": "1483|Frasses|FR",
+    "name": "Frasses",
+    "zipCode": "1483",
+    "canton": "FR"
+  },
+  {
+    "id": "3312|Fraubrunnen|BE",
+    "name": "Fraubrunnen",
+    "zipCode": "3312",
+    "canton": "BE"
+  },
+  {
+    "id": "3255|Frauchwil|BE",
+    "name": "Frauchwil",
+    "zipCode": "3255",
+    "canton": "BE"
+  },
+  {
+    "id": "8500|Frauenfeld|TG",
+    "name": "Frauenfeld",
+    "zipCode": "8500",
+    "canton": "TG"
+  },
+  {
+    "id": "3202|Frauenkappelen|BE",
+    "name": "Frauenkappelen",
+    "zipCode": "3202",
+    "canton": "BE"
+  },
+  {
+    "id": "7276|Frauenkirch|GR",
+    "name": "Frauenkirch",
+    "zipCode": "7276",
+    "canton": "GR"
+  },
+  {
+    "id": "6763|Freggio|TI",
+    "name": "Freggio",
+    "zipCode": "6763",
+    "canton": "TI"
+  },
+  {
+    "id": "2953|Fregiécourt|JU",
+    "name": "Fregiécourt",
+    "zipCode": "2953",
+    "canton": "JU"
+  },
+  {
+    "id": "3176|Freiburghaus|BE",
+    "name": "Freiburghaus",
+    "zipCode": "3176",
+    "canton": "BE"
+  },
+  {
+    "id": "9306|Freidorf|TG",
+    "name": "Freidorf",
+    "zipCode": "9306",
+    "canton": "TG"
+  },
+  {
+    "id": "8807|Freienbach|SZ",
+    "name": "Freienbach",
+    "zipCode": "8807",
+    "canton": "SZ"
+  },
+  {
+    "id": "8427|Freienstein|ZH",
+    "name": "Freienstein",
+    "zipCode": "8427",
+    "canton": "ZH"
+  },
+  {
+    "id": "5423|Freienwil|AG",
+    "name": "Freienwil",
+    "zipCode": "5423",
+    "canton": "AG"
+  },
+  {
+    "id": "3510|Freimettigen|BE",
+    "name": "Freimettigen",
+    "zipCode": "3510",
+    "canton": "BE"
+  },
+  {
+    "id": "1880|Frenières-sur-Bex|VD",
+    "name": "Frenières-sur-Bex",
+    "zipCode": "1880",
+    "canton": "VD"
+  },
+  {
+    "id": "4402|Frenkendorf|BL",
+    "name": "Frenkendorf",
+    "zipCode": "4402",
+    "canton": "BL"
+  },
+  {
+    "id": "2027|Fresens|NE",
+    "name": "Fresens",
+    "zipCode": "2027",
+    "canton": "NE"
+  },
+  {
+    "id": "2149|Fretereules|NE",
+    "name": "Fretereules",
+    "zipCode": "2149",
+    "canton": "NE"
+  },
+  {
+    "id": "8615|Freudwil|ZH",
+    "name": "Freudwil",
+    "zipCode": "8615",
+    "canton": "ZH"
+  },
+  {
+    "id": "1700|Fribourg|FR",
+    "name": "Fribourg",
+    "zipCode": "1700",
+    "canton": "FR"
+  },
+  {
+    "id": "5070|Frick|AG",
+    "name": "Frick",
+    "zipCode": "5070",
+    "canton": "AG"
+  },
+  {
+    "id": "8964|Friedlisberg|AG",
+    "name": "Friedlisberg",
+    "zipCode": "8964",
+    "canton": "AG"
+  },
+  {
+    "id": "3267|Frienisberg|BE",
+    "name": "Frienisberg",
+    "zipCode": "3267",
+    "canton": "BE"
+  },
+  {
+    "id": "6332|Friesencham|ZG",
+    "name": "Friesencham",
+    "zipCode": "6332",
+    "canton": "ZG"
+  },
+  {
+    "id": "3035|Frieswil|BE",
+    "name": "Frieswil",
+    "zipCode": "3035",
+    "canton": "BE"
+  },
+  {
+    "id": "7134|Friggahüs|GR",
+    "name": "Friggahüs",
+    "zipCode": "7134",
+    "canton": "GR"
+  },
+  {
+    "id": "9504|Friltschen|TG",
+    "name": "Friltschen",
+    "zipCode": "9504",
+    "canton": "TG"
+  },
+  {
+    "id": "2535|Frinvillier|BE",
+    "name": "Frinvillier",
+    "zipCode": "2535",
+    "canton": "BE"
+  },
+  {
+    "id": "3436|Frittenbach|BE",
+    "name": "Frittenbach",
+    "zipCode": "3436",
+    "canton": "BE"
+  },
+  {
+    "id": "4634|Froburg|SO",
+    "name": "Froburg",
+    "zipCode": "4634",
+    "canton": "SO"
+  },
+  {
+    "id": "1055|Froideville|VD",
+    "name": "Froideville",
+    "zipCode": "1055",
+    "canton": "VD"
+  },
+  {
+    "id": "1223|Frontenex|GE",
+    "name": "Frontenex",
+    "zipCode": "1223",
+    "canton": "GE"
+  },
+  {
+    "id": "1618|Fruence|FR",
+    "name": "Fruence",
+    "zipCode": "1618",
+    "canton": "FR"
+  },
+  {
+    "id": "9467|Frümsen|SG",
+    "name": "Frümsen",
+    "zipCode": "9467",
+    "canton": "SG"
+  },
+  {
+    "id": "8269|Fruthwilen|TG",
+    "name": "Fruthwilen",
+    "zipCode": "8269",
+    "canton": "TG"
+  },
+  {
+    "id": "3714|Frutigen|BE",
+    "name": "Frutigen",
+    "zipCode": "3714",
+    "canton": "BE"
+  },
+  {
+    "id": "6068|Frutt|OW",
+    "name": "Frutt",
+    "zipCode": "6068",
+    "canton": "OW"
+  },
+  {
+    "id": "7551|Ftan|GR",
+    "name": "Ftan",
+    "zipCode": "7551",
+    "canton": "GR"
+  },
+  {
+    "id": "8352|Fulau|ZH",
+    "name": "Fulau",
+    "zipCode": "8352",
+    "canton": "ZH"
+  },
+  {
+    "id": "7533|Fuldera|GR",
+    "name": "Fuldera",
+    "zipCode": "7533",
+    "canton": "GR"
+  },
+  {
+    "id": "4629|Fulenbach|SO",
+    "name": "Fulenbach",
+    "zipCode": "4629",
+    "canton": "SO"
+  },
+  {
+    "id": "5324|Full|AG",
+    "name": "Full",
+    "zipCode": "5324",
+    "canton": "AG"
+  },
+  {
+    "id": "4414|Füllinsdorf|BL",
+    "name": "Füllinsdorf",
+    "zipCode": "4414",
+    "canton": "BL"
+  },
+  {
+    "id": "1926|Fully|VS",
+    "name": "Fully",
+    "zipCode": "1926",
+    "canton": "VS"
+  },
+  {
+    "id": "7185|Fuorns|GR",
+    "name": "Fuorns",
+    "zipCode": "7185",
+    "canton": "GR"
+  },
+  {
+    "id": "3997|Fürgangen|VS",
+    "name": "Fürgangen",
+    "zipCode": "3997",
+    "canton": "VS"
+  },
+  {
+    "id": "6363|Fürigen|NW",
+    "name": "Fürigen",
+    "zipCode": "6363",
+    "canton": "NW"
+  },
+  {
+    "id": "7232|Furna|GR",
+    "name": "Furna",
+    "zipCode": "7232",
+    "canton": "GR"
+  },
+  {
+    "id": "7414|Fürstenau|GR",
+    "name": "Fürstenau",
+    "zipCode": "7414",
+    "canton": "GR"
+  },
+  {
+    "id": "7413|Fürstenaubruck|GR",
+    "name": "Fürstenaubruck",
+    "zipCode": "7413",
+    "canton": "GR"
+  },
+  {
+    "id": "9125|Furth|SG",
+    "name": "Furth",
+    "zipCode": "9125",
+    "canton": "SG"
+  },
+  {
+    "id": "6696|Fusio|TI",
+    "name": "Fusio",
+    "zipCode": "6696",
+    "canton": "TI"
+  },
+  {
+    "id": "3907|Gabi (Simplon)|VS",
+    "name": "Gabi (Simplon)",
+    "zipCode": "3907",
+    "canton": "VS"
+  },
+  {
+    "id": "8214|Gächlingen|SH",
+    "name": "Gächlingen",
+    "zipCode": "8214",
+    "canton": "SH"
+  },
+  {
+    "id": "4584|Gächliwil|SO",
+    "name": "Gächliwil",
+    "zipCode": "4584",
+    "canton": "SO"
+  },
+  {
+    "id": "8547|Gachnang|TG",
+    "name": "Gachnang",
+    "zipCode": "8547",
+    "canton": "TG"
+  },
+  {
+    "id": "7244|Gadenstätt|GR",
+    "name": "Gadenstätt",
+    "zipCode": "7244",
+    "canton": "GR"
+  },
+  {
+    "id": "3863|Gadmen|BE",
+    "name": "Gadmen",
+    "zipCode": "3863",
+    "canton": "BE"
+  },
+  {
+    "id": "6934|Gaggio|TI",
+    "name": "Gaggio",
+    "zipCode": "6934",
+    "canton": "TI"
+  },
+  {
+    "id": "6596|Gaggiole|TI",
+    "name": "Gaggiole",
+    "zipCode": "6596",
+    "canton": "TI"
+  },
+  {
+    "id": "6855|Gaggiolo|TI",
+    "name": "Gaggiolo",
+    "zipCode": "6855",
+    "canton": "TI"
+  },
+  {
+    "id": "9534|Gähwil|SG",
+    "name": "Gähwil",
+    "zipCode": "9534",
+    "canton": "SG"
+  },
+  {
+    "id": "2513|Gaicht|BE",
+    "name": "Gaicht",
+    "zipCode": "2513",
+    "canton": "BE"
+  },
+  {
+    "id": "9056|Gais|AR",
+    "name": "Gais",
+    "zipCode": "9056",
+    "canton": "AR"
+  },
+  {
+    "id": "9030|Gaiserwald|SG",
+    "name": "Gaiserwald",
+    "zipCode": "9030",
+    "canton": "SG"
+  },
+  {
+    "id": "8854|Galgenen|SZ",
+    "name": "Galgenen",
+    "zipCode": "8854",
+    "canton": "SZ"
+  },
+  {
+    "id": "5225|Gallenkirch|AG",
+    "name": "Gallenkirch",
+    "zipCode": "5225",
+    "canton": "AG"
+  },
+  {
+    "id": "3285|Galmiz|FR",
+    "name": "Galmiz",
+    "zipCode": "3285",
+    "canton": "FR"
+  },
+  {
+    "id": "3238|Gals|BE",
+    "name": "Gals",
+    "zipCode": "3238",
+    "canton": "BE"
+  },
+  {
+    "id": "5272|Galten|AG",
+    "name": "Galten",
+    "zipCode": "5272",
+    "canton": "AG"
+  },
+  {
+    "id": "1712|Galteren|FR",
+    "name": "Galteren",
+    "zipCode": "1712",
+    "canton": "FR"
+  },
+  {
+    "id": "3153|Gambach|BE",
+    "name": "Gambach",
+    "zipCode": "3153",
+    "canton": "BE"
+  },
+  {
+    "id": "3206|Gammen|BE",
+    "name": "Gammen",
+    "zipCode": "3206",
+    "canton": "BE"
+  },
+  {
+    "id": "3454|Gammenthal|BE",
+    "name": "Gammenthal",
+    "zipCode": "3454",
+    "canton": "BE"
+  },
+  {
+    "id": "3945|Gampel|VS",
+    "name": "Gampel",
+    "zipCode": "3945",
+    "canton": "VS"
+  },
+  {
+    "id": "3236|Gampelen|BE",
+    "name": "Gampelen",
+    "zipCode": "3236",
+    "canton": "BE"
+  },
+  {
+    "id": "9473|Gams|SG",
+    "name": "Gams",
+    "zipCode": "9473",
+    "canton": "SG"
+  },
+  {
+    "id": "3900|Gamsen|VS",
+    "name": "Gamsen",
+    "zipCode": "3900",
+    "canton": "VS"
+  },
+  {
+    "id": "6978|Gandria|TI",
+    "name": "Gandria",
+    "zipCode": "6978",
+    "canton": "TI"
+  },
+  {
+    "id": "4716|Gänsbrunnen|SO",
+    "name": "Gänsbrunnen",
+    "zipCode": "4716",
+    "canton": "SO"
+  },
+  {
+    "id": "5272|Gansingen|AG",
+    "name": "Gansingen",
+    "zipCode": "5272",
+    "canton": "AG"
+  },
+  {
+    "id": "9608|Ganterschwil|SG",
+    "name": "Ganterschwil",
+    "zipCode": "9608",
+    "canton": "SG"
+  },
+  {
+    "id": "3935|Gärlich|VS",
+    "name": "Gärlich",
+    "zipCode": "3935",
+    "canton": "VS"
+  },
+  {
+    "id": "3186|Garmiswil|FR",
+    "name": "Garmiswil",
+    "zipCode": "3186",
+    "canton": "FR"
+  },
+  {
+    "id": "3766|Garstatt|BE",
+    "name": "Garstatt",
+    "zipCode": "3766",
+    "canton": "BE"
+  },
+  {
+    "id": "8487|Garten|ZH",
+    "name": "Garten",
+    "zipCode": "8487",
+    "canton": "ZH"
+  },
+  {
+    "id": "3144|Gasel|BE",
+    "name": "Gasel",
+    "zipCode": "3144",
+    "canton": "BE"
+  },
+  {
+    "id": "3924|Gasenried|VS",
+    "name": "Gasenried",
+    "zipCode": "3924",
+    "canton": "VS"
+  },
+  {
+    "id": "9473|Gasenzen|SG",
+    "name": "Gasenzen",
+    "zipCode": "9473",
+    "canton": "SG"
+  },
+  {
+    "id": "7317|Gassaura|SG",
+    "name": "Gassaura",
+    "zipCode": "7317",
+    "canton": "SG"
+  },
+  {
+    "id": "8136|Gattikon|ZH",
+    "name": "Gattikon",
+    "zipCode": "8136",
+    "canton": "ZH"
+  },
+  {
+    "id": "5412|Gebenstorf|AG",
+    "name": "Gebenstorf",
+    "zipCode": "5412",
+    "canton": "AG"
+  },
+  {
+    "id": "8725|Gebertingen|SG",
+    "name": "Gebertingen",
+    "zipCode": "8725",
+    "canton": "SG"
+  },
+  {
+    "id": "9203|Gebhardswil|SG",
+    "name": "Gebhardswil",
+    "zipCode": "9203",
+    "canton": "SG"
+  },
+  {
+    "id": "8044|Geeren|ZH",
+    "name": "Geeren",
+    "zipCode": "8044",
+    "canton": "ZH"
+  },
+  {
+    "id": "8554|Gehrau|TG",
+    "name": "Gehrau",
+    "zipCode": "8554",
+    "canton": "TG"
+  },
+  {
+    "id": "3904|Geimen|VS",
+    "name": "Geimen",
+    "zipCode": "3904",
+    "canton": "VS"
+  },
+  {
+    "id": "6123|Geiss|LU",
+    "name": "Geiss",
+    "zipCode": "6123",
+    "canton": "LU"
+  },
+  {
+    "id": "3860|Geissholz|BE",
+    "name": "Geissholz",
+    "zipCode": "3860",
+    "canton": "BE"
+  },
+  {
+    "id": "6284|Gelfingen|LU",
+    "name": "Gelfingen",
+    "zipCode": "6284",
+    "canton": "LU"
+  },
+  {
+    "id": "3126|Gelterfingen|BE",
+    "name": "Gelterfingen",
+    "zipCode": "3126",
+    "canton": "BE"
+  },
+  {
+    "id": "4460|Gelterkinden|BL",
+    "name": "Gelterkinden",
+    "zipCode": "4460",
+    "canton": "BL"
+  },
+  {
+    "id": "5637|Geltwil|AG",
+    "name": "Geltwil",
+    "zipCode": "5637",
+    "canton": "AG"
+  },
+  {
+    "id": "4145|Gempen|SO",
+    "name": "Gempen",
+    "zipCode": "4145",
+    "canton": "SO"
+  },
+  {
+    "id": "3215|Gempenach|FR",
+    "name": "Gempenach",
+    "zipCode": "3215",
+    "canton": "FR"
+  },
+  {
+    "id": "6852|Genestrerio|TI",
+    "name": "Genestrerio",
+    "zipCode": "6852",
+    "canton": "TI"
+  },
+  {
+    "id": "1200|Genève|GE",
+    "name": "Genève",
+    "zipCode": "1200",
+    "canton": "GE"
+  },
+  {
+    "id": "1272|Genolier|VD",
+    "name": "Genolier",
+    "zipCode": "1272",
+    "canton": "VD"
+  },
+  {
+    "id": "1294|Genthod|GE",
+    "name": "Genthod",
+    "zipCode": "1294",
+    "canton": "GE"
+  },
+  {
+    "id": "6925|Gentilino|TI",
+    "name": "Gentilino",
+    "zipCode": "6925",
+    "canton": "TI"
+  },
+  {
+    "id": "9212|Geretschwil|SG",
+    "name": "Geretschwil",
+    "zipCode": "9212",
+    "canton": "SG"
+  },
+  {
+    "id": "3065|Geristein|BE",
+    "name": "Geristein",
+    "zipCode": "3065",
+    "canton": "BE"
+  },
+  {
+    "id": "4563|Gerlafingen|SO",
+    "name": "Gerlafingen",
+    "zipCode": "4563",
+    "canton": "SO"
+  },
+  {
+    "id": "8500|Gerlikon|TG",
+    "name": "Gerlikon",
+    "zipCode": "8500",
+    "canton": "TG"
+  },
+  {
+    "id": "8302|Gerlisberg|ZH",
+    "name": "Gerlisberg",
+    "zipCode": "8302",
+    "canton": "ZH"
+  },
+  {
+    "id": "6020|Gerliswil|LU",
+    "name": "Gerliswil",
+    "zipCode": "6020",
+    "canton": "LU"
+  },
+  {
+    "id": "8954|Geroldswil|ZH",
+    "name": "Geroldswil",
+    "zipCode": "8954",
+    "canton": "ZH"
+  },
+  {
+    "id": "2575|Gerolfingen|BE",
+    "name": "Gerolfingen",
+    "zipCode": "2575",
+    "canton": "BE"
+  },
+  {
+    "id": "6576|Gerra (Gambarogno)|TI",
+    "name": "Gerra (Gambarogno)",
+    "zipCode": "6576",
+    "canton": "TI"
+  },
+  {
+    "id": "6635|Gerra (Verzasca)|TI",
+    "name": "Gerra (Verzasca)",
+    "zipCode": "6635",
+    "canton": "TI"
+  },
+  {
+    "id": "6516|Gerra Piano|TI",
+    "name": "Gerra Piano",
+    "zipCode": "6516",
+    "canton": "TI"
+  },
+  {
+    "id": "6442|Gersau|SZ",
+    "name": "Gersau",
+    "zipCode": "6442",
+    "canton": "SZ"
+  },
+  {
+    "id": "3115|Gerzensee|BE",
+    "name": "Gerzensee",
+    "zipCode": "3115",
+    "canton": "BE"
+  },
+  {
+    "id": "3985|Geschinen|VS",
+    "name": "Geschinen",
+    "zipCode": "3985",
+    "canton": "VS"
+  },
+  {
+    "id": "6142|Gettnau|LU",
+    "name": "Gettnau",
+    "zipCode": "6142",
+    "canton": "LU"
+  },
+  {
+    "id": "3945|Getwing|VS",
+    "name": "Getwing",
+    "zipCode": "3945",
+    "canton": "VS"
+  },
+  {
+    "id": "6232|Geuensee|LU",
+    "name": "Geuensee",
+    "zipCode": "6232",
+    "canton": "LU"
+  },
+  {
+    "id": "9043|Gfeld|AR",
+    "name": "Gfeld",
+    "zipCode": "9043",
+    "canton": "AR"
+  },
+  {
+    "id": "8600|Gfenn|ZH",
+    "name": "Gfenn",
+    "zipCode": "8600",
+    "canton": "ZH"
+  },
+  {
+    "id": "4852|Gfill|AG",
+    "name": "Gfill",
+    "zipCode": "4852",
+    "canton": "AG"
+  },
+  {
+    "id": "6720|Ghirone|TI",
+    "name": "Ghirone",
+    "zipCode": "6720",
+    "canton": "TI"
+  },
+  {
+    "id": "7545|Giarsun|GR",
+    "name": "Giarsun",
+    "zipCode": "7545",
+    "canton": "GR"
+  },
+  {
+    "id": "8498|Gibswil-Ried|ZH",
+    "name": "Gibswil-Ried",
+    "zipCode": "8498",
+    "canton": "ZH"
+  },
+  {
+    "id": "4304|Giebenach|BL",
+    "name": "Giebenach",
+    "zipCode": "4304",
+    "canton": "BL"
+  },
+  {
+    "id": "3855|Giessbach|BE",
+    "name": "Giessbach",
+    "zipCode": "3855",
+    "canton": "BE"
+  },
+  {
+    "id": "8717|Giessen|SG",
+    "name": "Giessen",
+    "zipCode": "8717",
+    "canton": "SG"
+  },
+  {
+    "id": "1925|Giétroz|VS",
+    "name": "Giétroz",
+    "zipCode": "1925",
+    "canton": "VS"
+  },
+  {
+    "id": "1429|Giez|VD",
+    "name": "Giez",
+    "zipCode": "1429",
+    "canton": "VD"
+  },
+  {
+    "id": "1735|Giffers|FR",
+    "name": "Giffers",
+    "zipCode": "1735",
+    "canton": "FR"
+  },
+  {
+    "id": "1673|Gillarens|FR",
+    "name": "Gillarens",
+    "zipCode": "1673",
+    "canton": "FR"
+  },
+  {
+    "id": "1182|Gilly|VD",
+    "name": "Gilly",
+    "zipCode": "1182",
+    "canton": "VD"
+  },
+  {
+    "id": "1188|Gimel|VD",
+    "name": "Gimel",
+    "zipCode": "1188",
+    "canton": "VD"
+  },
+  {
+    "id": "3826|Gimmelwald|BE",
+    "name": "Gimmelwald",
+    "zipCode": "3826",
+    "canton": "BE"
+  },
+  {
+    "id": "3272|Gimmiz|BE",
+    "name": "Gimmiz",
+    "zipCode": "3272",
+    "canton": "BE"
+  },
+  {
+    "id": "1276|Gingins|VD",
+    "name": "Gingins",
+    "zipCode": "1276",
+    "canton": "VD"
+  },
+  {
+    "id": "6745|Giornico|TI",
+    "name": "Giornico",
+    "zipCode": "6745",
+    "canton": "TI"
+  },
+  {
+    "id": "5073|Gipf|AG",
+    "name": "Gipf",
+    "zipCode": "5073",
+    "canton": "AG"
+  },
+  {
+    "id": "5316|Gippingen|AG",
+    "name": "Gippingen",
+    "zipCode": "5316",
+    "canton": "AG"
+  },
+  {
+    "id": "7134|Giraniga|GR",
+    "name": "Giraniga",
+    "zipCode": "7134",
+    "canton": "GR"
+  },
+  {
+    "id": "8340|Girenbad bei Hinwil|ZH",
+    "name": "Girenbad bei Hinwil",
+    "zipCode": "8340",
+    "canton": "ZH"
+  },
+  {
+    "id": "8488|Girenbad bei Turbenthal|ZH",
+    "name": "Girenbad bei Turbenthal",
+    "zipCode": "8488",
+    "canton": "ZH"
+  },
+  {
+    "id": "8468|Girsberg|ZH",
+    "name": "Girsberg",
+    "zipCode": "8468",
+    "canton": "ZH"
+  },
+  {
+    "id": "8467|Gisenhard|ZH",
+    "name": "Gisenhard",
+    "zipCode": "8467",
+    "canton": "ZH"
+  },
+  {
+    "id": "6038|Gisikon|LU",
+    "name": "Gisikon",
+    "zipCode": "6038",
+    "canton": "LU"
+  },
+  {
+    "id": "6074|Giswil|OW",
+    "name": "Giswil",
+    "zipCode": "6074",
+    "canton": "OW"
+  },
+  {
+    "id": "6512|Giubiasco|TI",
+    "name": "Giubiasco",
+    "zipCode": "6512",
+    "canton": "TI"
+  },
+  {
+    "id": "6678|Giumaglio|TI",
+    "name": "Giumaglio",
+    "zipCode": "6678",
+    "canton": "TI"
+  },
+  {
+    "id": "1762|Givisiez|FR",
+    "name": "Givisiez",
+    "zipCode": "1762",
+    "canton": "FR"
+  },
+  {
+    "id": "1271|Givrins|VD",
+    "name": "Givrins",
+    "zipCode": "1271",
+    "canton": "VD"
+  },
+  {
+    "id": "1115|Gland|VD",
+    "name": "Gland",
+    "zipCode": "1115",
+    "canton": "VD"
+  },
+  {
+    "id": "1196|Gland|VD",
+    "name": "Gland",
+    "zipCode": "1196",
+    "canton": "VD"
+  },
+  {
+    "id": "4852|Gländ|AG",
+    "name": "Gländ",
+    "zipCode": "4852",
+    "canton": "AG"
+  },
+  {
+    "id": "3960|Glarey|VS",
+    "name": "Glarey",
+    "zipCode": "3960",
+    "canton": "VS"
+  },
+  {
+    "id": "7277|Glaris|GR",
+    "name": "Glaris",
+    "zipCode": "7277",
+    "canton": "GR"
+  },
+  {
+    "id": "8266|Glarisegg|TG",
+    "name": "Glarisegg",
+    "zipCode": "8266",
+    "canton": "TG"
+  },
+  {
+    "id": "8750|Glarus|GL",
+    "name": "Glarus",
+    "zipCode": "8750",
+    "canton": "GL"
+  },
+  {
+    "id": "7428|Glas|GR",
+    "name": "Glas",
+    "zipCode": "7428",
+    "canton": "GR"
+  },
+  {
+    "id": "4856|Glashütten|AG",
+    "name": "Glashütten",
+    "zipCode": "4856",
+    "canton": "AG"
+  },
+  {
+    "id": "8152|Glattbrugg|ZH",
+    "name": "Glattbrugg",
+    "zipCode": "8152",
+    "canton": "ZH"
+  },
+  {
+    "id": "8192|Glattfelden|ZH",
+    "name": "Glattfelden",
+    "zipCode": "8192",
+    "canton": "ZH"
+  },
+  {
+    "id": "8152|Glattpark|ZH",
+    "name": "Glattpark",
+    "zipCode": "8152",
+    "canton": "ZH"
+  },
+  {
+    "id": "3999|Gletsch|VS",
+    "name": "Gletsch",
+    "zipCode": "3999",
+    "canton": "VS"
+  },
+  {
+    "id": "1544|Gletterens|FR",
+    "name": "Gletterens",
+    "zipCode": "1544",
+    "canton": "FR"
+  },
+  {
+    "id": "1823|Glion|VD",
+    "name": "Glion",
+    "zipCode": "1823",
+    "canton": "VD"
+  },
+  {
+    "id": "3902|Glis|VS",
+    "name": "Glis",
+    "zipCode": "3902",
+    "canton": "VS"
+  },
+  {
+    "id": "3612|Glockenthal|BE",
+    "name": "Glockenthal",
+    "zipCode": "3612",
+    "canton": "BE"
+  },
+  {
+    "id": "2855|Glovelier|JU",
+    "name": "Glovelier",
+    "zipCode": "2855",
+    "canton": "JU"
+  },
+  {
+    "id": "3998|Gluringen|VS",
+    "name": "Gluringen",
+    "zipCode": "3998",
+    "canton": "VS"
+  },
+  {
+    "id": "1867|Glutières|VD",
+    "name": "Glutières",
+    "zipCode": "1867",
+    "canton": "VD"
+  },
+  {
+    "id": "5524|Gnadenthal|AG",
+    "name": "Gnadenthal",
+    "zipCode": "5524",
+    "canton": "AG"
+  },
+  {
+    "id": "6525|Gnosca|TI",
+    "name": "Gnosca",
+    "zipCode": "6525",
+    "canton": "TI"
+  },
+  {
+    "id": "8044|Gockhausen|ZH",
+    "name": "Gockhausen",
+    "zipCode": "8044",
+    "canton": "ZH"
+  },
+  {
+    "id": "3553|Gohl|BE",
+    "name": "Gohl",
+    "zipCode": "3553",
+    "canton": "BE"
+  },
+  {
+    "id": "6950|Gola di Lago|TI",
+    "name": "Gola di Lago",
+    "zipCode": "6950",
+    "canton": "TI"
+  },
+  {
+    "id": "3207|Golaten|BE",
+    "name": "Golaten",
+    "zipCode": "3207",
+    "canton": "BE"
+  },
+  {
+    "id": "9403|Goldach|SG",
+    "name": "Goldach",
+    "zipCode": "9403",
+    "canton": "SG"
+  },
+  {
+    "id": "6410|Goldau|SZ",
+    "name": "Goldau",
+    "zipCode": "6410",
+    "canton": "SZ"
+  },
+  {
+    "id": "3432|Goldbach|BE",
+    "name": "Goldbach",
+    "zipCode": "3432",
+    "canton": "BE"
+  },
+  {
+    "id": "8700|Goldbach|ZH",
+    "name": "Goldbach",
+    "zipCode": "8700",
+    "canton": "ZH"
+  },
+  {
+    "id": "6085|Goldern|BE",
+    "name": "Goldern",
+    "zipCode": "6085",
+    "canton": "BE"
+  },
+  {
+    "id": "8638|Goldingen|SG",
+    "name": "Goldingen",
+    "zipCode": "8638",
+    "canton": "SG"
+  },
+  {
+    "id": "3624|Goldiwil|BE",
+    "name": "Goldiwil",
+    "zipCode": "3624",
+    "canton": "BE"
+  },
+  {
+    "id": "3805|Goldswil bei Interlaken|BE",
+    "name": "Goldswil bei Interlaken",
+    "zipCode": "3805",
+    "canton": "BE"
+  },
+  {
+    "id": "6656|Golino|TI",
+    "name": "Golino",
+    "zipCode": "6656",
+    "canton": "TI"
+  },
+  {
+    "id": "1124|Gollion|VD",
+    "name": "Gollion",
+    "zipCode": "1124",
+    "canton": "VD"
+  },
+  {
+    "id": "6475|Golzern|UR",
+    "name": "Golzern",
+    "zipCode": "6475",
+    "canton": "UR"
+  },
+  {
+    "id": "3415|Gomerkinden|BE",
+    "name": "Gomerkinden",
+    "zipCode": "3415",
+    "canton": "BE"
+  },
+  {
+    "id": "8737|Gommiswald|SG",
+    "name": "Gommiswald",
+    "zipCode": "8737",
+    "canton": "SG"
+  },
+  {
+    "id": "4955|Gondiswil|BE",
+    "name": "Gondiswil",
+    "zipCode": "4955",
+    "canton": "BE"
+  },
+  {
+    "id": "3907|Gondo|VS",
+    "name": "Gondo",
+    "zipCode": "3907",
+    "canton": "VS"
+  },
+  {
+    "id": "9108|Gonten|AI",
+    "name": "Gonten",
+    "zipCode": "9108",
+    "canton": "AI"
+  },
+  {
+    "id": "9108|Gontenbad|AI",
+    "name": "Gontenbad",
+    "zipCode": "9108",
+    "canton": "AI"
+  },
+  {
+    "id": "5728|Gontenschwil|AG",
+    "name": "Gontenschwil",
+    "zipCode": "5728",
+    "canton": "AG"
+  },
+  {
+    "id": "3917|Goppenstein|VS",
+    "name": "Goppenstein",
+    "zipCode": "3917",
+    "canton": "VS"
+  },
+  {
+    "id": "3983|Goppisberg|VS",
+    "name": "Goppisberg",
+    "zipCode": "3983",
+    "canton": "VS"
+  },
+  {
+    "id": "6596|Gordemo|TI",
+    "name": "Gordemo",
+    "zipCode": "6596",
+    "canton": "TI"
+  },
+  {
+    "id": "6672|Gordevio|TI",
+    "name": "Gordevio",
+    "zipCode": "6672",
+    "canton": "TI"
+  },
+  {
+    "id": "6596|Gordola|TI",
+    "name": "Gordola",
+    "zipCode": "6596",
+    "canton": "TI"
+  },
+  {
+    "id": "6518|Gorduno|TI",
+    "name": "Gorduno",
+    "zipCode": "6518",
+    "canton": "TI"
+  },
+  {
+    "id": "2023|Gorgier|NE",
+    "name": "Gorgier",
+    "zipCode": "2023",
+    "canton": "NE"
+  },
+  {
+    "id": "6874|Gorla|TI",
+    "name": "Gorla",
+    "zipCode": "6874",
+    "canton": "TI"
+  },
+  {
+    "id": "3920|Gornergrat|VS",
+    "name": "Gornergrat",
+    "zipCode": "3920",
+    "canton": "VS"
+  },
+  {
+    "id": "6487|Göschenen|UR",
+    "name": "Göschenen",
+    "zipCode": "6487",
+    "canton": "UR"
+  },
+  {
+    "id": "6487|Göscheneralp|UR",
+    "name": "Göscheneralp",
+    "zipCode": "6487",
+    "canton": "UR"
+  },
+  {
+    "id": "5525|Göslikon|AG",
+    "name": "Göslikon",
+    "zipCode": "5525",
+    "canton": "AG"
+  },
+  {
+    "id": "8625|Gossau|ZH",
+    "name": "Gossau",
+    "zipCode": "8625",
+    "canton": "ZH"
+  },
+  {
+    "id": "9200|Gossau|SG",
+    "name": "Gossau",
+    "zipCode": "9200",
+    "canton": "SG"
+  },
+  {
+    "id": "1407|Gossens|VD",
+    "name": "Gossens",
+    "zipCode": "1407",
+    "canton": "VD"
+  },
+  {
+    "id": "8126|Gössikon|ZH",
+    "name": "Gössikon",
+    "zipCode": "8126",
+    "canton": "ZH"
+  },
+  {
+    "id": "4579|Gossliwil|SO",
+    "name": "Gossliwil",
+    "zipCode": "4579",
+    "canton": "SO"
+  },
+  {
+    "id": "8583|Götighofen|TG",
+    "name": "Götighofen",
+    "zipCode": "8583",
+    "canton": "TG"
+  },
+  {
+    "id": "1907|Gottefrey|VS",
+    "name": "Gottefrey",
+    "zipCode": "1907",
+    "canton": "VS"
+  },
+  {
+    "id": "4000|Gotthelf|BS",
+    "name": "Gotthelf",
+    "zipCode": "4000",
+    "canton": "BS"
+  },
+  {
+    "id": "8274|Gottlieben|TG",
+    "name": "Gottlieben",
+    "zipCode": "8274",
+    "canton": "TG"
+  },
+  {
+    "id": "9225|Gottshaus|TG",
+    "name": "Gottshaus",
+    "zipCode": "9225",
+    "canton": "TG"
+  },
+  {
+    "id": "2552|Gottstatt|BE",
+    "name": "Gottstatt",
+    "zipCode": "2552",
+    "canton": "BE"
+  },
+  {
+    "id": "8400|Gotzenwil|ZH",
+    "name": "Gotzenwil",
+    "zipCode": "8400",
+    "canton": "ZH"
+  },
+  {
+    "id": "1376|Goumoens-la-Ville|VD",
+    "name": "Goumoens-la-Ville",
+    "zipCode": "1376",
+    "canton": "VD"
+  },
+  {
+    "id": "1376|Goumoens-le-Jux|VD",
+    "name": "Goumoens-le-Jux",
+    "zipCode": "1376",
+    "canton": "VD"
+  },
+  {
+    "id": "2354|Goumois|JU",
+    "name": "Goumois",
+    "zipCode": "2354",
+    "canton": "JU"
+  },
+  {
+    "id": "3154|Graben|BE",
+    "name": "Graben",
+    "zipCode": "3154",
+    "canton": "BE"
+  },
+  {
+    "id": "3376|Graben|BE",
+    "name": "Graben",
+    "zipCode": "3376",
+    "canton": "BE"
+  },
+  {
+    "id": "9472|Grabs|SG",
+    "name": "Grabs",
+    "zipCode": "9472",
+    "canton": "SG"
+  },
+  {
+    "id": "9472|Grabserberg|SG",
+    "name": "Grabserberg",
+    "zipCode": "9472",
+    "canton": "SG"
+  },
+  {
+    "id": "3925|Grächen|VS",
+    "name": "Grächen",
+    "zipCode": "3925",
+    "canton": "VS"
+  },
+  {
+    "id": "3045|Grächwil|BE",
+    "name": "Grächwil",
+    "zipCode": "3045",
+    "canton": "BE"
+  },
+  {
+    "id": "6388|Grafenort|OW",
+    "name": "Grafenort",
+    "zipCode": "6388",
+    "canton": "OW"
+  },
+  {
+    "id": "6388|Grafenort|NW",
+    "name": "Grafenort",
+    "zipCode": "6388",
+    "canton": "NW"
+  },
+  {
+    "id": "3308|Grafenried|BE",
+    "name": "Grafenried",
+    "zipCode": "3308",
+    "canton": "BE"
+  },
+  {
+    "id": "8310|Grafstal|ZH",
+    "name": "Grafstal",
+    "zipCode": "8310",
+    "canton": "ZH"
+  },
+  {
+    "id": "8572|Graltshausen|TG",
+    "name": "Graltshausen",
+    "zipCode": "8572",
+    "canton": "TG"
+  },
+  {
+    "id": "9601|Grämigen|SG",
+    "name": "Grämigen",
+    "zipCode": "9601",
+    "canton": "SG"
+  },
+  {
+    "id": "6916|Grancia|TI",
+    "name": "Grancia",
+    "zipCode": "6916",
+    "canton": "TI"
+  },
+  {
+    "id": "1117|Grancy|VD",
+    "name": "Grancy",
+    "zipCode": "1117",
+    "canton": "VD"
+  },
+  {
+    "id": "1052|Grand Mont|VD",
+    "name": "Grand Mont",
+    "zipCode": "1052",
+    "canton": "VD"
+  },
+  {
+    "id": "2127|Grand-Bayard|NE",
+    "name": "Grand-Bayard",
+    "zipCode": "2127",
+    "canton": "NE"
+  },
+  {
+    "id": "1212|Grand-Lancy|GE",
+    "name": "Grand-Lancy",
+    "zipCode": "1212",
+    "canton": "GE"
+  },
+  {
+    "id": "2065|Grand-Savagnier|NE",
+    "name": "Grand-Savagnier",
+    "zipCode": "2065",
+    "canton": "NE"
+  },
+  {
+    "id": "1946|Grand-St-Bernard|VS",
+    "name": "Grand-St-Bernard",
+    "zipCode": "1946",
+    "canton": "VS"
+  },
+  {
+    "id": "1820|Grandchamp|VD",
+    "name": "Grandchamp",
+    "zipCode": "1820",
+    "canton": "VD"
+  },
+  {
+    "id": "1543|Grandcour|VD",
+    "name": "Grandcour",
+    "zipCode": "1543",
+    "canton": "VD"
+  },
+  {
+    "id": "1421|Grandevent|VD",
+    "name": "Grandevent",
+    "zipCode": "1421",
+    "canton": "VD"
+  },
+  {
+    "id": "2908|Grandfontaine|JU",
+    "name": "Grandfontaine",
+    "zipCode": "2908",
+    "canton": "JU"
+  },
+  {
+    "id": "2923|Grandgourt|JU",
+    "name": "Grandgourt",
+    "zipCode": "2923",
+    "canton": "JU"
+  },
+  {
+    "id": "1775|Grandsivaz|FR",
+    "name": "Grandsivaz",
+    "zipCode": "1775",
+    "canton": "FR"
+  },
+  {
+    "id": "1422|Grandson|VD",
+    "name": "Grandson",
+    "zipCode": "1422",
+    "canton": "VD"
+  },
+  {
+    "id": "2745|Grandval|BE",
+    "name": "Grandval",
+    "zipCode": "2745",
+    "canton": "BE"
+  },
+  {
+    "id": "1091|Grandvaux|VD",
+    "name": "Grandvaux",
+    "zipCode": "1091",
+    "canton": "VD"
+  },
+  {
+    "id": "1666|Grandvillard|FR",
+    "name": "Grandvillard",
+    "zipCode": "1666",
+    "canton": "FR"
+  },
+  {
+    "id": "3977|Granges|VS",
+    "name": "Granges",
+    "zipCode": "3977",
+    "canton": "VS"
+  },
+  {
+    "id": "1614|Granges (Veveyse)|FR",
+    "name": "Granges (Veveyse)",
+    "zipCode": "1614",
+    "canton": "FR"
+  },
+  {
+    "id": "1484|Granges-de-Vesin|FR",
+    "name": "Granges-de-Vesin",
+    "zipCode": "1484",
+    "canton": "FR"
+  },
+  {
+    "id": "1763|Granges-Paccot|FR",
+    "name": "Granges-Paccot",
+    "zipCode": "1763",
+    "canton": "FR"
+  },
+  {
+    "id": "1523|Granges-près-Marnand|VD",
+    "name": "Granges-près-Marnand",
+    "zipCode": "1523",
+    "canton": "VD"
+  },
+  {
+    "id": "1552|Granges-sous-Trey|VD",
+    "name": "Granges-sous-Trey",
+    "zipCode": "1552",
+    "canton": "VD"
+  },
+  {
+    "id": "1686|Grangettes|FR",
+    "name": "Grangettes",
+    "zipCode": "1686",
+    "canton": "FR"
+  },
+  {
+    "id": "5722|Gränichen|AG",
+    "name": "Gränichen",
+    "zipCode": "5722",
+    "canton": "AG"
+  },
+  {
+    "id": "1965|Granois|VS",
+    "name": "Granois",
+    "zipCode": "1965",
+    "canton": "VS"
+  },
+  {
+    "id": "8415|Gräslikon|ZH",
+    "name": "Gräslikon",
+    "zipCode": "8415",
+    "canton": "ZH"
+  },
+  {
+    "id": "3365|Grasswil|BE",
+    "name": "Grasswil",
+    "zipCode": "3365",
+    "canton": "BE"
+  },
+  {
+    "id": "1624|Grattavache|FR",
+    "name": "Grattavache",
+    "zipCode": "1624",
+    "canton": "FR"
+  },
+  {
+    "id": "3325|Grauenstein|BE",
+    "name": "Grauenstein",
+    "zipCode": "3325",
+    "canton": "BE"
+  },
+  {
+    "id": "6929|Gravesano|TI",
+    "name": "Gravesano",
+    "zipCode": "6929",
+    "canton": "TI"
+  },
+  {
+    "id": "3983|Greich|VS",
+    "name": "Greich",
+    "zipCode": "3983",
+    "canton": "VS"
+  },
+  {
+    "id": "8606|Greifensee|ZH",
+    "name": "Greifensee",
+    "zipCode": "8606",
+    "canton": "ZH"
+  },
+  {
+    "id": "4203|Grellingen|BL",
+    "name": "Grellingen",
+    "zipCode": "4203",
+    "canton": "BL"
+  },
+  {
+    "id": "2540|Grenchen|SO",
+    "name": "Grenchen",
+    "zipCode": "2540",
+    "canton": "SO"
+  },
+  {
+    "id": "2540|Grenchenberg|SO",
+    "name": "Grenchenberg",
+    "zipCode": "2540",
+    "canton": "SO"
+  },
+  {
+    "id": "3280|Greng|FR",
+    "name": "Greng",
+    "zipCode": "3280",
+    "canton": "FR"
+  },
+  {
+    "id": "3993|Grengiols|VS",
+    "name": "Grengiols",
+    "zipCode": "3993",
+    "canton": "VS"
+  },
+  {
+    "id": "1726|Grenilles|FR",
+    "name": "Grenilles",
+    "zipCode": "1726",
+    "canton": "FR"
+  },
+  {
+    "id": "1274|Grens|VD",
+    "name": "Grens",
+    "zipCode": "1274",
+    "canton": "VD"
+  },
+  {
+    "id": "6404|Greppen|LU",
+    "name": "Greppen",
+    "zipCode": "6404",
+    "canton": "LU"
+  },
+  {
+    "id": "6611|Gresso|TI",
+    "name": "Gresso",
+    "zipCode": "6611",
+    "canton": "TI"
+  },
+  {
+    "id": "1432|Gressy|VD",
+    "name": "Gressy",
+    "zipCode": "1432",
+    "canton": "VD"
+  },
+  {
+    "id": "9479|Gretschins|SG",
+    "name": "Gretschins",
+    "zipCode": "9479",
+    "canton": "SG"
+  },
+  {
+    "id": "5014|Gretzenbach|SO",
+    "name": "Gretzenbach",
+    "zipCode": "5014",
+    "canton": "SO"
+  },
+  {
+    "id": "6747|Gribbio|TI",
+    "name": "Gribbio",
+    "zipCode": "6747",
+    "canton": "TI"
+  },
+  {
+    "id": "3723|Griesalp|BE",
+    "name": "Griesalp",
+    "zipCode": "3723",
+    "canton": "BE"
+  },
+  {
+    "id": "3454|Griesbach|BE",
+    "name": "Griesbach",
+    "zipCode": "3454",
+    "canton": "BE"
+  },
+  {
+    "id": "8514|Griesenberg|TG",
+    "name": "Griesenberg",
+    "zipCode": "8514",
+    "canton": "TG"
+  },
+  {
+    "id": "3961|Grimentz|VS",
+    "name": "Grimentz",
+    "zipCode": "3961",
+    "canton": "VS"
+  },
+  {
+    "id": "1971|Grimisuat|VS",
+    "name": "Grimisuat",
+    "zipCode": "1971",
+    "canton": "VS"
+  },
+  {
+    "id": "3757|Grimmialp|BE",
+    "name": "Grimmialp",
+    "zipCode": "3757",
+    "canton": "BE"
+  },
+  {
+    "id": "3864|Grimselpass|VS",
+    "name": "Grimselpass",
+    "zipCode": "3864",
+    "canton": "VS"
+  },
+  {
+    "id": "4247|Grindel|SO",
+    "name": "Grindel",
+    "zipCode": "4247",
+    "canton": "SO"
+  },
+  {
+    "id": "3818|Grindelwald|BE",
+    "name": "Grindelwald",
+    "zipCode": "3818",
+    "canton": "BE"
+  },
+  {
+    "id": "3266|Grissenberg|BE",
+    "name": "Grissenberg",
+    "zipCode": "3266",
+    "canton": "BE"
+  },
+  {
+    "id": "4658|Grod|SO",
+    "name": "Grod",
+    "zipCode": "4658",
+    "canton": "SO"
+  },
+  {
+    "id": "1772|Grolley|FR",
+    "name": "Grolley",
+    "zipCode": "1772",
+    "canton": "FR"
+  },
+  {
+    "id": "3979|Grône|VS",
+    "name": "Grône",
+    "zipCode": "3979",
+    "canton": "VS"
+  },
+  {
+    "id": "6537|Grono|GR",
+    "name": "Grono",
+    "zipCode": "6537",
+    "canton": "GR"
+  },
+  {
+    "id": "8841|Gross|SZ",
+    "name": "Gross",
+    "zipCode": "8841",
+    "canton": "SZ"
+  },
+  {
+    "id": "3257|Grossaffoltern|BE",
+    "name": "Grossaffoltern",
+    "zipCode": "3257",
+    "canton": "BE"
+  },
+  {
+    "id": "8896|Grossberg|SG",
+    "name": "Grossberg",
+    "zipCode": "8896",
+    "canton": "SG"
+  },
+  {
+    "id": "6146|Grossdietwil|LU",
+    "name": "Grossdietwil",
+    "zipCode": "6146",
+    "canton": "LU"
+  },
+  {
+    "id": "1792|Grossguschelmuth|FR",
+    "name": "Grossguschelmuth",
+    "zipCode": "1792",
+    "canton": "FR"
+  },
+  {
+    "id": "3506|Grosshöchstetten|BE",
+    "name": "Grosshöchstetten",
+    "zipCode": "3506",
+    "canton": "BE"
+  },
+  {
+    "id": "3175|Grossried (Ueberstorf)|FR",
+    "name": "Grossried (Ueberstorf)",
+    "zipCode": "3175",
+    "canton": "FR"
+  },
+  {
+    "id": "6074|Grossteil|OW",
+    "name": "Grossteil",
+    "zipCode": "6074",
+    "canton": "OW"
+  },
+  {
+    "id": "6022|Grosswangen|LU",
+    "name": "Grosswangen",
+    "zipCode": "6022",
+    "canton": "LU"
+  },
+  {
+    "id": "9035|Grub|AR",
+    "name": "Grub",
+    "zipCode": "9035",
+    "canton": "AR"
+  },
+  {
+    "id": "9036|Grub|SG",
+    "name": "Grub",
+    "zipCode": "9036",
+    "canton": "SG"
+  },
+  {
+    "id": "3946|Gruben|VS",
+    "name": "Gruben",
+    "zipCode": "3946",
+    "canton": "VS"
+  },
+  {
+    "id": "3770|Grubenwald|BE",
+    "name": "Grubenwald",
+    "zipCode": "3770",
+    "canton": "BE"
+  },
+  {
+    "id": "1955|Grugnay|VS",
+    "name": "Grugnay",
+    "zipCode": "1955",
+    "canton": "VS"
+  },
+  {
+    "id": "3783|Grund bei Gstaad|BE",
+    "name": "Grund bei Gstaad",
+    "zipCode": "3783",
+    "canton": "BE"
+  },
+  {
+    "id": "8554|Grüneck|TG",
+    "name": "Grüneck",
+    "zipCode": "8554",
+    "canton": "TG"
+  },
+  {
+    "id": "3455|Grünen|BE",
+    "name": "Grünen",
+    "zipCode": "3455",
+    "canton": "BE"
+  },
+  {
+    "id": "3452|Grünenmatt|BE",
+    "name": "Grünenmatt",
+    "zipCode": "3452",
+    "canton": "BE"
+  },
+  {
+    "id": "8627|Grüningen|ZH",
+    "name": "Grüningen",
+    "zipCode": "8627",
+    "canton": "ZH"
+  },
+  {
+    "id": "7214|Grüsch|GR",
+    "name": "Grüsch",
+    "zipCode": "7214",
+    "canton": "GR"
+  },
+  {
+    "id": "8624|Grüt|ZH",
+    "name": "Grüt",
+    "zipCode": "8624",
+    "canton": "ZH"
+  },
+  {
+    "id": "8400|Grütze|ZH",
+    "name": "Grütze",
+    "zipCode": "8400",
+    "canton": "ZH"
+  },
+  {
+    "id": "1663|Gruyères|FR",
+    "name": "Gruyères",
+    "zipCode": "1663",
+    "canton": "FR"
+  },
+  {
+    "id": "1882|Gryon|VD",
+    "name": "Gryon",
+    "zipCode": "1882",
+    "canton": "VD"
+  },
+  {
+    "id": "3933|Gspon|VS",
+    "name": "Gspon",
+    "zipCode": "3933",
+    "canton": "VS"
+  },
+  {
+    "id": "3780|Gstaad|BE",
+    "name": "Gstaad",
+    "zipCode": "3780",
+    "canton": "BE"
+  },
+  {
+    "id": "3785|Gsteig bei Gstaad|BE",
+    "name": "Gsteig bei Gstaad",
+    "zipCode": "3785",
+    "canton": "BE"
+  },
+  {
+    "id": "3814|Gsteigwiler|BE",
+    "name": "Gsteigwiler",
+    "zipCode": "3814",
+    "canton": "BE"
+  },
+  {
+    "id": "7545|Guarda|GR",
+    "name": "Guarda",
+    "zipCode": "7545",
+    "canton": "GR"
+  },
+  {
+    "id": "6515|Gudo|TI",
+    "name": "Gudo",
+    "zipCode": "6515",
+    "canton": "TI"
+  },
+  {
+    "id": "1920|Gueuroz|VS",
+    "name": "Gueuroz",
+    "zipCode": "1920",
+    "canton": "VS"
+  },
+  {
+    "id": "1787|Guévaux|VD",
+    "name": "Guévaux",
+    "zipCode": "1787",
+    "canton": "VD"
+  },
+  {
+    "id": "3158|Guggisberg|BE",
+    "name": "Guggisberg",
+    "zipCode": "3158",
+    "canton": "BE"
+  },
+  {
+    "id": "8127|Guldenen|ZH",
+    "name": "Guldenen",
+    "zipCode": "8127",
+    "canton": "ZH"
+  },
+  {
+    "id": "1643|Gumefens|FR",
+    "name": "Gumefens",
+    "zipCode": "1643",
+    "canton": "FR"
+  },
+  {
+    "id": "3073|Gümligen|BE",
+    "name": "Gümligen",
+    "zipCode": "3073",
+    "canton": "BE"
+  },
+  {
+    "id": "3205|Gümmenen|BE",
+    "name": "Gümmenen",
+    "zipCode": "3205",
+    "canton": "BE"
+  },
+  {
+    "id": "4000|Gundeldingen|BS",
+    "name": "Gundeldingen",
+    "zipCode": "4000",
+    "canton": "BS"
+  },
+  {
+    "id": "8507|Gündelhart|TG",
+    "name": "Gündelhart",
+    "zipCode": "8507",
+    "canton": "TG"
+  },
+  {
+    "id": "8543|Gundetswil|ZH",
+    "name": "Gundetswil",
+    "zipCode": "8543",
+    "canton": "ZH"
+  },
+  {
+    "id": "8322|Gündisau|ZH",
+    "name": "Gündisau",
+    "zipCode": "8322",
+    "canton": "ZH"
+  },
+  {
+    "id": "8543|Gündlikon|ZH",
+    "name": "Gündlikon",
+    "zipCode": "8543",
+    "canton": "ZH"
+  },
+  {
+    "id": "3815|Gündlischwand|BE",
+    "name": "Gündlischwand",
+    "zipCode": "3815",
+    "canton": "BE"
+  },
+  {
+    "id": "6276|Güniken|LU",
+    "name": "Güniken",
+    "zipCode": "6276",
+    "canton": "LU"
+  },
+  {
+    "id": "4524|Günsberg|SO",
+    "name": "Günsberg",
+    "zipCode": "4524",
+    "canton": "SO"
+  },
+  {
+    "id": "8468|Guntalingen|ZH",
+    "name": "Guntalingen",
+    "zipCode": "8468",
+    "canton": "ZH"
+  },
+  {
+    "id": "3654|Gunten|BE",
+    "name": "Gunten",
+    "zipCode": "3654",
+    "canton": "BE"
+  },
+  {
+    "id": "8564|Gunterschwil|TG",
+    "name": "Gunterschwil",
+    "zipCode": "8564",
+    "canton": "TG"
+  },
+  {
+    "id": "8357|Guntershausen bei Aadorf|TG",
+    "name": "Guntershausen bei Aadorf",
+    "zipCode": "8357",
+    "canton": "TG"
+  },
+  {
+    "id": "8572|Guntershausen bei Birwinken|TG",
+    "name": "Guntershausen bei Birwinken",
+    "zipCode": "8572",
+    "canton": "TG"
+  },
+  {
+    "id": "8223|Guntmadingen|SH",
+    "name": "Guntmadingen",
+    "zipCode": "8223",
+    "canton": "SH"
+  },
+  {
+    "id": "4617|Gunzgen|SO",
+    "name": "Gunzgen",
+    "zipCode": "4617",
+    "canton": "SO"
+  },
+  {
+    "id": "6222|Gunzwil|LU",
+    "name": "Gunzwil",
+    "zipCode": "6222",
+    "canton": "LU"
+  },
+  {
+    "id": "3208|Gurbrü|BE",
+    "name": "Gurbrü",
+    "zipCode": "3208",
+    "canton": "BE"
+  },
+  {
+    "id": "3212|Gurmels|FR",
+    "name": "Gurmels",
+    "zipCode": "3212",
+    "canton": "FR"
+  },
+  {
+    "id": "3099|Gurnigel|BE",
+    "name": "Gurnigel",
+    "zipCode": "3099",
+    "canton": "BE"
+  },
+  {
+    "id": "9620|Gurtberg|SG",
+    "name": "Gurtberg",
+    "zipCode": "9620",
+    "canton": "SG"
+  },
+  {
+    "id": "3084|Gurten Kulm|BE",
+    "name": "Gurten Kulm",
+    "zipCode": "3084",
+    "canton": "BE"
+  },
+  {
+    "id": "6482|Gurtnellen|UR",
+    "name": "Gurtnellen",
+    "zipCode": "6482",
+    "canton": "UR"
+  },
+  {
+    "id": "3663|Gurzelen|BE",
+    "name": "Gurzelen",
+    "zipCode": "3663",
+    "canton": "BE"
+  },
+  {
+    "id": "1792|Guschelmuth|FR",
+    "name": "Guschelmuth",
+    "zipCode": "1792",
+    "canton": "FR"
+  },
+  {
+    "id": "4932|Gutenburg|BE",
+    "name": "Gutenburg",
+    "zipCode": "4932",
+    "canton": "BE"
+  },
+  {
+    "id": "8605|Gutenswil|ZH",
+    "name": "Gutenswil",
+    "zipCode": "8605",
+    "canton": "ZH"
+  },
+  {
+    "id": "8478|Gütighausen|ZH",
+    "name": "Gütighausen",
+    "zipCode": "8478",
+    "canton": "ZH"
+  },
+  {
+    "id": "3864|Guttannen|BE",
+    "name": "Guttannen",
+    "zipCode": "3864",
+    "canton": "BE"
+  },
+  {
+    "id": "3956|Guttet|VS",
+    "name": "Guttet",
+    "zipCode": "3956",
+    "canton": "VS"
+  },
+  {
+    "id": "8594|Güttingen|TG",
+    "name": "Güttingen",
+    "zipCode": "8594",
+    "canton": "TG"
+  },
+  {
+    "id": "3645|Gwatt|BE",
+    "name": "Gwatt",
+    "zipCode": "3645",
+    "canton": "BE"
+  },
+  {
+    "id": "3645|Gwattstutz|BE",
+    "name": "Gwattstutz",
+    "zipCode": "3645",
+    "canton": "BE"
+  },
+  {
+    "id": "1251|Gy|GE",
+    "name": "Gy",
+    "zipCode": "1251",
+    "canton": "GE"
+  },
+  {
+    "id": "3503|Gysenstein|BE",
+    "name": "Gysenstein",
+    "zipCode": "3503",
+    "canton": "BE"
+  },
+  {
+    "id": "2545|Haag|SO",
+    "name": "Haag",
+    "zipCode": "2545",
+    "canton": "SO"
+  },
+  {
+    "id": "9469|Haag|SG",
+    "name": "Haag",
+    "zipCode": "9469",
+    "canton": "SG"
+  },
+  {
+    "id": "3804|Habkern|BE",
+    "name": "Habkern",
+    "zipCode": "3804",
+    "canton": "BE"
+  },
+  {
+    "id": "5245|Habsburg|AG",
+    "name": "Habsburg",
+    "zipCode": "5245",
+    "canton": "AG"
+  },
+  {
+    "id": "6166|Habschwanden|LU",
+    "name": "Habschwanden",
+    "zipCode": "6166",
+    "canton": "LU"
+  },
+  {
+    "id": "3065|Habstetten|BE",
+    "name": "Habstetten",
+    "zipCode": "3065",
+    "canton": "BE"
+  },
+  {
+    "id": "8340|Hadlikon|ZH",
+    "name": "Hadlikon",
+    "zipCode": "8340",
+    "canton": "ZH"
+  },
+  {
+    "id": "4445|Häfelfingen|BL",
+    "name": "Häfelfingen",
+    "zipCode": "4445",
+    "canton": "BL"
+  },
+  {
+    "id": "9052|Hag|AR",
+    "name": "Hag",
+    "zipCode": "9052",
+    "canton": "AR"
+  },
+  {
+    "id": "8523|Hagenbuch|ZH",
+    "name": "Hagenbuch",
+    "zipCode": "8523",
+    "canton": "ZH"
+  },
+  {
+    "id": "4614|Hägendorf|SO",
+    "name": "Hägendorf",
+    "zipCode": "4614",
+    "canton": "SO"
+  },
+  {
+    "id": "6332|Hagendorn|ZG",
+    "name": "Hagendorn",
+    "zipCode": "6332",
+    "canton": "ZG"
+  },
+  {
+    "id": "5317|Hagenfirst|AG",
+    "name": "Hagenfirst",
+    "zipCode": "5317",
+    "canton": "AG"
+  },
+  {
+    "id": "8577|Hagenwil am Nollen|TG",
+    "name": "Hagenwil am Nollen",
+    "zipCode": "8577",
+    "canton": "TG"
+  },
+  {
+    "id": "8580|Hagenwil bei Amriswil|TG",
+    "name": "Hagenwil bei Amriswil",
+    "zipCode": "8580",
+    "canton": "TG"
+  },
+  {
+    "id": "9312|Häggenschwil|SG",
+    "name": "Häggenschwil",
+    "zipCode": "9312",
+    "canton": "SG"
+  },
+  {
+    "id": "5607|Hägglingen|AG",
+    "name": "Hägglingen",
+    "zipCode": "5607",
+    "canton": "AG"
+  },
+  {
+    "id": "2575|Hagneck|BE",
+    "name": "Hagneck",
+    "zipCode": "2575",
+    "canton": "BE"
+  },
+  {
+    "id": "8309|Hakab|ZH",
+    "name": "Hakab",
+    "zipCode": "8309",
+    "canton": "ZH"
+  },
+  {
+    "id": "9032|Halden|SG",
+    "name": "Halden",
+    "zipCode": "9032",
+    "canton": "SG"
+  },
+  {
+    "id": "9223|Halden|TG",
+    "name": "Halden",
+    "zipCode": "9223",
+    "canton": "TG"
+  },
+  {
+    "id": "7023|Haldenstein|GR",
+    "name": "Haldenstein",
+    "zipCode": "7023",
+    "canton": "GR"
+  },
+  {
+    "id": "6469|Haldi bei Schattdorf|UR",
+    "name": "Haldi bei Schattdorf",
+    "zipCode": "6469",
+    "canton": "UR"
+  },
+  {
+    "id": "9548|Halingen|TG",
+    "name": "Halingen",
+    "zipCode": "9548",
+    "canton": "TG"
+  },
+  {
+    "id": "8215|Hallau|SH",
+    "name": "Hallau",
+    "zipCode": "8215",
+    "canton": "SH"
+  },
+  {
+    "id": "5705|Hallwil|AG",
+    "name": "Hallwil",
+    "zipCode": "5705",
+    "canton": "AG"
+  },
+  {
+    "id": "4566|Halten|SO",
+    "name": "Halten",
+    "zipCode": "4566",
+    "canton": "SO"
+  },
+  {
+    "id": "9035|Halten|AR",
+    "name": "Halten",
+    "zipCode": "9035",
+    "canton": "AR"
+  },
+  {
+    "id": "9035|Halten|SG",
+    "name": "Halten",
+    "zipCode": "9035",
+    "canton": "SG"
+  },
+  {
+    "id": "6289|Hämikon|LU",
+    "name": "Hämikon",
+    "zipCode": "6289",
+    "canton": "LU"
+  },
+  {
+    "id": "3508|Hämlismatt|BE",
+    "name": "Hämlismatt",
+    "zipCode": "3508",
+    "canton": "BE"
+  },
+  {
+    "id": "3864|Handegg|BE",
+    "name": "Handegg",
+    "zipCode": "3864",
+    "canton": "BE"
+  },
+  {
+    "id": "8585|Happerswil|TG",
+    "name": "Happerswil",
+    "zipCode": "8585",
+    "canton": "TG"
+  },
+  {
+    "id": "3054|Hard|BE",
+    "name": "Hard",
+    "zipCode": "3054",
+    "canton": "BE"
+  },
+  {
+    "id": "9463|Hard|SG",
+    "name": "Hard",
+    "zipCode": "9463",
+    "canton": "SG"
+  },
+  {
+    "id": "3250|Hardern|BE",
+    "name": "Hardern",
+    "zipCode": "3250",
+    "canton": "BE"
+  },
+  {
+    "id": "8553|Harenwilen|TG",
+    "name": "Harenwilen",
+    "zipCode": "8553",
+    "canton": "TG"
+  },
+  {
+    "id": "4624|Härkingen|SO",
+    "name": "Härkingen",
+    "zipCode": "4624",
+    "canton": "SO"
+  },
+  {
+    "id": "3612|Hartlisberg|BE",
+    "name": "Hartlisberg",
+    "zipCode": "3612",
+    "canton": "BE"
+  },
+  {
+    "id": "8965|Hasenberg|AG",
+    "name": "Hasenberg",
+    "zipCode": "8965",
+    "canton": "AG"
+  },
+  {
+    "id": "8342|Hasenstrick|ZH",
+    "name": "Hasenstrick",
+    "zipCode": "8342",
+    "canton": "ZH"
+  },
+  {
+    "id": "6166|Hasle|LU",
+    "name": "Hasle",
+    "zipCode": "6166",
+    "canton": "LU"
+  },
+  {
+    "id": "3415|Hasle bei Burgdorf|BE",
+    "name": "Hasle bei Burgdorf",
+    "zipCode": "3415",
+    "canton": "BE"
+  },
+  {
+    "id": "3415|Hasle-Rüegsau|BE",
+    "name": "Hasle-Rüegsau",
+    "zipCode": "3415",
+    "canton": "BE"
+  },
+  {
+    "id": "8773|Haslen|GL",
+    "name": "Haslen",
+    "zipCode": "8773",
+    "canton": "GL"
+  },
+  {
+    "id": "9054|Haslen|AI",
+    "name": "Haslen",
+    "zipCode": "9054",
+    "canton": "AI"
+  },
+  {
+    "id": "3132|Hasli|BE",
+    "name": "Hasli",
+    "zipCode": "3132",
+    "canton": "BE"
+  },
+  {
+    "id": "8554|Hasli|TG",
+    "name": "Hasli",
+    "zipCode": "8554",
+    "canton": "TG"
+  },
+  {
+    "id": "6085|Hasliberg|BE",
+    "name": "Hasliberg",
+    "zipCode": "6085",
+    "canton": "BE"
+  },
+  {
+    "id": "8156|Hasliberg|ZH",
+    "name": "Hasliberg",
+    "zipCode": "8156",
+    "canton": "ZH"
+  },
+  {
+    "id": "8580|Hatswil|TG",
+    "name": "Hatswil",
+    "zipCode": "8580",
+    "canton": "TG"
+  },
+  {
+    "id": "8564|Hattenhausen|TG",
+    "name": "Hattenhausen",
+    "zipCode": "8564",
+    "canton": "TG"
+  },
+  {
+    "id": "8775|Hätzingen|GL",
+    "name": "Hätzingen",
+    "zipCode": "8775",
+    "canton": "GL"
+  },
+  {
+    "id": "4633|Hauenstein|SO",
+    "name": "Hauenstein",
+    "zipCode": "4633",
+    "canton": "SO"
+  },
+  {
+    "id": "9426|Haufen|AR",
+    "name": "Haufen",
+    "zipCode": "9426",
+    "canton": "AR"
+  },
+  {
+    "id": "8926|Hauptikon|ZH",
+    "name": "Hauptikon",
+    "zipCode": "8926",
+    "canton": "ZH"
+  },
+  {
+    "id": "9213|Hauptwil|TG",
+    "name": "Hauptwil",
+    "zipCode": "9213",
+    "canton": "TG"
+  },
+  {
+    "id": "5212|Hausen (AG)|AG",
+    "name": "Hausen (AG)",
+    "zipCode": "5212",
+    "canton": "AG"
+  },
+  {
+    "id": "8915|Hausen am Albis|ZH",
+    "name": "Hausen am Albis",
+    "zipCode": "8915",
+    "canton": "ZH"
+  },
+  {
+    "id": "8475|Hausen bei Ossingen|ZH",
+    "name": "Hausen bei Ossingen",
+    "zipCode": "8475",
+    "canton": "ZH"
+  },
+  {
+    "id": "3463|Häusermoos im Emmental|BE",
+    "name": "Häusermoos im Emmental",
+    "zipCode": "3463",
+    "canton": "BE"
+  },
+  {
+    "id": "8554|Häusern|TG",
+    "name": "Häusern",
+    "zipCode": "8554",
+    "canton": "TG"
+  },
+  {
+    "id": "8522|Häuslenen|TG",
+    "name": "Häuslenen",
+    "zipCode": "8522",
+    "canton": "TG"
+  },
+  {
+    "id": "1789|Haut-Vully|FR",
+    "name": "Haut-Vully",
+    "zipCode": "1789",
+    "canton": "FR"
+  },
+  {
+    "id": "1997|Haute-Nendaz|VS",
+    "name": "Haute-Nendaz",
+    "zipCode": "1997",
+    "canton": "VS"
+  },
+  {
+    "id": "2068|Hauterive|NE",
+    "name": "Hauterive",
+    "zipCode": "2068",
+    "canton": "NE"
+  },
+  {
+    "id": "1648|Hauteville|FR",
+    "name": "Hauteville",
+    "zipCode": "1648",
+    "canton": "FR"
+  },
+  {
+    "id": "1800|Hauteville (Vevey)|VD",
+    "name": "Hauteville (Vevey)",
+    "zipCode": "1800",
+    "canton": "VD"
+  },
+  {
+    "id": "3510|Häutligen|BE",
+    "name": "Häutligen",
+    "zipCode": "3510",
+    "canton": "BE"
+  },
+  {
+    "id": "8908|Hedingen|ZH",
+    "name": "Hedingen",
+    "zipCode": "8908",
+    "canton": "ZH"
+  },
+  {
+    "id": "9435|Heerbrugg|SG",
+    "name": "Heerbrugg",
+    "zipCode": "9435",
+    "canton": "SG"
+  },
+  {
+    "id": "8564|Hefenhausen|TG",
+    "name": "Hefenhausen",
+    "zipCode": "8564",
+    "canton": "TG"
+  },
+  {
+    "id": "8580|Hefenhofen|TG",
+    "name": "Hefenhofen",
+    "zipCode": "8580",
+    "canton": "TG"
+  },
+  {
+    "id": "3202|Heggidorn|BE",
+    "name": "Heggidorn",
+    "zipCode": "3202",
+    "canton": "BE"
+  },
+  {
+    "id": "8400|Hegi|ZH",
+    "name": "Hegi",
+    "zipCode": "8400",
+    "canton": "ZH"
+  },
+  {
+    "id": "8604|Hegnau|ZH",
+    "name": "Hegnau",
+    "zipCode": "8604",
+    "canton": "ZH"
+  },
+  {
+    "id": "9410|Heiden|AR",
+    "name": "Heiden",
+    "zipCode": "9410",
+    "canton": "AR"
+  },
+  {
+    "id": "3625|Heiligenschwendi|BE",
+    "name": "Heiligenschwendi",
+    "zipCode": "3625",
+    "canton": "BE"
+  },
+  {
+    "id": "6166|Heiligkreuz|LU",
+    "name": "Heiligkreuz",
+    "zipCode": "6166",
+    "canton": "LU"
+  },
+  {
+    "id": "8888|Heiligkreuz|SG",
+    "name": "Heiligkreuz",
+    "zipCode": "8888",
+    "canton": "SG"
+  },
+  {
+    "id": "9000|Heiligkreuz|SG",
+    "name": "Heiligkreuz",
+    "zipCode": "9000",
+    "canton": "SG"
+  },
+  {
+    "id": "9515|Heiligkreuz|TG",
+    "name": "Heiligkreuz",
+    "zipCode": "9515",
+    "canton": "TG"
+  },
+  {
+    "id": "3627|Heimberg|BE",
+    "name": "Heimberg",
+    "zipCode": "3627",
+    "canton": "BE"
+  },
+  {
+    "id": "3373|Heimenhausen|BE",
+    "name": "Heimenhausen",
+    "zipCode": "3373",
+    "canton": "BE"
+  },
+  {
+    "id": "8586|Heimenhofen|TG",
+    "name": "Heimenhofen",
+    "zipCode": "8586",
+    "canton": "TG"
+  },
+  {
+    "id": "3615|Heimenschwand|BE",
+    "name": "Heimenschwand",
+    "zipCode": "3615",
+    "canton": "BE"
+  },
+  {
+    "id": "3453|Heimisbach|BE",
+    "name": "Heimisbach",
+    "zipCode": "3453",
+    "canton": "BE"
+  },
+  {
+    "id": "3412|Heimiswil|BE",
+    "name": "Heimiswil",
+    "zipCode": "3412",
+    "canton": "BE"
+  },
+  {
+    "id": "4558|Heinrichswil|SO",
+    "name": "Heinrichswil",
+    "zipCode": "4558",
+    "canton": "SO"
+  },
+  {
+    "id": "8915|Heisch|ZH",
+    "name": "Heisch",
+    "zipCode": "8915",
+    "canton": "ZH"
+  },
+  {
+    "id": "1714|Heitenried|FR",
+    "name": "Heitenried",
+    "zipCode": "1714",
+    "canton": "FR"
+  },
+  {
+    "id": "8957|Heitersberg|AG",
+    "name": "Heitersberg",
+    "zipCode": "8957",
+    "canton": "AG"
+  },
+  {
+    "id": "9545|Heiterschen|TG",
+    "name": "Heiterschen",
+    "zipCode": "9545",
+    "canton": "TG"
+  },
+  {
+    "id": "9630|Heiterswil|SG",
+    "name": "Heiterswil",
+    "zipCode": "9630",
+    "canton": "SG"
+  },
+  {
+    "id": "3186|Heitiwil|FR",
+    "name": "Heitiwil",
+    "zipCode": "3186",
+    "canton": "FR"
+  },
+  {
+    "id": "9216|Heldswil|TG",
+    "name": "Heldswil",
+    "zipCode": "9216",
+    "canton": "TG"
+  },
+  {
+    "id": "3155|Helgisried|BE",
+    "name": "Helgisried",
+    "zipCode": "3155",
+    "canton": "BE"
+  },
+  {
+    "id": "6016|Hellbühl|LU",
+    "name": "Hellbühl",
+    "zipCode": "6016",
+    "canton": "LU"
+  },
+  {
+    "id": "4316|Hellikon|AG",
+    "name": "Hellikon",
+    "zipCode": "4316",
+    "canton": "AG"
+  },
+  {
+    "id": "3429|Hellsau|BE",
+    "name": "Hellsau",
+    "zipCode": "3429",
+    "canton": "BE"
+  },
+  {
+    "id": "9313|Helmishueb|TG",
+    "name": "Helmishueb",
+    "zipCode": "9313",
+    "canton": "TG"
+  },
+  {
+    "id": "8558|Helsighausen|TG",
+    "name": "Helsighausen",
+    "zipCode": "8558",
+    "canton": "TG"
+  },
+  {
+    "id": "9633|Hemberg|SG",
+    "name": "Hemberg",
+    "zipCode": "9633",
+    "canton": "SG"
+  },
+  {
+    "id": "8261|Hemishofen|SH",
+    "name": "Hemishofen",
+    "zipCode": "8261",
+    "canton": "SH"
+  },
+  {
+    "id": "8231|Hemmental|SH",
+    "name": "Hemmental",
+    "zipCode": "8231",
+    "canton": "SH"
+  },
+  {
+    "id": "8580|Hemmerswil|TG",
+    "name": "Hemmerswil",
+    "zipCode": "8580",
+    "canton": "TG"
+  },
+  {
+    "id": "4465|Hemmiken|BL",
+    "name": "Hemmiken",
+    "zipCode": "4465",
+    "canton": "BL"
+  },
+  {
+    "id": "9247|Henau|SG",
+    "name": "Henau",
+    "zipCode": "9247",
+    "canton": "SG"
+  },
+  {
+    "id": "5604|Hendschiken|AG",
+    "name": "Hendschiken",
+    "zipCode": "5604",
+    "canton": "AG"
+  },
+  {
+    "id": "8444|Henggart|ZH",
+    "name": "Henggart",
+    "zipCode": "8444",
+    "canton": "ZH"
+  },
+  {
+    "id": "1681|Hennens|FR",
+    "name": "Hennens",
+    "zipCode": "1681",
+    "canton": "FR"
+  },
+  {
+    "id": "1525|Henniez|VD",
+    "name": "Henniez",
+    "zipCode": "1525",
+    "canton": "VD"
+  },
+  {
+    "id": "4715|Herbetswil|SO",
+    "name": "Herbetswil",
+    "zipCode": "4715",
+    "canton": "SO"
+  },
+  {
+    "id": "3671|Herbligen|BE",
+    "name": "Herbligen",
+    "zipCode": "3671",
+    "canton": "BE"
+  },
+  {
+    "id": "8207|Herblingen|SH",
+    "name": "Herblingen",
+    "zipCode": "8207",
+    "canton": "SH"
+  },
+  {
+    "id": "3927|Herbriggen|VS",
+    "name": "Herbriggen",
+    "zipCode": "3927",
+    "canton": "VS"
+  },
+  {
+    "id": "8535|Herdern|TG",
+    "name": "Herdern",
+    "zipCode": "8535",
+    "canton": "TG"
+  },
+  {
+    "id": "1987|Hérémence|VS",
+    "name": "Hérémence",
+    "zipCode": "1987",
+    "canton": "VS"
+  },
+  {
+    "id": "6052|Hergiswil|NW",
+    "name": "Hergiswil",
+    "zipCode": "6052",
+    "canton": "NW"
+  },
+  {
+    "id": "6133|Hergiswil bei Willisau|LU",
+    "name": "Hergiswil bei Willisau",
+    "zipCode": "6133",
+    "canton": "LU"
+  },
+  {
+    "id": "9100|Herisau|AR",
+    "name": "Herisau",
+    "zipCode": "9100",
+    "canton": "AR"
+  },
+  {
+    "id": "6028|Herlisberg|LU",
+    "name": "Herlisberg",
+    "zipCode": "6028",
+    "canton": "LU"
+  },
+  {
+    "id": "1248|Hermance|GE",
+    "name": "Hermance",
+    "zipCode": "1248",
+    "canton": "GE"
+  },
+  {
+    "id": "8330|Hermatswil|ZH",
+    "name": "Hermatswil",
+    "zipCode": "8330",
+    "canton": "ZH"
+  },
+  {
+    "id": "1513|Hermenches|VD",
+    "name": "Hermenches",
+    "zipCode": "1513",
+    "canton": "VD"
+  },
+  {
+    "id": "5626|Hermetschwil-Staffeln|AG",
+    "name": "Hermetschwil-Staffeln",
+    "zipCode": "5626",
+    "canton": "AG"
+  },
+  {
+    "id": "8600|Hermikon|ZH",
+    "name": "Hermikon",
+    "zipCode": "8600",
+    "canton": "ZH"
+  },
+  {
+    "id": "3475|Hermiswil|BE",
+    "name": "Hermiswil",
+    "zipCode": "3475",
+    "canton": "BE"
+  },
+  {
+    "id": "3132|Hermiswil bei Kirchenthurnen|BE",
+    "name": "Hermiswil bei Kirchenthurnen",
+    "zipCode": "3132",
+    "canton": "BE"
+  },
+  {
+    "id": "3274|Hermrigen|BE",
+    "name": "Hermrigen",
+    "zipCode": "3274",
+    "canton": "BE"
+  },
+  {
+    "id": "3503|Herolfingen|BE",
+    "name": "Herolfingen",
+    "zipCode": "3503",
+    "canton": "BE"
+  },
+  {
+    "id": "8585|Herrenhof|TG",
+    "name": "Herrenhof",
+    "zipCode": "8585",
+    "canton": "TG"
+  },
+  {
+    "id": "3037|Herrenschwanden|BE",
+    "name": "Herrenschwanden",
+    "zipCode": "3037",
+    "canton": "BE"
+  },
+  {
+    "id": "8704|Herrliberg|ZH",
+    "name": "Herrliberg",
+    "zipCode": "8704",
+    "canton": "ZH"
+  },
+  {
+    "id": "4423|Hersberg|BL",
+    "name": "Hersberg",
+    "zipCode": "4423",
+    "canton": "BL"
+  },
+  {
+    "id": "8626|Herschmettlen|ZH",
+    "name": "Herschmettlen",
+    "zipCode": "8626",
+    "canton": "ZH"
+  },
+  {
+    "id": "4558|Hersiwil|SO",
+    "name": "Hersiwil",
+    "zipCode": "4558",
+    "canton": "SO"
+  },
+  {
+    "id": "5415|Hertenstein|AG",
+    "name": "Hertenstein",
+    "zipCode": "5415",
+    "canton": "AG"
+  },
+  {
+    "id": "6353|Hertenstein|LU",
+    "name": "Hertenstein",
+    "zipCode": "6353",
+    "canton": "LU"
+  },
+  {
+    "id": "5025|Herzberg|AG",
+    "name": "Herzberg",
+    "zipCode": "5025",
+    "canton": "AG"
+  },
+  {
+    "id": "5027|Herznach|AG",
+    "name": "Herznach",
+    "zipCode": "5027",
+    "canton": "AG"
+  },
+  {
+    "id": "3360|Herzogenbuchsee|BE",
+    "name": "Herzogenbuchsee",
+    "zipCode": "3360",
+    "canton": "BE"
+  },
+  {
+    "id": "3172|Herzwil|BE",
+    "name": "Herzwil",
+    "zipCode": "3172",
+    "canton": "BE"
+  },
+  {
+    "id": "8700|Heslibach|ZH",
+    "name": "Heslibach",
+    "zipCode": "8700",
+    "canton": "ZH"
+  },
+  {
+    "id": "8583|Hessenreuti|TG",
+    "name": "Hessenreuti",
+    "zipCode": "8583",
+    "canton": "TG"
+  },
+  {
+    "id": "4577|Hessigkofen|SO",
+    "name": "Hessigkofen",
+    "zipCode": "4577",
+    "canton": "SO"
+  },
+  {
+    "id": "5317|Hettenschwil|AG",
+    "name": "Hettenschwil",
+    "zipCode": "5317",
+    "canton": "AG"
+  },
+  {
+    "id": "3325|Hettiswil bei Hindelbank|BE",
+    "name": "Hettiswil bei Hindelbank",
+    "zipCode": "3325",
+    "canton": "BE"
+  },
+  {
+    "id": "8442|Hettlingen|ZH",
+    "name": "Hettlingen",
+    "zipCode": "8442",
+    "canton": "ZH"
+  },
+  {
+    "id": "3154|Heubach|BE",
+    "name": "Heubach",
+    "zipCode": "3154",
+    "canton": "BE"
+  },
+  {
+    "id": "8607|Heusberg|ZH",
+    "name": "Heusberg",
+    "zipCode": "8607",
+    "canton": "ZH"
+  },
+  {
+    "id": "3711|Heustrich|BE",
+    "name": "Heustrich",
+    "zipCode": "3711",
+    "canton": "BE"
+  },
+  {
+    "id": "6024|Hildisrieden|LU",
+    "name": "Hildisrieden",
+    "zipCode": "6024",
+    "canton": "LU"
+  },
+  {
+    "id": "6192|Hilfernthal|LU",
+    "name": "Hilfernthal",
+    "zipCode": "6192",
+    "canton": "LU"
+  },
+  {
+    "id": "5613|Hilfikon|AG",
+    "name": "Hilfikon",
+    "zipCode": "5613",
+    "canton": "AG"
+  },
+  {
+    "id": "3652|Hilterfingen|BE",
+    "name": "Hilterfingen",
+    "zipCode": "3652",
+    "canton": "BE"
+  },
+  {
+    "id": "4204|Himmelried|SO",
+    "name": "Himmelried",
+    "zipCode": "4204",
+    "canton": "SO"
+  },
+  {
+    "id": "3324|Hindelbank|BE",
+    "name": "Hindelbank",
+    "zipCode": "3324",
+    "canton": "BE"
+  },
+  {
+    "id": "8806|Hinterbäch|SZ",
+    "name": "Hinterbäch",
+    "zipCode": "8806",
+    "canton": "SZ"
+  },
+  {
+    "id": "8132|Hinteregg|ZH",
+    "name": "Hinteregg",
+    "zipCode": "8132",
+    "canton": "ZH"
+  },
+  {
+    "id": "9452|Hinterforst|SG",
+    "name": "Hinterforst",
+    "zipCode": "9452",
+    "canton": "SG"
+  },
+  {
+    "id": "3089|Hinterfultigen|BE",
+    "name": "Hinterfultigen",
+    "zipCode": "3089",
+    "canton": "BE"
+  },
+  {
+    "id": "8638|Hintergoldingen|SG",
+    "name": "Hintergoldingen",
+    "zipCode": "8638",
+    "canton": "SG"
+  },
+  {
+    "id": "9033|Hinterhof|SG",
+    "name": "Hinterhof",
+    "zipCode": "9033",
+    "canton": "SG"
+  },
+  {
+    "id": "3032|Hinterkappelen|BE",
+    "name": "Hinterkappelen",
+    "zipCode": "3032",
+    "canton": "BE"
+  },
+  {
+    "id": "6260|Hintermoos|LU",
+    "name": "Hintermoos",
+    "zipCode": "6260",
+    "canton": "LU"
+  },
+  {
+    "id": "7438|Hinterrhein|GR",
+    "name": "Hinterrhein",
+    "zipCode": "7438",
+    "canton": "GR"
+  },
+  {
+    "id": "6436|Hinterthal|SZ",
+    "name": "Hinterthal",
+    "zipCode": "6436",
+    "canton": "SZ"
+  },
+  {
+    "id": "4813|Hinterwil|AG",
+    "name": "Hinterwil",
+    "zipCode": "4813",
+    "canton": "AG"
+  },
+  {
+    "id": "8340|Hinwil|ZH",
+    "name": "Hinwil",
+    "zipCode": "8340",
+    "canton": "ZH"
+  },
+  {
+    "id": "9464|Hirschensprung|SG",
+    "name": "Hirschensprung",
+    "zipCode": "9464",
+    "canton": "SG"
+  },
+  {
+    "id": "3153|Hirschhorn|BE",
+    "name": "Hirschhorn",
+    "zipCode": "3153",
+    "canton": "BE"
+  },
+  {
+    "id": "3158|Hirschmatt|BE",
+    "name": "Hirschmatt",
+    "zipCode": "3158",
+    "canton": "BE"
+  },
+  {
+    "id": "5042|Hirschthal|AG",
+    "name": "Hirschthal",
+    "zipCode": "5042",
+    "canton": "AG"
+  },
+  {
+    "id": "8000|Hirslanden|ZH",
+    "name": "Hirslanden",
+    "zipCode": "8000",
+    "canton": "ZH"
+  },
+  {
+    "id": "3715|Hirzboden|BE",
+    "name": "Hirzboden",
+    "zipCode": "3715",
+    "canton": "BE"
+  },
+  {
+    "id": "4000|Hirzbrunnen|BS",
+    "name": "Hirzbrunnen",
+    "zipCode": "4000",
+    "canton": "BS"
+  },
+  {
+    "id": "8816|Hirzel|ZH",
+    "name": "Hirzel",
+    "zipCode": "8816",
+    "canton": "ZH"
+  },
+  {
+    "id": "8636|Hittenberg|ZH",
+    "name": "Hittenberg",
+    "zipCode": "8636",
+    "canton": "ZH"
+  },
+  {
+    "id": "8335|Hittnau|ZH",
+    "name": "Hittnau",
+    "zipCode": "8335",
+    "canton": "ZH"
+  },
+  {
+    "id": "6285|Hitzkirch|LU",
+    "name": "Hitzkirch",
+    "zipCode": "6285",
+    "canton": "LU"
+  },
+  {
+    "id": "8842|Hoch-Ybrig|SZ",
+    "name": "Hoch-Ybrig",
+    "zipCode": "8842",
+    "canton": "SZ"
+  },
+  {
+    "id": "6280|Hochdorf|LU",
+    "name": "Hochdorf",
+    "zipCode": "6280",
+    "canton": "LU"
+  },
+  {
+    "id": "8182|Hochfelden|ZH",
+    "name": "Hochfelden",
+    "zipCode": "8182",
+    "canton": "ZH"
+  },
+  {
+    "id": "3429|Höchstetten|BE",
+    "name": "Höchstetten",
+    "zipCode": "3429",
+    "canton": "BE"
+  },
+  {
+    "id": "4146|Hochwald|SO",
+    "name": "Hochwald",
+    "zipCode": "4146",
+    "canton": "SO"
+  },
+  {
+    "id": "8893|Hochwiese|SG",
+    "name": "Hochwiese",
+    "zipCode": "8893",
+    "canton": "SG"
+  },
+  {
+    "id": "8304|Hof|ZH",
+    "name": "Hof",
+    "zipCode": "8304",
+    "canton": "ZH"
+  },
+  {
+    "id": "8590|Hof|TG",
+    "name": "Hof",
+    "zipCode": "8590",
+    "canton": "TG"
+  },
+  {
+    "id": "9404|Hof|SG",
+    "name": "Hof",
+    "zipCode": "9404",
+    "canton": "SG"
+  },
+  {
+    "id": "8730|Hof bei Uznach|SG",
+    "name": "Hof bei Uznach",
+    "zipCode": "8730",
+    "canton": "SG"
+  },
+  {
+    "id": "3631|Höfen|BE",
+    "name": "Höfen",
+    "zipCode": "3631",
+    "canton": "BE"
+  },
+  {
+    "id": "4943|Hofen|BE",
+    "name": "Hofen",
+    "zipCode": "4943",
+    "canton": "BE"
+  },
+  {
+    "id": "8242|Hofen|SH",
+    "name": "Hofen",
+    "zipCode": "8242",
+    "canton": "SH"
+  },
+  {
+    "id": "8370|Hofen bei Sirnach|TG",
+    "name": "Hofen bei Sirnach",
+    "zipCode": "8370",
+    "canton": "TG"
+  },
+  {
+    "id": "9114|Hoffeld|SG",
+    "name": "Hoffeld",
+    "zipCode": "9114",
+    "canton": "SG"
+  },
+  {
+    "id": "6154|Hofstatt|LU",
+    "name": "Hofstatt",
+    "zipCode": "6154",
+    "canton": "LU"
+  },
+  {
+    "id": "4114|Hofstetten|SO",
+    "name": "Hofstetten",
+    "zipCode": "4114",
+    "canton": "SO"
+  },
+  {
+    "id": "8154|Hofstetten|ZH",
+    "name": "Hofstetten",
+    "zipCode": "8154",
+    "canton": "ZH"
+  },
+  {
+    "id": "8354|Hofstetten (ZH)|ZH",
+    "name": "Hofstetten (ZH)",
+    "zipCode": "8354",
+    "canton": "ZH"
+  },
+  {
+    "id": "3858|Hofstetten bei Brienz|BE",
+    "name": "Hofstetten bei Brienz",
+    "zipCode": "3858",
+    "canton": "BE"
+  },
+  {
+    "id": "3053|Hofwil|BE",
+    "name": "Hofwil",
+    "zipCode": "3053",
+    "canton": "BE"
+  },
+  {
+    "id": "6276|Hohenrain|LU",
+    "name": "Hohenrain",
+    "zipCode": "6276",
+    "canton": "LU"
+  },
+  {
+    "id": "9216|Hohentannen|TG",
+    "name": "Hohentannen",
+    "zipCode": "9216",
+    "canton": "TG"
+  },
+  {
+    "id": "6083|Hohfluh|BE",
+    "name": "Hohfluh",
+    "zipCode": "6083",
+    "canton": "BE"
+  },
+  {
+    "id": "9404|Hohriet|SG",
+    "name": "Hohriet",
+    "zipCode": "9404",
+    "canton": "SG"
+  },
+  {
+    "id": "3949|Hohtenn|VS",
+    "name": "Hohtenn",
+    "zipCode": "3949",
+    "canton": "VS"
+  },
+  {
+    "id": "4718|Holderbank|SO",
+    "name": "Holderbank",
+    "zipCode": "4718",
+    "canton": "SO"
+  },
+  {
+    "id": "5113|Holderbank|AG",
+    "name": "Holderbank",
+    "zipCode": "5113",
+    "canton": "AG"
+  },
+  {
+    "id": "4434|Hölstein|BL",
+    "name": "Hölstein",
+    "zipCode": "4434",
+    "canton": "BL"
+  },
+  {
+    "id": "8590|Holzenstein|TG",
+    "name": "Holzenstein",
+    "zipCode": "8590",
+    "canton": "TG"
+  },
+  {
+    "id": "6343|Holzhäusern|ZG",
+    "name": "Holzhäusern",
+    "zipCode": "6343",
+    "canton": "ZG"
+  },
+  {
+    "id": "8558|Holzhäusern|TG",
+    "name": "Holzhäusern",
+    "zipCode": "8558",
+    "canton": "TG"
+  },
+  {
+    "id": "5043|Holziken|AG",
+    "name": "Holziken",
+    "zipCode": "5043",
+    "canton": "AG"
+  },
+  {
+    "id": "3902|Holzji|VS",
+    "name": "Holzji",
+    "zipCode": "3902",
+    "canton": "VS"
+  },
+  {
+    "id": "8360|Holzmannshaus|TG",
+    "name": "Holzmannshaus",
+    "zipCode": "8360",
+    "canton": "TG"
+  },
+  {
+    "id": "3622|Homberg|BE",
+    "name": "Homberg",
+    "zipCode": "3622",
+    "canton": "BE"
+  },
+  {
+    "id": "8634|Hombrechtikon|ZH",
+    "name": "Hombrechtikon",
+    "zipCode": "8634",
+    "canton": "ZH"
+  },
+  {
+    "id": "8508|Homburg|TG",
+    "name": "Homburg",
+    "zipCode": "8508",
+    "canton": "TG"
+  },
+  {
+    "id": "6038|Honau|LU",
+    "name": "Honau",
+    "zipCode": "6038",
+    "canton": "LU"
+  },
+  {
+    "id": "3702|Hondrich|BE",
+    "name": "Hondrich",
+    "zipCode": "3702",
+    "canton": "BE"
+  },
+  {
+    "id": "4712|Höngen|SO",
+    "name": "Höngen",
+    "zipCode": "4712",
+    "canton": "SO"
+  },
+  {
+    "id": "8000|Höngg|ZH",
+    "name": "Höngg",
+    "zipCode": "8000",
+    "canton": "ZH"
+  },
+  {
+    "id": "8524|Horben bei Frauenfeld|TG",
+    "name": "Horben bei Frauenfeld",
+    "zipCode": "8524",
+    "canton": "TG"
+  },
+  {
+    "id": "8308|Horben bei Illnau|ZH",
+    "name": "Horben bei Illnau",
+    "zipCode": "8308",
+    "canton": "ZH"
+  },
+  {
+    "id": "8372|Horben bei Sirnach|TG",
+    "name": "Horben bei Sirnach",
+    "zipCode": "8372",
+    "canton": "TG"
+  },
+  {
+    "id": "3755|Horboden|BE",
+    "name": "Horboden",
+    "zipCode": "3755",
+    "canton": "BE"
+  },
+  {
+    "id": "8810|Horgen|ZH",
+    "name": "Horgen",
+    "zipCode": "8810",
+    "canton": "ZH"
+  },
+  {
+    "id": "8500|Horgenbach|TG",
+    "name": "Horgenbach",
+    "zipCode": "8500",
+    "canton": "TG"
+  },
+  {
+    "id": "8815|Horgenberg|ZH",
+    "name": "Horgenberg",
+    "zipCode": "8815",
+    "canton": "ZH"
+  },
+  {
+    "id": "8507|Hörhausen|TG",
+    "name": "Hörhausen",
+    "zipCode": "8507",
+    "canton": "TG"
+  },
+  {
+    "id": "8181|Höri|ZH",
+    "name": "Höri",
+    "zipCode": "8181",
+    "canton": "ZH"
+  },
+  {
+    "id": "9326|Horn|TG",
+    "name": "Horn",
+    "zipCode": "9326",
+    "canton": "TG"
+  },
+  {
+    "id": "5075|Hornussen|AG",
+    "name": "Hornussen",
+    "zipCode": "5075",
+    "canton": "AG"
+  },
+  {
+    "id": "3623|Horrenbach|BE",
+    "name": "Horrenbach",
+    "zipCode": "3623",
+    "canton": "BE"
+  },
+  {
+    "id": "4557|Horriwil|SO",
+    "name": "Horriwil",
+    "zipCode": "4557",
+    "canton": "SO"
+  },
+  {
+    "id": "6048|Horw|LU",
+    "name": "Horw",
+    "zipCode": "6048",
+    "canton": "LU"
+  },
+  {
+    "id": "9515|Hosenruck|TG",
+    "name": "Hosenruck",
+    "zipCode": "9515",
+    "canton": "TG"
+  },
+  {
+    "id": "6493|Hospental|UR",
+    "name": "Hospental",
+    "zipCode": "6493",
+    "canton": "UR"
+  },
+  {
+    "id": "8000|Hottingen|ZH",
+    "name": "Hottingen",
+    "zipCode": "8000",
+    "canton": "ZH"
+  },
+  {
+    "id": "5277|Hottwil|AG",
+    "name": "Hottwil",
+    "zipCode": "5277",
+    "canton": "AG"
+  },
+  {
+    "id": "8637|Hub|ZH",
+    "name": "Hub",
+    "zipCode": "8637",
+    "canton": "ZH"
+  },
+  {
+    "id": "6133|Hübeli|LU",
+    "name": "Hübeli",
+    "zipCode": "6133",
+    "canton": "LU"
+  },
+  {
+    "id": "8500|Huben|TG",
+    "name": "Huben",
+    "zipCode": "8500",
+    "canton": "TG"
+  },
+  {
+    "id": "4535|Hubersdorf|SO",
+    "name": "Hubersdorf",
+    "zipCode": "4535",
+    "canton": "SO"
+  },
+  {
+    "id": "8590|Hueb|TG",
+    "name": "Hueb",
+    "zipCode": "8590",
+    "canton": "TG"
+  },
+  {
+    "id": "9402|Hueb bei Mörschwil|SG",
+    "name": "Hueb bei Mörschwil",
+    "zipCode": "9402",
+    "canton": "SG"
+  },
+  {
+    "id": "1884|Huémoz|VD",
+    "name": "Huémoz",
+    "zipCode": "1884",
+    "canton": "VD"
+  },
+  {
+    "id": "8565|Hugelshofen|TG",
+    "name": "Hugelshofen",
+    "zipCode": "8565",
+    "canton": "TG"
+  },
+  {
+    "id": "8354|Huggenberg|ZH",
+    "name": "Huggenberg",
+    "zipCode": "8354",
+    "canton": "ZH"
+  },
+  {
+    "id": "4245|Huggerwald|SO",
+    "name": "Huggerwald",
+    "zipCode": "4245",
+    "canton": "SO"
+  },
+  {
+    "id": "8457|Humlikon|ZH",
+    "name": "Humlikon",
+    "zipCode": "8457",
+    "canton": "ZH"
+  },
+  {
+    "id": "9064|Hundwil|AR",
+    "name": "Hundwil",
+    "zipCode": "9064",
+    "canton": "AR"
+  },
+  {
+    "id": "6331|Hünenberg|ZG",
+    "name": "Hünenberg",
+    "zipCode": "6331",
+    "canton": "ZG"
+  },
+  {
+    "id": "8599|Hungerbüel|TG",
+    "name": "Hungerbüel",
+    "zipCode": "8599",
+    "canton": "TG"
+  },
+  {
+    "id": "3626|Hünibach|BE",
+    "name": "Hünibach",
+    "zipCode": "3626",
+    "canton": "BE"
+  },
+  {
+    "id": "4554|Hüniken|SO",
+    "name": "Hüniken",
+    "zipCode": "4554",
+    "canton": "SO"
+  },
+  {
+    "id": "8412|Hünikon|ZH",
+    "name": "Hünikon",
+    "zipCode": "8412",
+    "canton": "ZH"
+  },
+  {
+    "id": "8194|Hüntwangen|ZH",
+    "name": "Hüntwangen",
+    "zipCode": "8194",
+    "canton": "ZH"
+  },
+  {
+    "id": "5502|Hunzenschwil|AG",
+    "name": "Hunzenschwil",
+    "zipCode": "5502",
+    "canton": "AG"
+  },
+  {
+    "id": "9545|Hunzikon|TG",
+    "name": "Hunzikon",
+    "zipCode": "9545",
+    "canton": "TG"
+  },
+  {
+    "id": "8640|Hurden|SZ",
+    "name": "Hurden",
+    "zipCode": "8640",
+    "canton": "SZ"
+  },
+  {
+    "id": "8360|Hurnen|TG",
+    "name": "Hurnen",
+    "zipCode": "8360",
+    "canton": "TG"
+  },
+  {
+    "id": "3860|Hüsen|BE",
+    "name": "Hüsen",
+    "zipCode": "3860",
+    "canton": "BE"
+  },
+  {
+    "id": "6152|Hüswil|LU",
+    "name": "Hüswil",
+    "zipCode": "6152",
+    "canton": "LU"
+  },
+  {
+    "id": "8825|Hütten|ZH",
+    "name": "Hütten",
+    "zipCode": "8825",
+    "canton": "ZH"
+  },
+  {
+    "id": "8115|Hüttikon|ZH",
+    "name": "Hüttikon",
+    "zipCode": "8115",
+    "canton": "ZH"
+  },
+  {
+    "id": "8553|Hüttlingen|TG",
+    "name": "Hüttlingen",
+    "zipCode": "8553",
+    "canton": "TG"
+  },
+  {
+    "id": "4950|Huttwil|BE",
+    "name": "Huttwil",
+    "zipCode": "4950",
+    "canton": "BE"
+  },
+  {
+    "id": "8536|Hüttwilen|TG",
+    "name": "Hüttwilen",
+    "zipCode": "8536",
+    "canton": "TG"
+  },
+  {
+    "id": "8488|Hutzikon|ZH",
+    "name": "Hutzikon",
+    "zipCode": "8488",
+    "canton": "ZH"
+  },
+  {
+    "id": "6438|Ibach|SZ",
+    "name": "Ibach",
+    "zipCode": "6438",
+    "canton": "SZ"
+  },
+  {
+    "id": "8400|Iberg|ZH",
+    "name": "Iberg",
+    "zipCode": "8400",
+    "canton": "ZH"
+  },
+  {
+    "id": "8843|Ibergeregg|SZ",
+    "name": "Ibergeregg",
+    "zipCode": "8843",
+    "canton": "SZ"
+  },
+  {
+    "id": "4571|Ichertswil|SO",
+    "name": "Ichertswil",
+    "zipCode": "4571",
+    "canton": "SO"
+  },
+  {
+    "id": "1977|Icogne|VS",
+    "name": "Icogne",
+    "zipCode": "1977",
+    "canton": "VS"
+  },
+  {
+    "id": "4633|Ifenthal|SO",
+    "name": "Ifenthal",
+    "zipCode": "4633",
+    "canton": "SO"
+  },
+  {
+    "id": "3305|Iffwil|BE",
+    "name": "Iffwil",
+    "zipCode": "3305",
+    "canton": "BE"
+  },
+  {
+    "id": "8362|Ifwil|TG",
+    "name": "Ifwil",
+    "zipCode": "8362",
+    "canton": "TG"
+  },
+  {
+    "id": "7206|Igis|GR",
+    "name": "Igis",
+    "zipCode": "7206",
+    "canton": "GR"
+  },
+  {
+    "id": "7130|Ilanz|GR",
+    "name": "Ilanz",
+    "zipCode": "7130",
+    "canton": "GR"
+  },
+  {
+    "id": "3550|Ilfis|BE",
+    "name": "Ilfis",
+    "zipCode": "3550",
+    "canton": "BE"
+  },
+  {
+    "id": "1893|Illarsaz|VS",
+    "name": "Illarsaz",
+    "zipCode": "1893",
+    "canton": "VS"
+  },
+  {
+    "id": "6434|Illgau|SZ",
+    "name": "Illgau",
+    "zipCode": "6434",
+    "canton": "SZ"
+  },
+  {
+    "id": "8556|Illhart|TG",
+    "name": "Illhart",
+    "zipCode": "8556",
+    "canton": "TG"
+  },
+  {
+    "id": "8574|Illighausen|TG",
+    "name": "Illighausen",
+    "zipCode": "8574",
+    "canton": "TG"
+  },
+  {
+    "id": "3033|Illiswil|BE",
+    "name": "Illiswil",
+    "zipCode": "3033",
+    "canton": "BE"
+  },
+  {
+    "id": "8308|Illnau|ZH",
+    "name": "Illnau",
+    "zipCode": "8308",
+    "canton": "ZH"
+  },
+  {
+    "id": "1656|Im Fang|FR",
+    "name": "Im Fang",
+    "zipCode": "1656",
+    "canton": "FR"
+  },
+  {
+    "id": "4514|Im Holz|SO",
+    "name": "Im Holz",
+    "zipCode": "4514",
+    "canton": "SO"
+  },
+  {
+    "id": "6405|Immensee|SZ",
+    "name": "Immensee",
+    "zipCode": "6405",
+    "canton": "SZ"
+  },
+  {
+    "id": "6571|Indemini|TI",
+    "name": "Indemini",
+    "zipCode": "6571",
+    "canton": "TI"
+  },
+  {
+    "id": "3953|Inden|VS",
+    "name": "Inden",
+    "zipCode": "3953",
+    "canton": "VS"
+  },
+  {
+    "id": "6440|Ingenbohl|SZ",
+    "name": "Ingenbohl",
+    "zipCode": "6440",
+    "canton": "SZ"
+  },
+  {
+    "id": "3375|Inkwil|BE",
+    "name": "Inkwil",
+    "zipCode": "3375",
+    "canton": "BE"
+  },
+  {
+    "id": "7050|Innerarosa|GR",
+    "name": "Innerarosa",
+    "zipCode": "7050",
+    "canton": "GR"
+  },
+  {
+    "id": "3044|Innerberg|BE",
+    "name": "Innerberg",
+    "zipCode": "3044",
+    "canton": "BE"
+  },
+  {
+    "id": "3619|Innereriz|BE",
+    "name": "Innereriz",
+    "zipCode": "3619",
+    "canton": "BE"
+  },
+  {
+    "id": "7445|Innerferrera|GR",
+    "name": "Innerferrera",
+    "zipCode": "7445",
+    "canton": "GR"
+  },
+  {
+    "id": "8858|Innerthal|SZ",
+    "name": "Innerthal",
+    "zipCode": "8858",
+    "canton": "SZ"
+  },
+  {
+    "id": "3862|Innertkirchen|BE",
+    "name": "Innertkirchen",
+    "zipCode": "3862",
+    "canton": "BE"
+  },
+  {
+    "id": "7134|Innertobel|GR",
+    "name": "Innertobel",
+    "zipCode": "7134",
+    "canton": "GR"
+  },
+  {
+    "id": "3232|Ins|BE",
+    "name": "Ins",
+    "zipCode": "3232",
+    "canton": "BE"
+  },
+  {
+    "id": "6951|Insone|TI",
+    "name": "Insone",
+    "zipCode": "6951",
+    "canton": "TI"
+  },
+  {
+    "id": "3800|Interlaken|BE",
+    "name": "Interlaken",
+    "zipCode": "3800",
+    "canton": "BE"
+  },
+  {
+    "id": "6655|Intragna|TI",
+    "name": "Intragna",
+    "zipCode": "6655",
+    "canton": "TI"
+  },
+  {
+    "id": "6476|Intschi|UR",
+    "name": "Intschi",
+    "zipCode": "6476",
+    "canton": "UR"
+  },
+  {
+    "id": "6034|Inwil|LU",
+    "name": "Inwil",
+    "zipCode": "6034",
+    "canton": "LU"
+  },
+  {
+    "id": "2563|Ipsach|BE",
+    "name": "Ipsach",
+    "zipCode": "2563",
+    "canton": "BE"
+  },
+  {
+    "id": "6707|Iragna|TI",
+    "name": "Iragna",
+    "zipCode": "6707",
+    "canton": "TI"
+  },
+  {
+    "id": "8330|Irgenhausen|ZH",
+    "name": "Irgenhausen",
+    "zipCode": "8330",
+    "canton": "ZH"
+  },
+  {
+    "id": "4000|Iselin|BS",
+    "name": "Iselin",
+    "zipCode": "4000",
+    "canton": "BS"
+  },
+  {
+    "id": "8524|Iselisberg|TG",
+    "name": "Iselisberg",
+    "zipCode": "8524",
+    "canton": "TG"
+  },
+  {
+    "id": "3807|Iseltwald|BE",
+    "name": "Iseltwald",
+    "zipCode": "3807",
+    "canton": "BE"
+  },
+  {
+    "id": "5637|Isenbergschwil|AG",
+    "name": "Isenbergschwil",
+    "zipCode": "5637",
+    "canton": "AG"
+  },
+  {
+    "id": "3822|Isenfluh|BE",
+    "name": "Isenfluh",
+    "zipCode": "3822",
+    "canton": "BE"
+  },
+  {
+    "id": "6461|Isenthal|UR",
+    "name": "Isenthal",
+    "zipCode": "6461",
+    "canton": "UR"
+  },
+  {
+    "id": "6993|Iseo|TI",
+    "name": "Iseo",
+    "zipCode": "6993",
+    "canton": "TI"
+  },
+  {
+    "id": "1914|Isérables|VS",
+    "name": "Isérables",
+    "zipCode": "1914",
+    "canton": "VS"
+  },
+  {
+    "id": "8335|Isikon|ZH",
+    "name": "Isikon",
+    "zipCode": "8335",
+    "canton": "ZH"
+  },
+  {
+    "id": "6466|Isleten|UR",
+    "name": "Isleten",
+    "zipCode": "6466",
+    "canton": "UR"
+  },
+  {
+    "id": "8546|Islikon|TG",
+    "name": "Islikon",
+    "zipCode": "8546",
+    "canton": "TG"
+  },
+  {
+    "id": "8905|Islisberg|AG",
+    "name": "Islisberg",
+    "zipCode": "8905",
+    "canton": "AG"
+  },
+  {
+    "id": "6614|Isole di Brissago|TI",
+    "name": "Isole di Brissago",
+    "zipCode": "6614",
+    "canton": "TI"
+  },
+  {
+    "id": "6810|Isone|TI",
+    "name": "Isone",
+    "zipCode": "6810",
+    "canton": "TI"
+  },
+  {
+    "id": "1937|Issert|VS",
+    "name": "Issert",
+    "zipCode": "1937",
+    "canton": "VS"
+  },
+  {
+    "id": "8575|Istighofen|TG",
+    "name": "Istighofen",
+    "zipCode": "8575",
+    "canton": "TG"
+  },
+  {
+    "id": "8362|Itaslen|TG",
+    "name": "Itaslen",
+    "zipCode": "8362",
+    "canton": "TG"
+  },
+  {
+    "id": "4452|Itingen|BL",
+    "name": "Itingen",
+    "zipCode": "4452",
+    "canton": "BL"
+  },
+  {
+    "id": "3818|Itramen|BE",
+    "name": "Itramen",
+    "zipCode": "3818",
+    "canton": "BE"
+  },
+  {
+    "id": "3979|Itravers|VS",
+    "name": "Itravers",
+    "zipCode": "3979",
+    "canton": "VS"
+  },
+  {
+    "id": "8700|Itschnach|ZH",
+    "name": "Itschnach",
+    "zipCode": "8700",
+    "canton": "ZH"
+  },
+  {
+    "id": "1308|Ittens|VD",
+    "name": "Ittens",
+    "zipCode": "1308",
+    "canton": "VD"
+  },
+  {
+    "id": "5083|Ittenthal|AG",
+    "name": "Ittenthal",
+    "zipCode": "5083",
+    "canton": "AG"
+  },
+  {
+    "id": "3063|Ittigen|BE",
+    "name": "Ittigen",
+    "zipCode": "3063",
+    "canton": "BE"
+  },
+  {
+    "id": "8627|Itzikon|ZH",
+    "name": "Itzikon",
+    "zipCode": "8627",
+    "canton": "ZH"
+  },
+  {
+    "id": "3629|Jaberg|BE",
+    "name": "Jaberg",
+    "zipCode": "3629",
+    "canton": "BE"
+  },
+  {
+    "id": "9108|Jakobsbad|AI",
+    "name": "Jakobsbad",
+    "zipCode": "9108",
+    "canton": "AI"
+  },
+  {
+    "id": "9545|Jakobstal|TG",
+    "name": "Jakobstal",
+    "zipCode": "9545",
+    "canton": "TG"
+  },
+  {
+    "id": "8354|Jakobsthal|ZH",
+    "name": "Jakobsthal",
+    "zipCode": "8354",
+    "canton": "ZH"
+  },
+  {
+    "id": "3673|Jassbach|BE",
+    "name": "Jassbach",
+    "zipCode": "3673",
+    "canton": "BE"
+  },
+  {
+    "id": "1656|Jaun|FR",
+    "name": "Jaun",
+    "zipCode": "1656",
+    "canton": "FR"
+  },
+  {
+    "id": "3303|Jegenstorf|BE",
+    "name": "Jegenstorf",
+    "zipCode": "3303",
+    "canton": "BE"
+  },
+  {
+    "id": "3945|Jeizinen|VS",
+    "name": "Jeizinen",
+    "zipCode": "3945",
+    "canton": "VS"
+  },
+  {
+    "id": "7233|Jenaz|GR",
+    "name": "Jenaz",
+    "zipCode": "7233",
+    "canton": "GR"
+  },
+  {
+    "id": "7307|Jenins|GR",
+    "name": "Jenins",
+    "zipCode": "7307",
+    "canton": "GR"
+  },
+  {
+    "id": "7494|Jenisberg|GR",
+    "name": "Jenisberg",
+    "zipCode": "7494",
+    "canton": "GR"
+  },
+  {
+    "id": "2565|Jens|BE",
+    "name": "Jens",
+    "zipCode": "2565",
+    "canton": "BE"
+  },
+  {
+    "id": "3208|Jerisberg|BE",
+    "name": "Jerisberg",
+    "zipCode": "3208",
+    "canton": "BE"
+  },
+  {
+    "id": "3208|Jerisberghof|BE",
+    "name": "Jerisberghof",
+    "zipCode": "3208",
+    "canton": "BE"
+  },
+  {
+    "id": "3186|Jetschwil|FR",
+    "name": "Jetschwil",
+    "zipCode": "3186",
+    "canton": "FR"
+  },
+  {
+    "id": "3038|Jetzikofen|BE",
+    "name": "Jetzikofen",
+    "zipCode": "3038",
+    "canton": "BE"
+  },
+  {
+    "id": "1793|Jeuss|FR",
+    "name": "Jeuss",
+    "zipCode": "1793",
+    "canton": "FR"
+  },
+  {
+    "id": "8645|Jona|SG",
+    "name": "Jona",
+    "zipCode": "8645",
+    "canton": "SG"
+  },
+  {
+    "id": "8916|Jonen|AG",
+    "name": "Jonen",
+    "zipCode": "8916",
+    "canton": "AG"
+  },
+  {
+    "id": "1805|Jongny|VD",
+    "name": "Jongny",
+    "zipCode": "1805",
+    "canton": "VD"
+  },
+  {
+    "id": "9243|Jonschwil|SG",
+    "name": "Jonschwil",
+    "zipCode": "9243",
+    "canton": "SG"
+  },
+  {
+    "id": "1833|Jor|VD",
+    "name": "Jor",
+    "zipCode": "1833",
+    "canton": "VD"
+  },
+  {
+    "id": "1789|Joressens|FR",
+    "name": "Joressens",
+    "zipCode": "1789",
+    "canton": "FR"
+  },
+  {
+    "id": "1008|Jouxtens|VD",
+    "name": "Jouxtens",
+    "zipCode": "1008",
+    "canton": "VD"
+  },
+  {
+    "id": "3036|Jucher|BE",
+    "name": "Jucher",
+    "zipCode": "3036",
+    "canton": "BE"
+  },
+  {
+    "id": "3204|Juchlishaus|BE",
+    "name": "Juchlishaus",
+    "zipCode": "3204",
+    "canton": "BE"
+  },
+  {
+    "id": "3476|Juchten|BE",
+    "name": "Juchten",
+    "zipCode": "3476",
+    "canton": "BE"
+  },
+  {
+    "id": "8493|Juckeren|ZH",
+    "name": "Juckeren",
+    "zipCode": "8493",
+    "canton": "ZH"
+  },
+  {
+    "id": "7448|Juf|GR",
+    "name": "Juf",
+    "zipCode": "7448",
+    "canton": "GR"
+  },
+  {
+    "id": "7457|Julierpass|GR",
+    "name": "Julierpass",
+    "zipCode": "7457",
+    "canton": "GR"
+  },
+  {
+    "id": "3801|Jungfraujoch|BE",
+    "name": "Jungfraujoch",
+    "zipCode": "3801",
+    "canton": "BE"
+  },
+  {
+    "id": "1326|Juriens|VD",
+    "name": "Juriens",
+    "zipCode": "1326",
+    "canton": "VD"
+  },
+  {
+    "id": "1254|Jussy|GE",
+    "name": "Jussy",
+    "zipCode": "1254",
+    "canton": "GE"
+  },
+  {
+    "id": "1254|Jussy-le-Château|GE",
+    "name": "Jussy-le-Château",
+    "zipCode": "1254",
+    "canton": "GE"
+  },
+  {
+    "id": "6056|Kägiswil|OW",
+    "name": "Kägiswil",
+    "zipCode": "6056",
+    "canton": "OW"
+  },
+  {
+    "id": "9038|Kaien|AR",
+    "name": "Kaien",
+    "zipCode": "9038",
+    "canton": "AR"
+  },
+  {
+    "id": "4303|Kaiseraugst|AG",
+    "name": "Kaiseraugst",
+    "zipCode": "4303",
+    "canton": "AG"
+  },
+  {
+    "id": "5466|Kaiserstuhl|AG",
+    "name": "Kaiserstuhl",
+    "zipCode": "5466",
+    "canton": "AG"
+  },
+  {
+    "id": "6078|Kaiserstuhl|OW",
+    "name": "Kaiserstuhl",
+    "zipCode": "6078",
+    "canton": "OW"
+  },
+  {
+    "id": "5082|Kaisten|AG",
+    "name": "Kaisten",
+    "zipCode": "5082",
+    "canton": "AG"
+  },
+  {
+    "id": "3415|Kalchofen|BE",
+    "name": "Kalchofen",
+    "zipCode": "3415",
+    "canton": "BE"
+  },
+  {
+    "id": "8536|Kalchrain|TG",
+    "name": "Kalchrain",
+    "zipCode": "8536",
+    "canton": "TG"
+  },
+  {
+    "id": "5625|Kallern|AG",
+    "name": "Kallern",
+    "zipCode": "5625",
+    "canton": "AG"
+  },
+  {
+    "id": "3283|Kallnach|BE",
+    "name": "Kallnach",
+    "zipCode": "3283",
+    "canton": "BE"
+  },
+  {
+    "id": "3922|Kalpetran|VS",
+    "name": "Kalpetran",
+    "zipCode": "3922",
+    "canton": "VS"
+  },
+  {
+    "id": "3413|Kaltacker|BE",
+    "name": "Kaltacker",
+    "zipCode": "3413",
+    "canton": "BE"
+  },
+  {
+    "id": "6212|Kaltbach|LU",
+    "name": "Kaltbach",
+    "zipCode": "6212",
+    "canton": "LU"
+  },
+  {
+    "id": "8722|Kaltbrunn|SG",
+    "name": "Kaltbrunn",
+    "zipCode": "8722",
+    "canton": "SG"
+  },
+  {
+    "id": "8259|Kaltenbach|TG",
+    "name": "Kaltenbach",
+    "zipCode": "8259",
+    "canton": "TG"
+  },
+  {
+    "id": "8514|Kaltenbrunnen|TG",
+    "name": "Kaltenbrunnen",
+    "zipCode": "8514",
+    "canton": "TG"
+  },
+  {
+    "id": "9508|Kalthäusern|TG",
+    "name": "Kalthäusern",
+    "zipCode": "9508",
+    "canton": "TG"
+  },
+  {
+    "id": "4535|Kammersrohr|SO",
+    "name": "Kammersrohr",
+    "zipCode": "4535",
+    "canton": "SO"
+  },
+  {
+    "id": "3714|Kanderbrück|BE",
+    "name": "Kanderbrück",
+    "zipCode": "3714",
+    "canton": "BE"
+  },
+  {
+    "id": "3716|Kandergrund|BE",
+    "name": "Kandergrund",
+    "zipCode": "3716",
+    "canton": "BE"
+  },
+  {
+    "id": "3718|Kandersteg|BE",
+    "name": "Kandersteg",
+    "zipCode": "3718",
+    "canton": "BE"
+  },
+  {
+    "id": "4447|Känerkinden|BL",
+    "name": "Känerkinden",
+    "zipCode": "4447",
+    "canton": "BL"
+  },
+  {
+    "id": "8810|Käpfnach|ZH",
+    "name": "Käpfnach",
+    "zipCode": "8810",
+    "canton": "ZH"
+  },
+  {
+    "id": "4616|Kappel|SO",
+    "name": "Kappel",
+    "zipCode": "4616",
+    "canton": "SO"
+  },
+  {
+    "id": "8508|Kappel|TG",
+    "name": "Kappel",
+    "zipCode": "8508",
+    "canton": "TG"
+  },
+  {
+    "id": "8926|Kappel am Albis|ZH",
+    "name": "Kappel am Albis",
+    "zipCode": "8926",
+    "canton": "ZH"
+  },
+  {
+    "id": "3273|Kappelen|BE",
+    "name": "Kappelen",
+    "zipCode": "3273",
+    "canton": "BE"
+  },
+  {
+    "id": "3032|Kappelenring|BE",
+    "name": "Kappelenring",
+    "zipCode": "3032",
+    "canton": "BE"
+  },
+  {
+    "id": "3063|Kappelisacker|BE",
+    "name": "Kappelisacker",
+    "zipCode": "3063",
+    "canton": "BE"
+  },
+  {
+    "id": "8532|Kartause Ittingen|TG",
+    "name": "Kartause Ittingen",
+    "zipCode": "8532",
+    "canton": "TG"
+  },
+  {
+    "id": "6086|Käserstatt|BE",
+    "name": "Käserstatt",
+    "zipCode": "6086",
+    "canton": "BE"
+  },
+  {
+    "id": "6047|Kastanienbaum|LU",
+    "name": "Kastanienbaum",
+    "zipCode": "6047",
+    "canton": "LU"
+  },
+  {
+    "id": "8153|Katzenrüti|ZH",
+    "name": "Katzenrüti",
+    "zipCode": "8153",
+    "canton": "ZH"
+  },
+  {
+    "id": "8105|Katzensee|ZH",
+    "name": "Katzensee",
+    "zipCode": "8105",
+    "canton": "ZH"
+  },
+  {
+    "id": "3126|Kaufdorf|BE",
+    "name": "Kaufdorf",
+    "zipCode": "3126",
+    "canton": "BE"
+  },
+  {
+    "id": "8546|Kefikon|ZH",
+    "name": "Kefikon",
+    "zipCode": "8546",
+    "canton": "ZH"
+  },
+  {
+    "id": "8546|Kefikon|TG",
+    "name": "Kefikon",
+    "zipCode": "8546",
+    "canton": "TG"
+  },
+  {
+    "id": "8572|Kehlhof|TG",
+    "name": "Kehlhof",
+    "zipCode": "8572",
+    "canton": "TG"
+  },
+  {
+    "id": "8712|Kehlhof|ZH",
+    "name": "Kehlhof",
+    "zipCode": "8712",
+    "canton": "ZH"
+  },
+  {
+    "id": "3122|Kehrsatz|BE",
+    "name": "Kehrsatz",
+    "zipCode": "3122",
+    "canton": "BE"
+  },
+  {
+    "id": "6365|Kehrsiten|NW",
+    "name": "Kehrsiten",
+    "zipCode": "6365",
+    "canton": "NW"
+  },
+  {
+    "id": "8307|Kemleten|ZH",
+    "name": "Kemleten",
+    "zipCode": "8307",
+    "canton": "ZH"
+  },
+  {
+    "id": "6333|Kemmatten|ZG",
+    "name": "Kemmatten",
+    "zipCode": "6333",
+    "canton": "ZG"
+  },
+  {
+    "id": "6197|Kemmeriboden|BE",
+    "name": "Kemmeriboden",
+    "zipCode": "6197",
+    "canton": "BE"
+  },
+  {
+    "id": "5436|Kempfhof|AG",
+    "name": "Kempfhof",
+    "zipCode": "5436",
+    "canton": "AG"
+  },
+  {
+    "id": "8640|Kempraten|SG",
+    "name": "Kempraten",
+    "zipCode": "8640",
+    "canton": "SG"
+  },
+  {
+    "id": "8623|Kempten|ZH",
+    "name": "Kempten",
+    "zipCode": "8623",
+    "canton": "ZH"
+  },
+  {
+    "id": "8310|Kemptthal|ZH",
+    "name": "Kemptthal",
+    "zipCode": "8310",
+    "canton": "ZH"
+  },
+  {
+    "id": "3309|Kernenried|BE",
+    "name": "Kernenried",
+    "zipCode": "3309",
+    "canton": "BE"
+  },
+  {
+    "id": "6064|Kerns|OW",
+    "name": "Kerns",
+    "zipCode": "6064",
+    "canton": "OW"
+  },
+  {
+    "id": "3210|Kerzers|FR",
+    "name": "Kerzers",
+    "zipCode": "3210",
+    "canton": "FR"
+  },
+  {
+    "id": "8593|Kesswil|TG",
+    "name": "Kesswil",
+    "zipCode": "8593",
+    "canton": "TG"
+  },
+  {
+    "id": "4703|Kestenholz|SO",
+    "name": "Kestenholz",
+    "zipCode": "4703",
+    "canton": "SO"
+  },
+  {
+    "id": "4468|Kienberg|SO",
+    "name": "Kienberg",
+    "zipCode": "4468",
+    "canton": "SO"
+  },
+  {
+    "id": "3628|Kienersrüti|BE",
+    "name": "Kienersrüti",
+    "zipCode": "3628",
+    "canton": "BE"
+  },
+  {
+    "id": "3855|Kienholz|BE",
+    "name": "Kienholz",
+    "zipCode": "3855",
+    "canton": "BE"
+  },
+  {
+    "id": "3723|Kiental|BE",
+    "name": "Kiental",
+    "zipCode": "3723",
+    "canton": "BE"
+  },
+  {
+    "id": "3629|Kiesen|BE",
+    "name": "Kiesen",
+    "zipCode": "3629",
+    "canton": "BE"
+  },
+  {
+    "id": "4496|Kilchberg|BL",
+    "name": "Kilchberg",
+    "zipCode": "4496",
+    "canton": "BL"
+  },
+  {
+    "id": "8802|Kilchberg|ZH",
+    "name": "Kilchberg",
+    "zipCode": "8802",
+    "canton": "ZH"
+  },
+  {
+    "id": "6204|Kilchbühl|LU",
+    "name": "Kilchbühl",
+    "zipCode": "6204",
+    "canton": "LU"
+  },
+  {
+    "id": "8956|Killwangen|AG",
+    "name": "Killwangen",
+    "zipCode": "8956",
+    "canton": "AG"
+  },
+  {
+    "id": "8604|Kindhausen|ZH",
+    "name": "Kindhausen",
+    "zipCode": "8604",
+    "canton": "ZH"
+  },
+  {
+    "id": "8962|Kindhausen|AG",
+    "name": "Kindhausen",
+    "zipCode": "8962",
+    "canton": "AG"
+  },
+  {
+    "id": "3917|Kippel|VS",
+    "name": "Kippel",
+    "zipCode": "3917",
+    "canton": "VS"
+  },
+  {
+    "id": "3422|Kirchberg|BE",
+    "name": "Kirchberg",
+    "zipCode": "3422",
+    "canton": "BE"
+  },
+  {
+    "id": "9533|Kirchberg|SG",
+    "name": "Kirchberg",
+    "zipCode": "9533",
+    "canton": "SG"
+  },
+  {
+    "id": "5225|Kirchbözberg|AG",
+    "name": "Kirchbözberg",
+    "zipCode": "5225",
+    "canton": "AG"
+  },
+  {
+    "id": "8474|Kirchdinhard|ZH",
+    "name": "Kirchdinhard",
+    "zipCode": "8474",
+    "canton": "ZH"
+  },
+  {
+    "id": "3116|Kirchdorf|BE",
+    "name": "Kirchdorf",
+    "zipCode": "3116",
+    "canton": "BE"
+  },
+  {
+    "id": "5416|Kirchdorf|AG",
+    "name": "Kirchdorf",
+    "zipCode": "5416",
+    "canton": "AG"
+  },
+  {
+    "id": "3000|Kirchenfeld|BE",
+    "name": "Kirchenfeld",
+    "zipCode": "3000",
+    "canton": "BE"
+  },
+  {
+    "id": "3128|Kirchenthurnen|BE",
+    "name": "Kirchenthurnen",
+    "zipCode": "3128",
+    "canton": "BE"
+  },
+  {
+    "id": "6060|Kirchhofen|OW",
+    "name": "Kirchhofen",
+    "zipCode": "6060",
+    "canton": "OW"
+  },
+  {
+    "id": "5054|Kirchleerau|AG",
+    "name": "Kirchleerau",
+    "zipCode": "5054",
+    "canton": "AG"
+  },
+  {
+    "id": "3038|Kirchlindach|BE",
+    "name": "Kirchlindach",
+    "zipCode": "3038",
+    "canton": "BE"
+  },
+  {
+    "id": "5044|Kirchrued|AG",
+    "name": "Kirchrued",
+    "zipCode": "5044",
+    "canton": "AG"
+  },
+  {
+    "id": "8585|Klarsreuti|TG",
+    "name": "Klarsreuti",
+    "zipCode": "8585",
+    "canton": "TG"
+  },
+  {
+    "id": "8451|Kleinandelfingen|ZH",
+    "name": "Kleinandelfingen",
+    "zipCode": "8451",
+    "canton": "ZH"
+  },
+  {
+    "id": "8498|Kleinbäretswil|ZH",
+    "name": "Kleinbäretswil",
+    "zipCode": "8498",
+    "canton": "ZH"
+  },
+  {
+    "id": "3213|Kleinbösingen|FR",
+    "name": "Kleinbösingen",
+    "zipCode": "3213",
+    "canton": "FR"
+  },
+  {
+    "id": "4936|Kleindietwil|BE",
+    "name": "Kleindietwil",
+    "zipCode": "4936",
+    "canton": "BE"
+  },
+  {
+    "id": "5314|Kleindöttingen|AG",
+    "name": "Kleindöttingen",
+    "zipCode": "5314",
+    "canton": "AG"
+  },
+  {
+    "id": "3823|Kleine Scheidegg|BE",
+    "name": "Kleine Scheidegg",
+    "zipCode": "3823",
+    "canton": "BE"
+  },
+  {
+    "id": "3205|Kleingümmenen|BE",
+    "name": "Kleingümmenen",
+    "zipCode": "3205",
+    "canton": "BE"
+  },
+  {
+    "id": "3212|Kleingurmels|FR",
+    "name": "Kleingurmels",
+    "zipCode": "3212",
+    "canton": "FR"
+  },
+  {
+    "id": "1792|Kleinguschelmuth|FR",
+    "name": "Kleinguschelmuth",
+    "zipCode": "1792",
+    "canton": "FR"
+  },
+  {
+    "id": "4000|Kleinhüningen|BS",
+    "name": "Kleinhüningen",
+    "zipCode": "4000",
+    "canton": "BS"
+  },
+  {
+    "id": "8312|Kleinikon|ZH",
+    "name": "Kleinikon",
+    "zipCode": "8312",
+    "canton": "ZH"
+  },
+  {
+    "id": "4245|Kleinlützel|SO",
+    "name": "Kleinlützel",
+    "zipCode": "4245",
+    "canton": "SO"
+  },
+  {
+    "id": "6074|Kleinteil|OW",
+    "name": "Kleinteil",
+    "zipCode": "6074",
+    "canton": "OW"
+  },
+  {
+    "id": "4612|Kleinwangen|SO",
+    "name": "Kleinwangen",
+    "zipCode": "4612",
+    "canton": "SO"
+  },
+  {
+    "id": "6277|Kleinwangen|LU",
+    "name": "Kleinwangen",
+    "zipCode": "6277",
+    "canton": "LU"
+  },
+  {
+    "id": "6375|Klewenalp|NW",
+    "name": "Klewenalp",
+    "zipCode": "6375",
+    "canton": "NW"
+  },
+  {
+    "id": "8508|Klingenberg|TG",
+    "name": "Klingenberg",
+    "zipCode": "8508",
+    "canton": "TG"
+  },
+  {
+    "id": "8264|Klingenzell|TG",
+    "name": "Klingenzell",
+    "zipCode": "8264",
+    "canton": "TG"
+  },
+  {
+    "id": "5313|Klingnau|AG",
+    "name": "Klingnau",
+    "zipCode": "5313",
+    "canton": "AG"
+  },
+  {
+    "id": "8750|Klöntal|GL",
+    "name": "Klöntal",
+    "zipCode": "8750",
+    "canton": "GL"
+  },
+  {
+    "id": "7252|Klosters Dorf|GR",
+    "name": "Klosters Dorf",
+    "zipCode": "7252",
+    "canton": "GR"
+  },
+  {
+    "id": "7250|Klosters Platz|GR",
+    "name": "Klosters Platz",
+    "zipCode": "7250",
+    "canton": "GR"
+  },
+  {
+    "id": "8302|Kloten|ZH",
+    "name": "Kloten",
+    "zipCode": "8302",
+    "canton": "ZH"
+  },
+  {
+    "id": "4710|Klus|SO",
+    "name": "Klus",
+    "zipCode": "4710",
+    "canton": "SO"
+  },
+  {
+    "id": "4000|Klybeck|BS",
+    "name": "Klybeck",
+    "zipCode": "4000",
+    "canton": "BS"
+  },
+  {
+    "id": "8881|Knoblisbühl|SG",
+    "name": "Knoblisbühl",
+    "zipCode": "8881",
+    "canton": "SG"
+  },
+  {
+    "id": "8934|Knonau|ZH",
+    "name": "Knonau",
+    "zipCode": "8934",
+    "canton": "ZH"
+  },
+  {
+    "id": "6213|Knutwil|LU",
+    "name": "Knutwil",
+    "zipCode": "6213",
+    "canton": "LU"
+  },
+  {
+    "id": "9463|Kobelwald|SG",
+    "name": "Kobelwald",
+    "zipCode": "9463",
+    "canton": "SG"
+  },
+  {
+    "id": "5322|Koblenz|AG",
+    "name": "Koblenz",
+    "zipCode": "5322",
+    "canton": "AG"
+  },
+  {
+    "id": "8483|Kollbrunn|ZH",
+    "name": "Kollbrunn",
+    "zipCode": "8483",
+    "canton": "ZH"
+  },
+  {
+    "id": "5742|Kölliken|AG",
+    "name": "Kölliken",
+    "zipCode": "5742",
+    "canton": "AG"
+  },
+  {
+    "id": "5200|Königsfelden|AG",
+    "name": "Königsfelden",
+    "zipCode": "5200",
+    "canton": "AG"
+  },
+  {
+    "id": "3098|Köniz|BE",
+    "name": "Köniz",
+    "zipCode": "3098",
+    "canton": "BE"
+  },
+  {
+    "id": "3510|Konolfingen|BE",
+    "name": "Konolfingen",
+    "zipCode": "3510",
+    "canton": "BE"
+  },
+  {
+    "id": "3425|Koppigen|BE",
+    "name": "Koppigen",
+    "zipCode": "3425",
+    "canton": "BE"
+  },
+  {
+    "id": "3262|Kosthofen|BE",
+    "name": "Kosthofen",
+    "zipCode": "3262",
+    "canton": "BE"
+  },
+  {
+    "id": "6217|Kottwil|LU",
+    "name": "Kottwil",
+    "zipCode": "6217",
+    "canton": "LU"
+  },
+  {
+    "id": "9214|Kradolf|TG",
+    "name": "Kradolf",
+    "zipCode": "9214",
+    "canton": "TG"
+  },
+  {
+    "id": "3315|Kräiligen|BE",
+    "name": "Kräiligen",
+    "zipCode": "3315",
+    "canton": "BE"
+  },
+  {
+    "id": "3704|Krattigen|BE",
+    "name": "Krattigen",
+    "zipCode": "3704",
+    "canton": "BE"
+  },
+  {
+    "id": "3326|Krauchthal|BE",
+    "name": "Krauchthal",
+    "zipCode": "3326",
+    "canton": "BE"
+  },
+  {
+    "id": "8280|Kreuzlingen|TG",
+    "name": "Kreuzlingen",
+    "zipCode": "8280",
+    "canton": "TG"
+  },
+  {
+    "id": "3179|Kriechenwil|BE",
+    "name": "Kriechenwil",
+    "zipCode": "3179",
+    "canton": "BE"
+  },
+  {
+    "id": "4566|Kriegstetten|SO",
+    "name": "Kriegstetten",
+    "zipCode": "4566",
+    "canton": "SO"
+  },
+  {
+    "id": "6010|Kriens|LU",
+    "name": "Kriens",
+    "zipCode": "6010",
+    "canton": "LU"
+  },
+  {
+    "id": "9451|Kriessern|SG",
+    "name": "Kriessern",
+    "zipCode": "9451",
+    "canton": "SG"
+  },
+  {
+    "id": "9546|Krillberg|TG",
+    "name": "Krillberg",
+    "zipCode": "9546",
+    "canton": "TG"
+  },
+  {
+    "id": "9622|Krinau|SG",
+    "name": "Krinau",
+    "zipCode": "9622",
+    "canton": "SG"
+  },
+  {
+    "id": "9300|Kronbühl|SG",
+    "name": "Kronbühl",
+    "zipCode": "9300",
+    "canton": "SG"
+  },
+  {
+    "id": "3555|Kröschenbrunnen|BE",
+    "name": "Kröschenbrunnen",
+    "zipCode": "3555",
+    "canton": "BE"
+  },
+  {
+    "id": "6232|Krummbach|LU",
+    "name": "Krummbach",
+    "zipCode": "6232",
+    "canton": "LU"
+  },
+  {
+    "id": "9643|Krummenau|SG",
+    "name": "Krummenau",
+    "zipCode": "9643",
+    "canton": "SG"
+  },
+  {
+    "id": "7240|Küblis|GR",
+    "name": "Küblis",
+    "zipCode": "7240",
+    "canton": "GR"
+  },
+  {
+    "id": "8506|Kugelshofen|TG",
+    "name": "Kugelshofen",
+    "zipCode": "8506",
+    "canton": "TG"
+  },
+  {
+    "id": "3086|Kühlewil|BE",
+    "name": "Kühlewil",
+    "zipCode": "3086",
+    "canton": "BE"
+  },
+  {
+    "id": "6234|Kulmerau|LU",
+    "name": "Kulmerau",
+    "zipCode": "6234",
+    "canton": "LU"
+  },
+  {
+    "id": "8586|Kümmertshausen|TG",
+    "name": "Kümmertshausen",
+    "zipCode": "8586",
+    "canton": "TG"
+  },
+  {
+    "id": "4665|Küngoldingen|AG",
+    "name": "Küngoldingen",
+    "zipCode": "4665",
+    "canton": "AG"
+  },
+  {
+    "id": "7315|Kunkels|GR",
+    "name": "Kunkels",
+    "zipCode": "7315",
+    "canton": "GR"
+  },
+  {
+    "id": "5444|Künten|AG",
+    "name": "Künten",
+    "zipCode": "5444",
+    "canton": "AG"
+  },
+  {
+    "id": "8500|Kurzdorf|TG",
+    "name": "Kurzdorf",
+    "zipCode": "8500",
+    "canton": "TG"
+  },
+  {
+    "id": "8280|Kurzrickenbach|TG",
+    "name": "Kurzrickenbach",
+    "zipCode": "8280",
+    "canton": "TG"
+  },
+  {
+    "id": "8700|Küsnacht|ZH",
+    "name": "Küsnacht",
+    "zipCode": "8700",
+    "canton": "ZH"
+  },
+  {
+    "id": "6403|Küssnacht am Rigi|SZ",
+    "name": "Küssnacht am Rigi",
+    "zipCode": "6403",
+    "canton": "SZ"
+  },
+  {
+    "id": "5024|Küttigen|AG",
+    "name": "Küttigen",
+    "zipCode": "5024",
+    "canton": "AG"
+  },
+  {
+    "id": "4581|Küttigkofen|SO",
+    "name": "Küttigkofen",
+    "zipCode": "4581",
+    "canton": "SO"
+  },
+  {
+    "id": "4586|Kyburg|SO",
+    "name": "Kyburg",
+    "zipCode": "4586",
+    "canton": "SO"
+  },
+  {
+    "id": "8314|Kyburg|ZH",
+    "name": "Kyburg",
+    "zipCode": "8314",
+    "canton": "ZH"
+  },
+  {
+    "id": "1344|L'Abbaye|VD",
+    "name": "L'Abbaye",
+    "zipCode": "1344",
+    "canton": "VD"
+  },
+  {
+    "id": "1355|L'Abergement|VD",
+    "name": "L'Abergement",
+    "zipCode": "1355",
+    "canton": "VD"
+  },
+  {
+    "id": "1880|L'Allex|VD",
+    "name": "L'Allex",
+    "zipCode": "1880",
+    "canton": "VD"
+  },
+  {
+    "id": "1807|L'Alliaz|VD",
+    "name": "L'Alliaz",
+    "zipCode": "1807",
+    "canton": "VD"
+  },
+  {
+    "id": "1454|L'Auberson|VD",
+    "name": "L'Auberson",
+    "zipCode": "1454",
+    "canton": "VD"
+  },
+  {
+    "id": "1660|L'Etivaz|VD",
+    "name": "L'Etivaz",
+    "zipCode": "1660",
+    "canton": "VD"
+  },
+  {
+    "id": "1148|L'Isle|VD",
+    "name": "L'Isle",
+    "zipCode": "1148",
+    "canton": "VD"
+  },
+  {
+    "id": "1341|L'Orient|VD",
+    "name": "L'Orient",
+    "zipCode": "1341",
+    "canton": "VD"
+  },
+  {
+    "id": "1902|La Balmaz|VS",
+    "name": "La Balmaz",
+    "zipCode": "1902",
+    "canton": "VS"
+  },
+  {
+    "id": "1882|La Barboleusaz|VD",
+    "name": "La Barboleusaz",
+    "zipCode": "1882",
+    "canton": "VD"
+  },
+  {
+    "id": "1920|La Bâtiaz|VS",
+    "name": "La Bâtiaz",
+    "zipCode": "1920",
+    "canton": "VS"
+  },
+  {
+    "id": "2360|La Bosse|JU",
+    "name": "La Bosse",
+    "zipCode": "2360",
+    "canton": "JU"
+  },
+  {
+    "id": "2406|La Brévine|NE",
+    "name": "La Brévine",
+    "zipCode": "2406",
+    "canton": "NE"
+  },
+  {
+    "id": "1222|La Capite|GE",
+    "name": "La Capite",
+    "zipCode": "1222",
+    "canton": "GE"
+  },
+  {
+    "id": "2406|La Châtagne|NE",
+    "name": "La Châtagne",
+    "zipCode": "2406",
+    "canton": "NE"
+  },
+  {
+    "id": "1308|La Chaux (Cossonay)|VD",
+    "name": "La Chaux (Cossonay)",
+    "zipCode": "1308",
+    "canton": "VD"
+  },
+  {
+    "id": "2333|La Chaux-d'Abel|BE",
+    "name": "La Chaux-d'Abel",
+    "zipCode": "2333",
+    "canton": "BE"
+  },
+  {
+    "id": "2300|La Chaux-de-Fonds|NE",
+    "name": "La Chaux-de-Fonds",
+    "zipCode": "2300",
+    "canton": "NE"
+  },
+  {
+    "id": "1454|La Chaux-de-Ste-Croix|VD",
+    "name": "La Chaux-de-Ste-Croix",
+    "zipCode": "1454",
+    "canton": "VD"
+  },
+  {
+    "id": "2345|La Chaux-des-Breuleux|JU",
+    "name": "La Chaux-des-Breuleux",
+    "zipCode": "2345",
+    "canton": "JU"
+  },
+  {
+    "id": "2405|La Chaux-du-Milieu|NE",
+    "name": "La Chaux-du-Milieu",
+    "zipCode": "2405",
+    "canton": "NE"
+  },
+  {
+    "id": "1806|La Chiésaz|VD",
+    "name": "La Chiésaz",
+    "zipCode": "1806",
+    "canton": "VD"
+  },
+  {
+    "id": "2300|La Cibourg|NE",
+    "name": "La Cibourg",
+    "zipCode": "2300",
+    "canton": "NE"
+  },
+  {
+    "id": "2333|La Cibourg|BE",
+    "name": "La Cibourg",
+    "zipCode": "2333",
+    "canton": "BE"
+  },
+  {
+    "id": "2616|La Cibourg|BE",
+    "name": "La Cibourg",
+    "zipCode": "2616",
+    "canton": "BE"
+  },
+  {
+    "id": "1862|La Comballaz|VD",
+    "name": "La Comballaz",
+    "zipCode": "1862",
+    "canton": "VD"
+  },
+  {
+    "id": "1093|La Conversion|VD",
+    "name": "La Conversion",
+    "zipCode": "1093",
+    "canton": "VD"
+  },
+  {
+    "id": "2314|La Corbatière|NE",
+    "name": "La Corbatière",
+    "zipCode": "2314",
+    "canton": "NE"
+  },
+  {
+    "id": "1782|La Corbaz|FR",
+    "name": "La Corbaz",
+    "zipCode": "1782",
+    "canton": "FR"
+  },
+  {
+    "id": "2117|La Côte-aux-Fées|NE",
+    "name": "La Côte-aux-Fées",
+    "zipCode": "2117",
+    "canton": "NE"
+  },
+  {
+    "id": "1148|La Coudre|VD",
+    "name": "La Coudre",
+    "zipCode": "1148",
+    "canton": "VD"
+  },
+  {
+    "id": "2000|La Coudre|NE",
+    "name": "La Coudre",
+    "zipCode": "2000",
+    "canton": "NE"
+  },
+  {
+    "id": "1920|La Crettaz|VS",
+    "name": "La Crettaz",
+    "zipCode": "1920",
+    "canton": "VS"
+  },
+  {
+    "id": "1923|La Creusaz|VS",
+    "name": "La Creusaz",
+    "zipCode": "1923",
+    "canton": "VS"
+  },
+  {
+    "id": "1090|La Croix|VD",
+    "name": "La Croix",
+    "zipCode": "1090",
+    "canton": "VD"
+  },
+  {
+    "id": "1921|La Croix|VS",
+    "name": "La Croix",
+    "zipCode": "1921",
+    "canton": "VS"
+  },
+  {
+    "id": "1257|La Croix-de-Rozon|GE",
+    "name": "La Croix-de-Rozon",
+    "zipCode": "1257",
+    "canton": "GE"
+  },
+  {
+    "id": "1265|La Cure|VD",
+    "name": "La Cure",
+    "zipCode": "1265",
+    "canton": "VD"
+  },
+  {
+    "id": "1891|La Doey|VS",
+    "name": "La Doey",
+    "zipCode": "1891",
+    "canton": "VS"
+  },
+  {
+    "id": "1937|La Douay|VS",
+    "name": "La Douay",
+    "zipCode": "1937",
+    "canton": "VS"
+  },
+  {
+    "id": "1763|La Faye|FR",
+    "name": "La Faye",
+    "zipCode": "1763",
+    "canton": "FR"
+  },
+  {
+    "id": "2333|La Ferrière|BE",
+    "name": "La Ferrière",
+    "zipCode": "2333",
+    "canton": "BE"
+  },
+  {
+    "id": "1921|La Fontaine|VS",
+    "name": "La Fontaine",
+    "zipCode": "1921",
+    "canton": "VS"
+  },
+  {
+    "id": "1866|La Forclaz|VD",
+    "name": "La Forclaz",
+    "zipCode": "1866",
+    "canton": "VD"
+  },
+  {
+    "id": "1920|La Forclaz|VS",
+    "name": "La Forclaz",
+    "zipCode": "1920",
+    "canton": "VS"
+  },
+  {
+    "id": "1985|La Forclaz|VS",
+    "name": "La Forclaz",
+    "zipCode": "1985",
+    "canton": "VS"
+  },
+  {
+    "id": "1944|La Fouly|VS",
+    "name": "La Fouly",
+    "zipCode": "1944",
+    "canton": "VS"
+  },
+  {
+    "id": "1933|La Garde|VS",
+    "name": "La Garde",
+    "zipCode": "1933",
+    "canton": "VS"
+  },
+  {
+    "id": "1264|La Givrine|VD",
+    "name": "La Givrine",
+    "zipCode": "1264",
+    "canton": "VD"
+  },
+  {
+    "id": "1347|La Golisse|VD",
+    "name": "La Golisse",
+    "zipCode": "1347",
+    "canton": "VD"
+  },
+  {
+    "id": "1224|La Gradelle|GE",
+    "name": "La Gradelle",
+    "zipCode": "1224",
+    "canton": "GE"
+  },
+  {
+    "id": "2604|La Heutte|BE",
+    "name": "La Heutte",
+    "zipCode": "2604",
+    "canton": "BE"
+  },
+  {
+    "id": "2400|La Jaluse|NE",
+    "name": "La Jaluse",
+    "zipCode": "2400",
+    "canton": "NE"
+  },
+  {
+    "id": "2043|La Jonchère|NE",
+    "name": "La Jonchère",
+    "zipCode": "2043",
+    "canton": "NE"
+  },
+  {
+    "id": "1697|La Joux|FR",
+    "name": "La Joux",
+    "zipCode": "1697",
+    "canton": "FR"
+  },
+  {
+    "id": "2058|La Joux-du-Plâne|NE",
+    "name": "La Joux-du-Plâne",
+    "zipCode": "2058",
+    "canton": "NE"
+  },
+  {
+    "id": "1660|La Lécherette|VD",
+    "name": "La Lécherette",
+    "zipCode": "1660",
+    "canton": "VD"
+  },
+  {
+    "id": "1982|La Luette|VS",
+    "name": "La Luette",
+    "zipCode": "1982",
+    "canton": "VS"
+  },
+  {
+    "id": "1687|La Magne|FR",
+    "name": "La Magne",
+    "zipCode": "1687",
+    "canton": "FR"
+  },
+  {
+    "id": "1462|La Mauguettaz|VD",
+    "name": "La Mauguettaz",
+    "zipCode": "1462",
+    "canton": "VD"
+  },
+  {
+    "id": "1947|La Montoz|VS",
+    "name": "La Montoz",
+    "zipCode": "1947",
+    "canton": "VS"
+  },
+  {
+    "id": "1431|La Mothe|VD",
+    "name": "La Mothe",
+    "zipCode": "1431",
+    "canton": "VD"
+  },
+  {
+    "id": "2889|La Motte|JU",
+    "name": "La Motte",
+    "zipCode": "2889",
+    "canton": "JU"
+  },
+  {
+    "id": "1965|La Muraz|VS",
+    "name": "La Muraz",
+    "zipCode": "1965",
+    "canton": "VS"
+  },
+  {
+    "id": "1686|La Neirigue|FR",
+    "name": "La Neirigue",
+    "zipCode": "1686",
+    "canton": "FR"
+  },
+  {
+    "id": "2520|La Neuveville|BE",
+    "name": "La Neuveville",
+    "zipCode": "2520",
+    "canton": "BE"
+  },
+  {
+    "id": "1222|La Pallanterie|GE",
+    "name": "La Pallanterie",
+    "zipCode": "1222",
+    "canton": "GE"
+  },
+  {
+    "id": "2316|La Petite-Joux|NE",
+    "name": "La Petite-Joux",
+    "zipCode": "2316",
+    "canton": "NE"
+  },
+  {
+    "id": "1966|La Place|VS",
+    "name": "La Place",
+    "zipCode": "1966",
+    "canton": "VS"
+  },
+  {
+    "id": "1283|La Plaine|GE",
+    "name": "La Plaine",
+    "zipCode": "1283",
+    "canton": "GE"
+  },
+  {
+    "id": "1227|La Praille|GE",
+    "name": "La Praille",
+    "zipCode": "1227",
+    "canton": "GE"
+  },
+  {
+    "id": "2523|La Praye|BE",
+    "name": "La Praye",
+    "zipCode": "2523",
+    "canton": "BE"
+  },
+  {
+    "id": "1148|La Praz|VD",
+    "name": "La Praz",
+    "zipCode": "1148",
+    "canton": "VD"
+  },
+  {
+    "id": "7522|La Punt|GR",
+    "name": "La Punt",
+    "zipCode": "7522",
+    "canton": "GR"
+  },
+  {
+    "id": "1902|La Rasse|VS",
+    "name": "La Rasse",
+    "zipCode": "1902",
+    "canton": "VS"
+  },
+  {
+    "id": "1278|La Rippe|VD",
+    "name": "La Rippe",
+    "zipCode": "1278",
+    "canton": "VD"
+  },
+  {
+    "id": "1417|La Robellaz|VD",
+    "name": "La Robellaz",
+    "zipCode": "1417",
+    "canton": "VD"
+  },
+  {
+    "id": "1634|La Roche|FR",
+    "name": "La Roche",
+    "zipCode": "1634",
+    "canton": "FR"
+  },
+  {
+    "id": "1613|La Rogivue|VD",
+    "name": "La Rogivue",
+    "zipCode": "1613",
+    "canton": "VD"
+  },
+  {
+    "id": "7742|La Rösa|GR",
+    "name": "La Rösa",
+    "zipCode": "7742",
+    "canton": "GR"
+  },
+  {
+    "id": "1009|La Rosiaz|VD",
+    "name": "La Rosiaz",
+    "zipCode": "1009",
+    "canton": "VD"
+  },
+  {
+    "id": "1937|La Rosière|VS",
+    "name": "La Rosière",
+    "zipCode": "1937",
+    "canton": "VS"
+  },
+  {
+    "id": "1623|La Rougève|FR",
+    "name": "La Rougève",
+    "zipCode": "1623",
+    "canton": "FR"
+  },
+  {
+    "id": "1356|La Russille|VD",
+    "name": "La Russille",
+    "zipCode": "1356",
+    "canton": "VD"
+  },
+  {
+    "id": "1985|La Sage|VS",
+    "name": "La Sage",
+    "zipCode": "1985",
+    "canton": "VS"
+  },
+  {
+    "id": "1450|La Sagne|VD",
+    "name": "La Sagne",
+    "zipCode": "1450",
+    "canton": "VD"
+  },
+  {
+    "id": "2314|La Sagne|NE",
+    "name": "La Sagne",
+    "zipCode": "2314",
+    "canton": "NE"
+  },
+  {
+    "id": "2314|La Sagne-Eglise|NE",
+    "name": "La Sagne-Eglise",
+    "zipCode": "2314",
+    "canton": "NE"
+  },
+  {
+    "id": "1000|La Sallaz|VD",
+    "name": "La Sallaz",
+    "zipCode": "1000",
+    "canton": "VD"
+  },
+  {
+    "id": "1315|La Sarraz|VD",
+    "name": "La Sarraz",
+    "zipCode": "1315",
+    "canton": "VD"
+  },
+  {
+    "id": "1943|La Seiloz|VS",
+    "name": "La Seiloz",
+    "zipCode": "1943",
+    "canton": "VS"
+  },
+  {
+    "id": "1783|La Sonnaz|FR",
+    "name": "La Sonnaz",
+    "zipCode": "1783",
+    "canton": "FR"
+  },
+  {
+    "id": "2720|La Tanne|BE",
+    "name": "La Tanne",
+    "zipCode": "2720",
+    "canton": "BE"
+  },
+  {
+    "id": "1658|La Tine|VD",
+    "name": "La Tine",
+    "zipCode": "1658",
+    "canton": "VD"
+  },
+  {
+    "id": "1984|La Tour|VS",
+    "name": "La Tour",
+    "zipCode": "1984",
+    "canton": "VS"
+  },
+  {
+    "id": "1814|La Tour-de-Peilz|VD",
+    "name": "La Tour-de-Peilz",
+    "zipCode": "1814",
+    "canton": "VD"
+  },
+  {
+    "id": "1635|La Tour-de-Trême|FR",
+    "name": "La Tour-de-Trême",
+    "zipCode": "1635",
+    "canton": "FR"
+  },
+  {
+    "id": "2019|La Tourne|NE",
+    "name": "La Tourne",
+    "zipCode": "2019",
+    "canton": "NE"
+  },
+  {
+    "id": "1637|La Tsintre|FR",
+    "name": "La Tsintre",
+    "zipCode": "1637",
+    "canton": "FR"
+  },
+  {
+    "id": "1654|La Valsainte|FR",
+    "name": "La Valsainte",
+    "zipCode": "1654",
+    "canton": "FR"
+  },
+  {
+    "id": "1992|La Vernaz|VS",
+    "name": "La Vernaz",
+    "zipCode": "1992",
+    "canton": "VS"
+  },
+  {
+    "id": "1624|La Verrerie|FR",
+    "name": "La Verrerie",
+    "zipCode": "1624",
+    "canton": "FR"
+  },
+  {
+    "id": "1904|La Verrerie|VS",
+    "name": "La Verrerie",
+    "zipCode": "1904",
+    "canton": "VS"
+  },
+  {
+    "id": "1489|La Vounaise|FR",
+    "name": "La Vounaise",
+    "zipCode": "1489",
+    "canton": "FR"
+  },
+  {
+    "id": "1454|La Vraconnaz|VD",
+    "name": "La Vraconnaz",
+    "zipCode": "1454",
+    "canton": "VD"
+  },
+  {
+    "id": "2052|La Vue-des-Alpes|NE",
+    "name": "La Vue-des-Alpes",
+    "zipCode": "2052",
+    "canton": "NE"
+  },
+  {
+    "id": "7031|Laax|GR",
+    "name": "Laax",
+    "zipCode": "7031",
+    "canton": "GR"
+  },
+  {
+    "id": "8853|Lachen|SZ",
+    "name": "Lachen",
+    "zipCode": "8853",
+    "canton": "SZ"
+  },
+  {
+    "id": "9000|Lachen|SG",
+    "name": "Lachen",
+    "zipCode": "9000",
+    "canton": "SG"
+  },
+  {
+    "id": "9428|Lachen|AR",
+    "name": "Lachen",
+    "zipCode": "9428",
+    "canton": "AR"
+  },
+  {
+    "id": "1287|Laconnex|GE",
+    "name": "Laconnex",
+    "zipCode": "1287",
+    "canton": "GE"
+  },
+  {
+    "id": "7155|Ladir|GR",
+    "name": "Ladir",
+    "zipCode": "7155",
+    "canton": "GR"
+  },
+  {
+    "id": "7082|Lain|GR",
+    "name": "Lain",
+    "zipCode": "7082",
+    "canton": "GR"
+  },
+  {
+    "id": "2718|Lajoux|JU",
+    "name": "Lajoux",
+    "zipCode": "2718",
+    "canton": "JU"
+  },
+  {
+    "id": "3931|Lalden|VS",
+    "name": "Lalden",
+    "zipCode": "3931",
+    "canton": "VS"
+  },
+  {
+    "id": "1807|Lally|VD",
+    "name": "Lally",
+    "zipCode": "1807",
+    "canton": "VD"
+  },
+  {
+    "id": "2516|Lamboing|BE",
+    "name": "Lamboing",
+    "zipCode": "2516",
+    "canton": "BE"
+  },
+  {
+    "id": "6814|Lamone|TI",
+    "name": "Lamone",
+    "zipCode": "6814",
+    "canton": "TI"
+  },
+  {
+    "id": "4432|Lampenberg|BL",
+    "name": "Lampenberg",
+    "zipCode": "4432",
+    "canton": "BL"
+  },
+  {
+    "id": "8556|Lamperswil|TG",
+    "name": "Lamperswil",
+    "zipCode": "8556",
+    "canton": "TG"
+  },
+  {
+    "id": "1983|Lana|VS",
+    "name": "Lana",
+    "zipCode": "1983",
+    "canton": "VS"
+  },
+  {
+    "id": "1212|Lancy|GE",
+    "name": "Lancy",
+    "zipCode": "1212",
+    "canton": "GE"
+  },
+  {
+    "id": "6545|Landarenca|GR",
+    "name": "Landarenca",
+    "zipCode": "6545",
+    "canton": "GR"
+  },
+  {
+    "id": "1257|Landecy|GE",
+    "name": "Landecy",
+    "zipCode": "1257",
+    "canton": "GE"
+  },
+  {
+    "id": "3036|Landerswil|BE",
+    "name": "Landerswil",
+    "zipCode": "3036",
+    "canton": "BE"
+  },
+  {
+    "id": "2046|Landeyeux|NE",
+    "name": "Landeyeux",
+    "zipCode": "2046",
+    "canton": "NE"
+  },
+  {
+    "id": "8903|Landikon|ZH",
+    "name": "Landikon",
+    "zipCode": "8903",
+    "canton": "ZH"
+  },
+  {
+    "id": "3434|Landiswil|BE",
+    "name": "Landiswil",
+    "zipCode": "3434",
+    "canton": "BE"
+  },
+  {
+    "id": "7302|Landquart|GR",
+    "name": "Landquart",
+    "zipCode": "7302",
+    "canton": "GR"
+  },
+  {
+    "id": "7302|Landquart-Fabriken|GR",
+    "name": "Landquart-Fabriken",
+    "zipCode": "7302",
+    "canton": "GR"
+  },
+  {
+    "id": "8597|Landschlacht|TG",
+    "name": "Landschlacht",
+    "zipCode": "8597",
+    "canton": "TG"
+  },
+  {
+    "id": "3427|Landshut|BE",
+    "name": "Landshut",
+    "zipCode": "3427",
+    "canton": "BE"
+  },
+  {
+    "id": "8135|Langenberg|ZH",
+    "name": "Langenberg",
+    "zipCode": "8135",
+    "canton": "ZH"
+  },
+  {
+    "id": "6039|Längenbold|LU",
+    "name": "Längenbold",
+    "zipCode": "6039",
+    "canton": "LU"
+  },
+  {
+    "id": "4438|Langenbruck|BL",
+    "name": "Langenbruck",
+    "zipCode": "4438",
+    "canton": "BL"
+  },
+  {
+    "id": "3636|Längenbühl|BE",
+    "name": "Längenbühl",
+    "zipCode": "3636",
+    "canton": "BE"
+  },
+  {
+    "id": "4513|Langendorf|SO",
+    "name": "Langendorf",
+    "zipCode": "4513",
+    "canton": "SO"
+  },
+  {
+    "id": "3556|Längengrund|BE",
+    "name": "Längengrund",
+    "zipCode": "3556",
+    "canton": "BE"
+  },
+  {
+    "id": "8486|Langenhard|ZH",
+    "name": "Langenhard",
+    "zipCode": "8486",
+    "canton": "ZH"
+  },
+  {
+    "id": "8555|Langenhart|TG",
+    "name": "Langenhart",
+    "zipCode": "8555",
+    "canton": "TG"
+  },
+  {
+    "id": "3075|Langenloh|BE",
+    "name": "Langenloh",
+    "zipCode": "3075",
+    "canton": "BE"
+  },
+  {
+    "id": "8467|Langenmoos|ZH",
+    "name": "Langenmoos",
+    "zipCode": "8467",
+    "canton": "ZH"
+  },
+  {
+    "id": "3653|Längenschachen|BE",
+    "name": "Längenschachen",
+    "zipCode": "3653",
+    "canton": "BE"
+  },
+  {
+    "id": "4900|Langenthal|BE",
+    "name": "Langenthal",
+    "zipCode": "4900",
+    "canton": "BE"
+  },
+  {
+    "id": "9000|Langgass|SG",
+    "name": "Langgass",
+    "zipCode": "9000",
+    "canton": "SG"
+  },
+  {
+    "id": "3000|Länggasse|BE",
+    "name": "Länggasse",
+    "zipCode": "3000",
+    "canton": "BE"
+  },
+  {
+    "id": "8135|Langnau am Albis|ZH",
+    "name": "Langnau am Albis",
+    "zipCode": "8135",
+    "canton": "ZH"
+  },
+  {
+    "id": "6262|Langnau bei Reiden|LU",
+    "name": "Langnau bei Reiden",
+    "zipCode": "6262",
+    "canton": "LU"
+  },
+  {
+    "id": "3550|Langnau im Emmental|BE",
+    "name": "Langnau im Emmental",
+    "zipCode": "3550",
+    "canton": "BE"
+  },
+  {
+    "id": "8585|Langrickenbach|TG",
+    "name": "Langrickenbach",
+    "zipCode": "8585",
+    "canton": "TG"
+  },
+  {
+    "id": "7057|Langwies|GR",
+    "name": "Langwies",
+    "zipCode": "7057",
+    "canton": "GR"
+  },
+  {
+    "id": "8246|Langwiesen|ZH",
+    "name": "Langwiesen",
+    "zipCode": "8246",
+    "canton": "ZH"
+  },
+  {
+    "id": "9503|Lanterswil|TG",
+    "name": "Lanterswil",
+    "zipCode": "9503",
+    "canton": "TG"
+  },
+  {
+    "id": "7083|Lantsch/Lenz|GR",
+    "name": "Lantsch/Lenz",
+    "zipCode": "7083",
+    "canton": "GR"
+  },
+  {
+    "id": "3148|Lanzenhäusern|BE",
+    "name": "Lanzenhäusern",
+    "zipCode": "3148",
+    "canton": "BE"
+  },
+  {
+    "id": "8506|Lanzenneunforn|TG",
+    "name": "Lanzenneunforn",
+    "zipCode": "8506",
+    "canton": "TG"
+  },
+  {
+    "id": "7265|Laret|GR",
+    "name": "Laret",
+    "zipCode": "7265",
+    "canton": "GR"
+  },
+  {
+    "id": "7562|Laret|GR",
+    "name": "Laret",
+    "zipCode": "7562",
+    "canton": "GR"
+  },
+  {
+    "id": "6724|Largario|TI",
+    "name": "Largario",
+    "zipCode": "6724",
+    "canton": "TI"
+  },
+  {
+    "id": "7484|Latsch|GR",
+    "name": "Latsch",
+    "zipCode": "7484",
+    "canton": "GR"
+  },
+  {
+    "id": "3758|Latterbach|BE",
+    "name": "Latterbach",
+    "zipCode": "3758",
+    "canton": "BE"
+  },
+  {
+    "id": "3053|Lätti|BE",
+    "name": "Lätti",
+    "zipCode": "3053",
+    "canton": "BE"
+  },
+  {
+    "id": "2572|Lattrigen|BE",
+    "name": "Lattrigen",
+    "zipCode": "2572",
+    "canton": "BE"
+  },
+  {
+    "id": "3782|Lauenen bei Gstaad|BE",
+    "name": "Lauenen bei Gstaad",
+    "zipCode": "3782",
+    "canton": "BE"
+  },
+  {
+    "id": "6424|Lauerz|SZ",
+    "name": "Lauerz",
+    "zipCode": "6424",
+    "canton": "SZ"
+  },
+  {
+    "id": "4448|Läufelfingen|BL",
+    "name": "Läufelfingen",
+    "zipCode": "4448",
+    "canton": "BL"
+  },
+  {
+    "id": "4242|Laufen|BL",
+    "name": "Laufen",
+    "zipCode": "4242",
+    "canton": "BL"
+  },
+  {
+    "id": "8248|Laufen-Uhwiesen|ZH",
+    "name": "Laufen-Uhwiesen",
+    "zipCode": "8248",
+    "canton": "ZH"
+  },
+  {
+    "id": "5080|Laufenburg|AG",
+    "name": "Laufenburg",
+    "zipCode": "5080",
+    "canton": "AG"
+  },
+  {
+    "id": "5200|Lauffohr|AG",
+    "name": "Lauffohr",
+    "zipCode": "5200",
+    "canton": "AG"
+  },
+  {
+    "id": "9466|Läui|SG",
+    "name": "Läui",
+    "zipCode": "9466",
+    "canton": "SG"
+  },
+  {
+    "id": "3177|Laupen|BE",
+    "name": "Laupen",
+    "zipCode": "3177",
+    "canton": "BE"
+  },
+  {
+    "id": "8637|Laupen|ZH",
+    "name": "Laupen",
+    "zipCode": "8637",
+    "canton": "ZH"
+  },
+  {
+    "id": "9524|Laupen|SG",
+    "name": "Laupen",
+    "zipCode": "9524",
+    "canton": "SG"
+  },
+  {
+    "id": "4712|Laupersdorf|SO",
+    "name": "Laupersdorf",
+    "zipCode": "4712",
+    "canton": "SO"
+  },
+  {
+    "id": "3438|Lauperswil|BE",
+    "name": "Lauperswil",
+    "zipCode": "3438",
+    "canton": "BE"
+  },
+  {
+    "id": "1000|Lausanne|VD",
+    "name": "Lausanne",
+    "zipCode": "1000",
+    "canton": "VD"
+  },
+  {
+    "id": "4415|Lausen|BL",
+    "name": "Lausen",
+    "zipCode": "4415",
+    "canton": "BL"
+  },
+  {
+    "id": "3414|Lauterbach|BE",
+    "name": "Lauterbach",
+    "zipCode": "3414",
+    "canton": "BE"
+  },
+  {
+    "id": "3822|Lauterbrunnen|BE",
+    "name": "Lauterbrunnen",
+    "zipCode": "3822",
+    "canton": "BE"
+  },
+  {
+    "id": "4426|Lauwil|BL",
+    "name": "Lauwil",
+    "zipCode": "4426",
+    "canton": "BL"
+  },
+  {
+    "id": "6633|Lavertezzo|TI",
+    "name": "Lavertezzo",
+    "zipCode": "6633",
+    "canton": "TI"
+  },
+  {
+    "id": "1892|Lavey-les-Bains|VD",
+    "name": "Lavey-les-Bains",
+    "zipCode": "1892",
+    "canton": "VD"
+  },
+  {
+    "id": "1892|Lavey-Village|VD",
+    "name": "Lavey-Village",
+    "zipCode": "1892",
+    "canton": "VD"
+  },
+  {
+    "id": "1175|Lavigny|VD",
+    "name": "Lavigny",
+    "zipCode": "1175",
+    "canton": "VD"
+  },
+  {
+    "id": "7543|Lavin|GR",
+    "name": "Lavin",
+    "zipCode": "7543",
+    "canton": "GR"
+  },
+  {
+    "id": "6718|Lavòrceno|TI",
+    "name": "Lavòrceno",
+    "zipCode": "6718",
+    "canton": "TI"
+  },
+  {
+    "id": "6746|Lavorgo|TI",
+    "name": "Lavorgo",
+    "zipCode": "6746",
+    "canton": "TI"
+  },
+  {
+    "id": "3994|Lax|VS",
+    "name": "Lax",
+    "zipCode": "3994",
+    "canton": "VS"
+  },
+  {
+    "id": "2360|Le Bémont|JU",
+    "name": "Le Bémont",
+    "zipCode": "2360",
+    "canton": "JU"
+  },
+  {
+    "id": "1880|Le Bévieux|VD",
+    "name": "Le Bévieux",
+    "zipCode": "1880",
+    "canton": "VD"
+  },
+  {
+    "id": "1937|Le Biolley-sur-Orsières|VS",
+    "name": "Le Biolley-sur-Orsières",
+    "zipCode": "1937",
+    "canton": "VS"
+  },
+  {
+    "id": "1997|Le Bleusy|VS",
+    "name": "Le Bleusy",
+    "zipCode": "1997",
+    "canton": "VS"
+  },
+  {
+    "id": "2336|Le Boéchet|JU",
+    "name": "Le Boéchet",
+    "zipCode": "2336",
+    "canton": "JU"
+  },
+  {
+    "id": "1932|Le Borgeaud|VS",
+    "name": "Le Borgeaud",
+    "zipCode": "1932",
+    "canton": "VS"
+  },
+  {
+    "id": "1920|Le Bourg|VS",
+    "name": "Le Bourg",
+    "zipCode": "1920",
+    "canton": "VS"
+  },
+  {
+    "id": "1348|Le Brassus|VD",
+    "name": "Le Brassus",
+    "zipCode": "1348",
+    "canton": "VD"
+  },
+  {
+    "id": "1921|Le Brocard|VS",
+    "name": "Le Brocard",
+    "zipCode": "1921",
+    "canton": "VS"
+  },
+  {
+    "id": "2406|Le Brouillet|NE",
+    "name": "Le Brouillet",
+    "zipCode": "2406",
+    "canton": "NE"
+  },
+  {
+    "id": "1645|Le Bry|FR",
+    "name": "Le Bry",
+    "zipCode": "1645",
+    "canton": "FR"
+  },
+  {
+    "id": "1348|Le Campe|VD",
+    "name": "Le Campe",
+    "zipCode": "1348",
+    "canton": "VD"
+  },
+  {
+    "id": "1285|Le Cannelet|GE",
+    "name": "Le Cannelet",
+    "zipCode": "1285",
+    "canton": "GE"
+  },
+  {
+    "id": "1348|Le Carroz|VD",
+    "name": "Le Carroz",
+    "zipCode": "1348",
+    "canton": "VD"
+  },
+  {
+    "id": "1921|Le Cergneux|VS",
+    "name": "Le Cergneux",
+    "zipCode": "1921",
+    "canton": "VS"
+  },
+  {
+    "id": "2414|Le Cerneux-Péquignot|NE",
+    "name": "Le Cerneux-Péquignot",
+    "zipCode": "2414",
+    "canton": "NE"
+  },
+  {
+    "id": "2345|Le Cerneux-Veusil|JU",
+    "name": "Le Cerneux-Veusil",
+    "zipCode": "2345",
+    "canton": "JU"
+  },
+  {
+    "id": "2722|Le Cernil|BE",
+    "name": "Le Cernil",
+    "zipCode": "2722",
+    "canton": "BE"
+  },
+  {
+    "id": "1934|Le Châble|VS",
+    "name": "Le Châble",
+    "zipCode": "1934",
+    "canton": "VS"
+  },
+  {
+    "id": "1000|Le Chalet-à-Gobet|VD",
+    "name": "Le Chalet-à-Gobet",
+    "zipCode": "1000",
+    "canton": "VD"
+  },
+  {
+    "id": "2738|Le Chaluet|BE",
+    "name": "Le Chaluet",
+    "zipCode": "2738",
+    "canton": "BE"
+  },
+  {
+    "id": "1987|Le Chargeur|VS",
+    "name": "Le Chargeur",
+    "zipCode": "1987",
+    "canton": "VS"
+  },
+  {
+    "id": "1450|Le Château-de-Ste-Croix|VD",
+    "name": "Le Château-de-Ste-Croix",
+    "zipCode": "1450",
+    "canton": "VD"
+  },
+  {
+    "id": "1925|Le Châtelard|VS",
+    "name": "Le Châtelard",
+    "zipCode": "1925",
+    "canton": "VS"
+  },
+  {
+    "id": "1689|Le Châtelard-près-Romont|FR",
+    "name": "Le Châtelard-près-Romont",
+    "zipCode": "1689",
+    "canton": "FR"
+  },
+  {
+    "id": "1347|Le Chenit|VD",
+    "name": "Le Chenit",
+    "zipCode": "1347",
+    "canton": "VD"
+  },
+  {
+    "id": "2400|Le Col-des-Roches|NE",
+    "name": "Le Col-des-Roches",
+    "zipCode": "2400",
+    "canton": "NE"
+  },
+  {
+    "id": "2058|Le Côty|NE",
+    "name": "Le Côty",
+    "zipCode": "2058",
+    "canton": "NE"
+  },
+  {
+    "id": "1372|Le Coudray|VD",
+    "name": "Le Coudray",
+    "zipCode": "1372",
+    "canton": "VD"
+  },
+  {
+    "id": "2314|Le Crêt|NE",
+    "name": "Le Crêt",
+    "zipCode": "2314",
+    "canton": "NE"
+  },
+  {
+    "id": "2322|Le Crêt-du-Locle|NE",
+    "name": "Le Crêt-du-Locle",
+    "zipCode": "2322",
+    "canton": "NE"
+  },
+  {
+    "id": "1611|Le Crêt-près-Semsales|FR",
+    "name": "Le Crêt-près-Semsales",
+    "zipCode": "1611",
+    "canton": "FR"
+  },
+  {
+    "id": "2400|Le Crozot|NE",
+    "name": "Le Crozot",
+    "zipCode": "2400",
+    "canton": "NE"
+  },
+  {
+    "id": "1337|Le Day|VD",
+    "name": "Le Day",
+    "zipCode": "1337",
+    "canton": "VD"
+  },
+  {
+    "id": "1071|Le Dézaley|VD",
+    "name": "Le Dézaley",
+    "zipCode": "1071",
+    "canton": "VD"
+  },
+  {
+    "id": "1921|Le Fays|VS",
+    "name": "Le Fays",
+    "zipCode": "1921",
+    "canton": "VS"
+  },
+  {
+    "id": "1947|Le Fregnoley|VS",
+    "name": "Le Fregnoley",
+    "zipCode": "1947",
+    "canton": "VS"
+  },
+  {
+    "id": "2712|Le Fuet|BE",
+    "name": "Le Fuet",
+    "zipCode": "2712",
+    "canton": "BE"
+  },
+  {
+    "id": "1218|Le Grand-Saconnex|GE",
+    "name": "Le Grand-Saconnex",
+    "zipCode": "1218",
+    "canton": "GE"
+  },
+  {
+    "id": "2720|Le Jeanbrenin|BE",
+    "name": "Le Jeanbrenin",
+    "zipCode": "2720",
+    "canton": "BE"
+  },
+  {
+    "id": "2318|Le Joratel|NE",
+    "name": "Le Joratel",
+    "zipCode": "2318",
+    "canton": "NE"
+  },
+  {
+    "id": "1609|Le Jordil|FR",
+    "name": "Le Jordil",
+    "zipCode": "1609",
+    "canton": "FR"
+  },
+  {
+    "id": "2525|Le Landeron|NE",
+    "name": "Le Landeron",
+    "zipCode": "2525",
+    "canton": "NE"
+  },
+  {
+    "id": "2023|Le Lessy|NE",
+    "name": "Le Lessy",
+    "zipCode": "2023",
+    "canton": "NE"
+  },
+  {
+    "id": "1345|Le Lieu|VD",
+    "name": "Le Lieu",
+    "zipCode": "1345",
+    "canton": "VD"
+  },
+  {
+    "id": "1219|Le Lignon|GE",
+    "name": "Le Lignon",
+    "zipCode": "1219",
+    "canton": "GE"
+  },
+  {
+    "id": "2400|Le Locle|NE",
+    "name": "Le Locle",
+    "zipCode": "2400",
+    "canton": "NE"
+  },
+  {
+    "id": "1348|Le Marchairuz|VD",
+    "name": "Le Marchairuz",
+    "zipCode": "1348",
+    "canton": "VD"
+  },
+  {
+    "id": "1947|Le Martinet|VS",
+    "name": "Le Martinet",
+    "zipCode": "1947",
+    "canton": "VS"
+  },
+  {
+    "id": "1801|Le Mont-Pèlerin|VD",
+    "name": "Le Mont-Pèlerin",
+    "zipCode": "1801",
+    "canton": "VD"
+  },
+  {
+    "id": "1052|Le Mont-sur-Lausanne|VD",
+    "name": "Le Mont-sur-Lausanne",
+    "zipCode": "1052",
+    "canton": "VD"
+  },
+  {
+    "id": "1948|Le Morgnes|VS",
+    "name": "Le Morgnes",
+    "zipCode": "1948",
+    "canton": "VS"
+  },
+  {
+    "id": "1724|Le Mouret|FR",
+    "name": "Le Mouret",
+    "zipCode": "1724",
+    "canton": "FR"
+  },
+  {
+    "id": "1273|Le Muids|VD",
+    "name": "Le Muids",
+    "zipCode": "1273",
+    "canton": "VD"
+  },
+  {
+    "id": "2340|Le Noirmont|JU",
+    "name": "Le Noirmont",
+    "zipCode": "2340",
+    "canton": "JU"
+  },
+  {
+    "id": "1724|Le Pafuet|FR",
+    "name": "Le Pafuet",
+    "zipCode": "1724",
+    "canton": "FR"
+  },
+  {
+    "id": "1661|Le Pâquier|FR",
+    "name": "Le Pâquier",
+    "zipCode": "1661",
+    "canton": "FR"
+  },
+  {
+    "id": "2058|Le Pâquier|NE",
+    "name": "Le Pâquier",
+    "zipCode": "2058",
+    "canton": "NE"
+  },
+  {
+    "id": "1991|Le Parfay|VS",
+    "name": "Le Parfay",
+    "zipCode": "1991",
+    "canton": "VS"
+  },
+  {
+    "id": "1788|Le Péage|FR",
+    "name": "Le Péage",
+    "zipCode": "1788",
+    "canton": "FR"
+  },
+  {
+    "id": "1200|Le Petit-Saconnex|GE",
+    "name": "Le Petit-Saconnex",
+    "zipCode": "1200",
+    "canton": "GE"
+  },
+  {
+    "id": "2336|Le Peu-Claude|JU",
+    "name": "Le Peu-Claude",
+    "zipCode": "2336",
+    "canton": "JU"
+  },
+  {
+    "id": "2340|Le Peu-Péquinot|JU",
+    "name": "Le Peu-Péquinot",
+    "zipCode": "2340",
+    "canton": "JU"
+  },
+  {
+    "id": "2345|Le Peuchapatte|JU",
+    "name": "Le Peuchapatte",
+    "zipCode": "2345",
+    "canton": "JU"
+  },
+  {
+    "id": "1948|Le Planchamp|VS",
+    "name": "Le Planchamp",
+    "zipCode": "1948",
+    "canton": "VS"
+  },
+  {
+    "id": "1342|Le Pont|VD",
+    "name": "Le Pont",
+    "zipCode": "1342",
+    "canton": "VD"
+  },
+  {
+    "id": "2534|Le Pré-Carrel|BE",
+    "name": "Le Pré-Carrel",
+    "zipCode": "2534",
+    "canton": "BE"
+  },
+  {
+    "id": "2714|Le Prédame|JU",
+    "name": "Le Prédame",
+    "zipCode": "2714",
+    "canton": "JU"
+  },
+  {
+    "id": "7746|Le Prese|GR",
+    "name": "Le Prese",
+    "zipCode": "7746",
+    "canton": "GR"
+  },
+  {
+    "id": "2400|Le Prévoux|NE",
+    "name": "Le Prévoux",
+    "zipCode": "2400",
+    "canton": "NE"
+  },
+  {
+    "id": "2400|Le Quartier|NE",
+    "name": "Le Quartier",
+    "zipCode": "2400",
+    "canton": "NE"
+  },
+  {
+    "id": "1347|Le Rocheray|VD",
+    "name": "Le Rocheray",
+    "zipCode": "1347",
+    "canton": "VD"
+  },
+  {
+    "id": "2345|Le Roselet|JU",
+    "name": "Le Roselet",
+    "zipCode": "2345",
+    "canton": "JU"
+  },
+  {
+    "id": "1864|Le Rosex|VD",
+    "name": "Le Rosex",
+    "zipCode": "1864",
+    "canton": "VD"
+  },
+  {
+    "id": "1934|Le Sapey|VS",
+    "name": "Le Sapey",
+    "zipCode": "1934",
+    "canton": "VS"
+  },
+  {
+    "id": "1678|Le Saulgy|FR",
+    "name": "Le Saulgy",
+    "zipCode": "1678",
+    "canton": "FR"
+  },
+  {
+    "id": "1345|Le Séchey|VD",
+    "name": "Le Séchey",
+    "zipCode": "1345",
+    "canton": "VD"
+  },
+  {
+    "id": "1347|Le Sentier|VD",
+    "name": "Le Sentier",
+    "zipCode": "1347",
+    "canton": "VD"
+  },
+  {
+    "id": "1863|Le Sépey|VD",
+    "name": "Le Sépey",
+    "zipCode": "1863",
+    "canton": "VD"
+  },
+  {
+    "id": "1347|Le Solliat|VD",
+    "name": "Le Solliat",
+    "zipCode": "1347",
+    "canton": "VD"
+  },
+  {
+    "id": "1923|Le Trétien|VS",
+    "name": "Le Trétien",
+    "zipCode": "1923",
+    "canton": "VS"
+  },
+  {
+    "id": "1091|Le Tronchet|VD",
+    "name": "Le Tronchet",
+    "zipCode": "1091",
+    "canton": "VD"
+  },
+  {
+    "id": "1261|Le Vaud|VD",
+    "name": "Le Vaud",
+    "zipCode": "1261",
+    "canton": "VD"
+  },
+  {
+    "id": "1773|Léchelles|FR",
+    "name": "Léchelles",
+    "zipCode": "1773",
+    "canton": "FR"
+  },
+  {
+    "id": "6556|Leggia|GR",
+    "name": "Leggia",
+    "zipCode": "6556",
+    "canton": "GR"
+  },
+  {
+    "id": "5325|Leibstadt|AG",
+    "name": "Leibstadt",
+    "zipCode": "5325",
+    "canton": "AG"
+  },
+  {
+    "id": "5733|Leimbach|AG",
+    "name": "Leimbach",
+    "zipCode": "5733",
+    "canton": "AG"
+  },
+  {
+    "id": "8041|Leimbach|ZH",
+    "name": "Leimbach",
+    "zipCode": "8041",
+    "canton": "ZH"
+  },
+  {
+    "id": "8584|Leimbach|TG",
+    "name": "Leimbach",
+    "zipCode": "8584",
+    "canton": "TG"
+  },
+  {
+    "id": "4935|Leimiswil|BE",
+    "name": "Leimiswil",
+    "zipCode": "4935",
+    "canton": "BE"
+  },
+  {
+    "id": "3706|Leissigen|BE",
+    "name": "Leissigen",
+    "zipCode": "3706",
+    "canton": "BE"
+  },
+  {
+    "id": "6960|Lelgio|TI",
+    "name": "Lelgio",
+    "zipCode": "6960",
+    "canton": "TI"
+  },
+  {
+    "id": "9525|Lenggenwil|SG",
+    "name": "Lenggenwil",
+    "zipCode": "9525",
+    "canton": "SG"
+  },
+  {
+    "id": "2543|Lengnau|BE",
+    "name": "Lengnau",
+    "zipCode": "2543",
+    "canton": "BE"
+  },
+  {
+    "id": "5426|Lengnau|AG",
+    "name": "Lengnau",
+    "zipCode": "5426",
+    "canton": "AG"
+  },
+  {
+    "id": "8574|Lengwil|TG",
+    "name": "Lengwil",
+    "zipCode": "8574",
+    "canton": "TG"
+  },
+  {
+    "id": "3775|Lenk im Simmental|BE",
+    "name": "Lenk im Simmental",
+    "zipCode": "3775",
+    "canton": "BE"
+  },
+  {
+    "id": "1978|Lens|VS",
+    "name": "Lens",
+    "zipCode": "1978",
+    "canton": "VS"
+  },
+  {
+    "id": "1745|Lentigny|FR",
+    "name": "Lentigny",
+    "zipCode": "1745",
+    "canton": "FR"
+  },
+  {
+    "id": "5600|Lenzburg|AG",
+    "name": "Lenzburg",
+    "zipCode": "5600",
+    "canton": "AG"
+  },
+  {
+    "id": "7077|Lenzerheide See|GR",
+    "name": "Lenzerheide See",
+    "zipCode": "7077",
+    "canton": "GR"
+  },
+  {
+    "id": "7078|Lenzerheide/Lai|GR",
+    "name": "Lenzerheide/Lai",
+    "zipCode": "7078",
+    "canton": "GR"
+  },
+  {
+    "id": "8732|Lenzikon|SG",
+    "name": "Lenzikon",
+    "zipCode": "8732",
+    "canton": "SG"
+  },
+  {
+    "id": "6716|Leontica|TI",
+    "name": "Leontica",
+    "zipCode": "6716",
+    "canton": "TI"
+  },
+  {
+    "id": "3600|Lerchenfeld|BE",
+    "name": "Lerchenfeld",
+    "zipCode": "3600",
+    "canton": "BE"
+  },
+  {
+    "id": "1227|Les Acacias|GE",
+    "name": "Les Acacias",
+    "zipCode": "1227",
+    "canton": "GE"
+  },
+  {
+    "id": "1992|Les Agettes|VS",
+    "name": "Les Agettes",
+    "zipCode": "1992",
+    "canton": "VS"
+  },
+  {
+    "id": "1943|Les Arlaches|VS",
+    "name": "Les Arlaches",
+    "zipCode": "1943",
+    "canton": "VS"
+  },
+  {
+    "id": "1220|Les Avanchets|GE",
+    "name": "Les Avanchets",
+    "zipCode": "1220",
+    "canton": "GE"
+  },
+  {
+    "id": "1833|Les Avants|VD",
+    "name": "Les Avants",
+    "zipCode": "1833",
+    "canton": "VD"
+  },
+  {
+    "id": "1864|Les Aviolats|VD",
+    "name": "Les Aviolats",
+    "zipCode": "1864",
+    "canton": "VD"
+  },
+  {
+    "id": "2127|Les Bayards|NE",
+    "name": "Les Bayards",
+    "zipCode": "2127",
+    "canton": "NE"
+  },
+  {
+    "id": "1996|Les Bioley-de-Brignon|VS",
+    "name": "Les Bioley-de-Brignon",
+    "zipCode": "1996",
+    "canton": "VS"
+  },
+  {
+    "id": "1346|Les Bioux|VD",
+    "name": "Les Bioux",
+    "zipCode": "1346",
+    "canton": "VD"
+  },
+  {
+    "id": "2336|Les Bois|JU",
+    "name": "Les Bois",
+    "zipCode": "2336",
+    "canton": "JU"
+  },
+  {
+    "id": "1865|Les Bovets|VD",
+    "name": "Les Bovets",
+    "zipCode": "1865",
+    "canton": "VD"
+  },
+  {
+    "id": "2416|Les Brenets|NE",
+    "name": "Les Brenets",
+    "zipCode": "2416",
+    "canton": "NE"
+  },
+  {
+    "id": "2345|Les Breuleux|JU",
+    "name": "Les Breuleux",
+    "zipCode": "2345",
+    "canton": "JU"
+  },
+  {
+    "id": "2058|Les Bugnenets|NE",
+    "name": "Les Bugnenets",
+    "zipCode": "2058",
+    "canton": "NE"
+  },
+  {
+    "id": "2350|Les Cerlatez|JU",
+    "name": "Les Cerlatez",
+    "zipCode": "2350",
+    "canton": "JU"
+  },
+  {
+    "id": "1343|Les Charbonnières|VD",
+    "name": "Les Charbonnières",
+    "zipCode": "1343",
+    "canton": "VD"
+  },
+  {
+    "id": "1680|Les Chavannes-sous-Romont|FR",
+    "name": "Les Chavannes-sous-Romont",
+    "zipCode": "1680",
+    "canton": "FR"
+  },
+  {
+    "id": "1906|Les Chênes|VS",
+    "name": "Les Chênes",
+    "zipCode": "1906",
+    "canton": "VS"
+  },
+  {
+    "id": "1807|Les Chevalleyres|VD",
+    "name": "Les Chevalleyres",
+    "zipCode": "1807",
+    "canton": "VD"
+  },
+  {
+    "id": "1356|Les Clées|VD",
+    "name": "Les Clées",
+    "zipCode": "1356",
+    "canton": "VD"
+  },
+  {
+    "id": "2314|Les Coeudres|NE",
+    "name": "Les Coeudres",
+    "zipCode": "2314",
+    "canton": "NE"
+  },
+  {
+    "id": "1988|Les Collons|VS",
+    "name": "Les Collons",
+    "zipCode": "1988",
+    "canton": "VS"
+  },
+  {
+    "id": "1066|Les Croisettes|VD",
+    "name": "Les Croisettes",
+    "zipCode": "1066",
+    "canton": "VD"
+  },
+  {
+    "id": "1873|Les Crosets|VS",
+    "name": "Les Crosets",
+    "zipCode": "1873",
+    "canton": "VS"
+  },
+  {
+    "id": "1080|Les Cullayes|VD",
+    "name": "Les Cullayes",
+    "zipCode": "1080",
+    "canton": "VD"
+  },
+  {
+    "id": "1752|Les Daillettes|FR",
+    "name": "Les Daillettes",
+    "zipCode": "1752",
+    "canton": "FR"
+  },
+  {
+    "id": "1880|Les Dévens|VD",
+    "name": "Les Dévens",
+    "zipCode": "1880",
+    "canton": "VD"
+  },
+  {
+    "id": "1865|Les Diablerets|VD",
+    "name": "Les Diablerets",
+    "zipCode": "1865",
+    "canton": "VD"
+  },
+  {
+    "id": "1200|Les Eaux-Vives|GE",
+    "name": "Les Eaux-Vives",
+    "zipCode": "1200",
+    "canton": "GE"
+  },
+  {
+    "id": "1697|Les Ecasseys|FR",
+    "name": "Les Ecasseys",
+    "zipCode": "1697",
+    "canton": "FR"
+  },
+  {
+    "id": "2748|Les Ecorcheresses|BE",
+    "name": "Les Ecorcheresses",
+    "zipCode": "2748",
+    "canton": "BE"
+  },
+  {
+    "id": "2338|Les Emibois|JU",
+    "name": "Les Emibois",
+    "zipCode": "2338",
+    "canton": "JU"
+  },
+  {
+    "id": "2363|Les Enfers|JU",
+    "name": "Les Enfers",
+    "zipCode": "2363",
+    "canton": "JU"
+  },
+  {
+    "id": "2300|Les Eplatures|NE",
+    "name": "Les Eplatures",
+    "zipCode": "2300",
+    "canton": "NE"
+  },
+  {
+    "id": "1897|Les Evouettes|VS",
+    "name": "Les Evouettes",
+    "zipCode": "1897",
+    "canton": "VS"
+  },
+  {
+    "id": "2416|Les Frêtes|NE",
+    "name": "Les Frêtes",
+    "zipCode": "2416",
+    "canton": "NE"
+  },
+  {
+    "id": "1566|Les Friques|FR",
+    "name": "Les Friques",
+    "zipCode": "1566",
+    "canton": "FR"
+  },
+  {
+    "id": "2206|Les Geneveys-sur-Coffrane|NE",
+    "name": "Les Geneveys-sur-Coffrane",
+    "zipCode": "2206",
+    "canton": "NE"
+  },
+  {
+    "id": "2714|Les Genevez|JU",
+    "name": "Les Genevez",
+    "zipCode": "2714",
+    "canton": "JU"
+  },
+  {
+    "id": "1871|Les Giettes|VS",
+    "name": "Les Giettes",
+    "zipCode": "1871",
+    "canton": "VS"
+  },
+  {
+    "id": "1660|Les Granges|VD",
+    "name": "Les Granges",
+    "zipCode": "1660",
+    "canton": "VD"
+  },
+  {
+    "id": "1922|Les Granges|VS",
+    "name": "Les Granges",
+    "zipCode": "1922",
+    "canton": "VS"
+  },
+  {
+    "id": "2019|Les Grattes|NE",
+    "name": "Les Grattes",
+    "zipCode": "2019",
+    "canton": "NE"
+  },
+  {
+    "id": "1984|Les Haudères|VS",
+    "name": "Les Haudères",
+    "zipCode": "1984",
+    "canton": "VS"
+  },
+  {
+    "id": "2208|Les Hauts-Geneveys|NE",
+    "name": "Les Hauts-Geneveys",
+    "zipCode": "2208",
+    "canton": "NE"
+  },
+  {
+    "id": "1929|Les Jeurs|VS",
+    "name": "Les Jeurs",
+    "zipCode": "1929",
+    "canton": "VS"
+  },
+  {
+    "id": "2300|Les Joux-Derrière|NE",
+    "name": "Les Joux-Derrière",
+    "zipCode": "2300",
+    "canton": "NE"
+  },
+  {
+    "id": "2052|Les Loges|NE",
+    "name": "Les Loges",
+    "zipCode": "2052",
+    "canton": "NE"
+  },
+  {
+    "id": "1923|Les Marécottes|VS",
+    "name": "Les Marécottes",
+    "zipCode": "1923",
+    "canton": "VS"
+  },
+  {
+    "id": "1987|Les Masses|VS",
+    "name": "Les Masses",
+    "zipCode": "1987",
+    "canton": "VS"
+  },
+  {
+    "id": "1992|Les Mayens-de-Sion|VS",
+    "name": "Les Mayens-de-Sion",
+    "zipCode": "1992",
+    "canton": "VS"
+  },
+  {
+    "id": "1808|Les Monts-de-Corsier|VD",
+    "name": "Les Monts-de-Corsier",
+    "zipCode": "1808",
+    "canton": "VD"
+  },
+  {
+    "id": "1068|Les Monts-de-Pully|VD",
+    "name": "Les Monts-de-Pully",
+    "zipCode": "1068",
+    "canton": "VD"
+  },
+  {
+    "id": "1862|Les Mosses|VD",
+    "name": "Les Mosses",
+    "zipCode": "1862",
+    "canton": "VD"
+  },
+  {
+    "id": "1660|Les Moulins|VD",
+    "name": "Les Moulins",
+    "zipCode": "1660",
+    "canton": "VD"
+  },
+  {
+    "id": "1945|Les Moulins|VS",
+    "name": "Les Moulins",
+    "zipCode": "1945",
+    "canton": "VS"
+  },
+  {
+    "id": "1868|Les Neyres|VS",
+    "name": "Les Neyres",
+    "zipCode": "1868",
+    "canton": "VS"
+  },
+  {
+    "id": "1619|Les Paccots|FR",
+    "name": "Les Paccots",
+    "zipCode": "1619",
+    "canton": "FR"
+  },
+  {
+    "id": "2318|Les Petits-Ponts|NE",
+    "name": "Les Petits-Ponts",
+    "zipCode": "2318",
+    "canton": "NE"
+  },
+  {
+    "id": "1947|Les Places|VS",
+    "name": "Les Places",
+    "zipCode": "1947",
+    "canton": "VS"
+  },
+  {
+    "id": "1052|Les Planches|VD",
+    "name": "Les Planches",
+    "zipCode": "1052",
+    "canton": "VD"
+  },
+  {
+    "id": "1475|Les Planches|FR",
+    "name": "Les Planches",
+    "zipCode": "1475",
+    "canton": "FR"
+  },
+  {
+    "id": "1820|Les Planches|VD",
+    "name": "Les Planches",
+    "zipCode": "1820",
+    "canton": "VD"
+  },
+  {
+    "id": "1863|Les Planches|VD",
+    "name": "Les Planches",
+    "zipCode": "1863",
+    "canton": "VD"
+  },
+  {
+    "id": "2325|Les Planchettes|NE",
+    "name": "Les Planchettes",
+    "zipCode": "2325",
+    "canton": "NE"
+  },
+  {
+    "id": "1880|Les Plans-sur-Bex|VD",
+    "name": "Les Plans-sur-Bex",
+    "zipCode": "1880",
+    "canton": "VD"
+  },
+  {
+    "id": "2353|Les Pommerats|JU",
+    "name": "Les Pommerats",
+    "zipCode": "2353",
+    "canton": "JU"
+  },
+  {
+    "id": "2610|Les Pontins|BE",
+    "name": "Les Pontins",
+    "zipCode": "2610",
+    "canton": "BE"
+  },
+  {
+    "id": "1627|Les Ponts|FR",
+    "name": "Les Ponts",
+    "zipCode": "1627",
+    "canton": "FR"
+  },
+  {
+    "id": "2316|Les Ponts-de-Martel|NE",
+    "name": "Les Ponts-de-Martel",
+    "zipCode": "2316",
+    "canton": "NE"
+  },
+  {
+    "id": "1880|Les Posses-sur-Bex|VD",
+    "name": "Les Posses-sur-Bex",
+    "zipCode": "1880",
+    "canton": "VD"
+  },
+  {
+    "id": "1981|Les Prasses|VS",
+    "name": "Les Prasses",
+    "zipCode": "1981",
+    "canton": "VS"
+  },
+  {
+    "id": "2534|Les Prés-d'Orvin|BE",
+    "name": "Les Prés-d'Orvin",
+    "zipCode": "2534",
+    "canton": "BE"
+  },
+  {
+    "id": "2954|Les Rangiers|JU",
+    "name": "Les Rangiers",
+    "zipCode": "2954",
+    "canton": "JU"
+  },
+  {
+    "id": "1921|Les Rappes|VS",
+    "name": "Les Rappes",
+    "zipCode": "1921",
+    "canton": "VS"
+  },
+  {
+    "id": "1452|Les Rasses|VD",
+    "name": "Les Rasses",
+    "zipCode": "1452",
+    "canton": "VD"
+  },
+  {
+    "id": "2400|Les Replattes|NE",
+    "name": "Les Replattes",
+    "zipCode": "2400",
+    "canton": "NE"
+  },
+  {
+    "id": "2722|Les Reussilles|BE",
+    "name": "Les Reussilles",
+    "zipCode": "2722",
+    "canton": "BE"
+  },
+  {
+    "id": "2800|Les Rondez|JU",
+    "name": "Les Rondez",
+    "zipCode": "2800",
+    "canton": "JU"
+  },
+  {
+    "id": "2360|Les Rouges-Terres|JU",
+    "name": "Les Rouges-Terres",
+    "zipCode": "2360",
+    "canton": "JU"
+  },
+  {
+    "id": "2108|Les Ruillères|NE",
+    "name": "Les Ruillères",
+    "zipCode": "2108",
+    "canton": "NE"
+  },
+  {
+    "id": "2124|Les Sagnettes|NE",
+    "name": "Les Sagnettes",
+    "zipCode": "2124",
+    "canton": "NE"
+  },
+  {
+    "id": "2362|Les Sairains|JU",
+    "name": "Les Sairains",
+    "zipCode": "2362",
+    "canton": "JU"
+  },
+  {
+    "id": "1669|Les Sciernes-d'Albeuve|FR",
+    "name": "Les Sciernes-d'Albeuve",
+    "zipCode": "1669",
+    "canton": "FR"
+  },
+  {
+    "id": "2406|Les Taillères|NE",
+    "name": "Les Taillères",
+    "zipCode": "2406",
+    "canton": "NE"
+  },
+  {
+    "id": "1607|Les Tavernes|VD",
+    "name": "Les Tavernes",
+    "zipCode": "1607",
+    "canton": "VD"
+  },
+  {
+    "id": "1607|Les Thioleyres|VD",
+    "name": "Les Thioleyres",
+    "zipCode": "1607",
+    "canton": "VD"
+  },
+  {
+    "id": "1422|Les Tuileries|VD",
+    "name": "Les Tuileries",
+    "zipCode": "1422",
+    "canton": "VD"
+  },
+  {
+    "id": "2345|Les Vacheries|JU",
+    "name": "Les Vacheries",
+    "zipCode": "2345",
+    "canton": "JU"
+  },
+  {
+    "id": "2714|Les Vacheries-Genevez|JU",
+    "name": "Les Vacheries-Genevez",
+    "zipCode": "2714",
+    "canton": "JU"
+  },
+  {
+    "id": "1932|Les Valettes|VS",
+    "name": "Les Valettes",
+    "zipCode": "1932",
+    "canton": "VS"
+  },
+  {
+    "id": "1955|Les Vérines|VS",
+    "name": "Les Vérines",
+    "zipCode": "1955",
+    "canton": "VS"
+  },
+  {
+    "id": "2126|Les Verrières|NE",
+    "name": "Les Verrières",
+    "zipCode": "2126",
+    "canton": "NE"
+  },
+  {
+    "id": "2054|Les Vieux-Prés|NE",
+    "name": "Les Vieux-Prés",
+    "zipCode": "2054",
+    "canton": "NE"
+  },
+  {
+    "id": "1862|Les Voëttes|VD",
+    "name": "Les Voëttes",
+    "zipCode": "1862",
+    "canton": "VD"
+  },
+  {
+    "id": "1424|Les Vullierens|VD",
+    "name": "Les Vullierens",
+    "zipCode": "1424",
+    "canton": "VD"
+  },
+  {
+    "id": "1669|Lessoc|FR",
+    "name": "Lessoc",
+    "zipCode": "1669",
+    "canton": "FR"
+  },
+  {
+    "id": "8487|Lettenberg|ZH",
+    "name": "Lettenberg",
+    "zipCode": "8487",
+    "canton": "ZH"
+  },
+  {
+    "id": "9428|Leuchen|AR",
+    "name": "Leuchen",
+    "zipCode": "9428",
+    "canton": "AR"
+  },
+  {
+    "id": "8774|Leuggelbach|GL",
+    "name": "Leuggelbach",
+    "zipCode": "8774",
+    "canton": "GL"
+  },
+  {
+    "id": "5316|Leuggern|AG",
+    "name": "Leuggern",
+    "zipCode": "5316",
+    "canton": "AG"
+  },
+  {
+    "id": "3953|Leuk-Stadt|VS",
+    "name": "Leuk-Stadt",
+    "zipCode": "3953",
+    "canton": "VS"
+  },
+  {
+    "id": "3954|Leukerbad|VS",
+    "name": "Leukerbad",
+    "zipCode": "3954",
+    "canton": "VS"
+  },
+  {
+    "id": "5725|Leutwil|AG",
+    "name": "Leutwil",
+    "zipCode": "5725",
+    "canton": "AG"
+  },
+  {
+    "id": "3297|Leuzigen|BE",
+    "name": "Leuzigen",
+    "zipCode": "3297",
+    "canton": "BE"
+  },
+  {
+    "id": "1942|Levron|VS",
+    "name": "Levron",
+    "zipCode": "1942",
+    "canton": "VS"
+  },
+  {
+    "id": "1854|Leysin|VD",
+    "name": "Leysin",
+    "zipCode": "1854",
+    "canton": "VD"
+  },
+  {
+    "id": "1912|Leytron|VS",
+    "name": "Leytron",
+    "zipCode": "1912",
+    "canton": "VS"
+  },
+  {
+    "id": "7745|Li Curt|GR",
+    "name": "Li Curt",
+    "zipCode": "7745",
+    "canton": "GR"
+  },
+  {
+    "id": "9614|Libingen|SG",
+    "name": "Libingen",
+    "zipCode": "9614",
+    "canton": "SG"
+  },
+  {
+    "id": "9620|Lichtensteig|SG",
+    "name": "Lichtensteig",
+    "zipCode": "9620",
+    "canton": "SG"
+  },
+  {
+    "id": "1945|Liddes|VS",
+    "name": "Liddes",
+    "zipCode": "1945",
+    "canton": "VS"
+  },
+  {
+    "id": "1637|Liderrey|FR",
+    "name": "Liderrey",
+    "zipCode": "1637",
+    "canton": "FR"
+  },
+  {
+    "id": "3097|Liebefeld|BE",
+    "name": "Liebefeld",
+    "zipCode": "3097",
+    "canton": "BE"
+  },
+  {
+    "id": "8506|Liebenfels|TG",
+    "name": "Liebenfels",
+    "zipCode": "8506",
+    "canton": "TG"
+  },
+  {
+    "id": "8543|Liebensberg|ZH",
+    "name": "Liebensberg",
+    "zipCode": "8543",
+    "canton": "ZH"
+  },
+  {
+    "id": "3173|Liebewil|BE",
+    "name": "Liebewil",
+    "zipCode": "3173",
+    "canton": "BE"
+  },
+  {
+    "id": "3213|Liebistorf|FR",
+    "name": "Liebistorf",
+    "zipCode": "3213",
+    "canton": "FR"
+  },
+  {
+    "id": "4303|Liebrüti|AG",
+    "name": "Liebrüti",
+    "zipCode": "4303",
+    "canton": "AG"
+  },
+  {
+    "id": "4436|Liedertswil|BL",
+    "name": "Liedertswil",
+    "zipCode": "4436",
+    "canton": "BL"
+  },
+  {
+    "id": "1688|Lieffrens|FR",
+    "name": "Lieffrens",
+    "zipCode": "1688",
+    "canton": "FR"
+  },
+  {
+    "id": "6277|Lieli|LU",
+    "name": "Lieli",
+    "zipCode": "6277",
+    "canton": "LU"
+  },
+  {
+    "id": "8966|Lieli|AG",
+    "name": "Lieli",
+    "zipCode": "8966",
+    "canton": "AG"
+  },
+  {
+    "id": "9464|Lienz|SG",
+    "name": "Lienz",
+    "zipCode": "9464",
+    "canton": "SG"
+  },
+  {
+    "id": "4253|Liesberg|BL",
+    "name": "Liesberg",
+    "zipCode": "4253",
+    "canton": "BL"
+  },
+  {
+    "id": "4254|Liesberg Dorf|BL",
+    "name": "Liesberg Dorf",
+    "zipCode": "4254",
+    "canton": "BL"
+  },
+  {
+    "id": "4410|Liestal|BL",
+    "name": "Liestal",
+    "zipCode": "4410",
+    "canton": "BL"
+  },
+  {
+    "id": "1969|Liez|VS",
+    "name": "Liez",
+    "zipCode": "1969",
+    "canton": "VS"
+  },
+  {
+    "id": "2514|Ligerz|BE",
+    "name": "Ligerz",
+    "zipCode": "2514",
+    "canton": "BE"
+  },
+  {
+    "id": "1357|Lignerolle|VD",
+    "name": "Lignerolle",
+    "zipCode": "1357",
+    "canton": "VD"
+  },
+  {
+    "id": "2523|Lignières|NE",
+    "name": "Lignières",
+    "zipCode": "2523",
+    "canton": "NE"
+  },
+  {
+    "id": "6853|Ligornetto|TI",
+    "name": "Ligornetto",
+    "zipCode": "6853",
+    "canton": "TI"
+  },
+  {
+    "id": "8127|Limberg|ZH",
+    "name": "Limberg",
+    "zipCode": "8127",
+    "canton": "ZH"
+  },
+  {
+    "id": "3317|Limpach|BE",
+    "name": "Limpach",
+    "zipCode": "3317",
+    "canton": "BE"
+  },
+  {
+    "id": "8315|Lindau|ZH",
+    "name": "Lindau",
+    "zipCode": "8315",
+    "canton": "ZH"
+  },
+  {
+    "id": "3673|Linden|BE",
+    "name": "Linden",
+    "zipCode": "3673",
+    "canton": "BE"
+  },
+  {
+    "id": "4812|Linden|AG",
+    "name": "Linden",
+    "zipCode": "4812",
+    "canton": "AG"
+  },
+  {
+    "id": "6332|Lindencham|ZG",
+    "name": "Lindencham",
+    "zipCode": "6332",
+    "canton": "ZG"
+  },
+  {
+    "id": "4935|Lindenholz|BE",
+    "name": "Lindenholz",
+    "zipCode": "4935",
+    "canton": "BE"
+  },
+  {
+    "id": "3067|Lindenthal bei Boll|BE",
+    "name": "Lindenthal bei Boll",
+    "zipCode": "3067",
+    "canton": "BE"
+  },
+  {
+    "id": "9032|Lindenwis|SG",
+    "name": "Lindenwis",
+    "zipCode": "9032",
+    "canton": "SG"
+  },
+  {
+    "id": "6682|Linescio|TI",
+    "name": "Linescio",
+    "zipCode": "6682",
+    "canton": "TI"
+  },
+  {
+    "id": "5225|Linn|AG",
+    "name": "Linn",
+    "zipCode": "5225",
+    "canton": "AG"
+  },
+  {
+    "id": "8783|Linthal|GL",
+    "name": "Linthal",
+    "zipCode": "8783",
+    "canton": "GL"
+  },
+  {
+    "id": "8494|Lippenschwendi|ZH",
+    "name": "Lippenschwendi",
+    "zipCode": "8494",
+    "canton": "ZH"
+  },
+  {
+    "id": "8564|Lipperswil|TG",
+    "name": "Lipperswil",
+    "zipCode": "8564",
+    "canton": "TG"
+  },
+  {
+    "id": "8566|Lippoldswilen|TG",
+    "name": "Lippoldswilen",
+    "zipCode": "8566",
+    "canton": "TG"
+  },
+  {
+    "id": "6936|Lisone|TI",
+    "name": "Lisone",
+    "zipCode": "6936",
+    "canton": "TI"
+  },
+  {
+    "id": "6014|Littau|LU",
+    "name": "Littau",
+    "zipCode": "6014",
+    "canton": "LU"
+  },
+  {
+    "id": "9573|Littenheid|TG",
+    "name": "Littenheid",
+    "zipCode": "9573",
+    "canton": "TG"
+  },
+  {
+    "id": "7058|Litzirüti|GR",
+    "name": "Litzirüti",
+    "zipCode": "7058",
+    "canton": "GR"
+  },
+  {
+    "id": "3178|Litzistorf|FR",
+    "name": "Litzistorf",
+    "zipCode": "3178",
+    "canton": "FR"
+  },
+  {
+    "id": "3268|Lobsigen|BE",
+    "name": "Lobsigen",
+    "zipCode": "3268",
+    "canton": "BE"
+  },
+  {
+    "id": "3960|Loc|VS",
+    "name": "Loc",
+    "zipCode": "3960",
+    "canton": "VS"
+  },
+  {
+    "id": "6600|Locarno|TI",
+    "name": "Locarno",
+    "zipCode": "6600",
+    "canton": "TI"
+  },
+  {
+    "id": "9404|Loch|SG",
+    "name": "Loch",
+    "zipCode": "9404",
+    "canton": "SG"
+  },
+  {
+    "id": "6661|Loco|TI",
+    "name": "Loco",
+    "zipCode": "6661",
+    "canton": "TI"
+  },
+  {
+    "id": "6678|Lodano|TI",
+    "name": "Lodano",
+    "zipCode": "6678",
+    "canton": "TI"
+  },
+  {
+    "id": "6527|Lodrino|TI",
+    "name": "Lodrino",
+    "zipCode": "6527",
+    "canton": "TI"
+  },
+  {
+    "id": "1233|Loëx|GE",
+    "name": "Loëx",
+    "zipCode": "1233",
+    "canton": "GE"
+  },
+  {
+    "id": "6563|Logiano|GR",
+    "name": "Logiano",
+    "zipCode": "6563",
+    "canton": "GR"
+  },
+  {
+    "id": "4573|Lohn|SO",
+    "name": "Lohn",
+    "zipCode": "4573",
+    "canton": "SO"
+  },
+  {
+    "id": "7433|Lohn|GR",
+    "name": "Lohn",
+    "zipCode": "7433",
+    "canton": "GR"
+  },
+  {
+    "id": "8235|Lohn|SH",
+    "name": "Lohn",
+    "zipCode": "8235",
+    "canton": "SH"
+  },
+  {
+    "id": "8224|Löhningen|SH",
+    "name": "Löhningen",
+    "zipCode": "8224",
+    "canton": "SH"
+  },
+  {
+    "id": "3127|Lohnstorf|BE",
+    "name": "Lohnstorf",
+    "zipCode": "3127",
+    "canton": "BE"
+  },
+  {
+    "id": "9308|Lömmenschwil|SG",
+    "name": "Lömmenschwil",
+    "zipCode": "9308",
+    "canton": "SG"
+  },
+  {
+    "id": "9506|Lommis|TG",
+    "name": "Lommis",
+    "zipCode": "9506",
+    "canton": "TG"
+  },
+  {
+    "id": "4514|Lommiswil|SO",
+    "name": "Lommiswil",
+    "zipCode": "4514",
+    "canton": "SO"
+  },
+  {
+    "id": "1027|Lonay|VD",
+    "name": "Lonay",
+    "zipCode": "1027",
+    "canton": "VD"
+  },
+  {
+    "id": "1261|Longirod|VD",
+    "name": "Longirod",
+    "zipCode": "1261",
+    "canton": "VD"
+  },
+  {
+    "id": "6956|Lopagno|TI",
+    "name": "Lopagno",
+    "zipCode": "6956",
+    "canton": "TI"
+  },
+  {
+    "id": "6582|Loro|TI",
+    "name": "Loro",
+    "zipCode": "6582",
+    "canton": "TI"
+  },
+  {
+    "id": "3000|Lorraine|BE",
+    "name": "Lorraine",
+    "zipCode": "3000",
+    "canton": "BE"
+  },
+  {
+    "id": "6300|Lorzen|ZG",
+    "name": "Lorzen",
+    "zipCode": "6300",
+    "canton": "ZG"
+  },
+  {
+    "id": "6616|Losone|TI",
+    "name": "Losone",
+    "zipCode": "6616",
+    "canton": "TI"
+  },
+  {
+    "id": "1782|Lossy|FR",
+    "name": "Lossy",
+    "zipCode": "1782",
+    "canton": "FR"
+  },
+  {
+    "id": "6558|Lostallo|GR",
+    "name": "Lostallo",
+    "zipCode": "6558",
+    "canton": "GR"
+  },
+  {
+    "id": "4654|Lostorf|SO",
+    "name": "Lostorf",
+    "zipCode": "4654",
+    "canton": "SO"
+  },
+  {
+    "id": "6716|Lottigna|TI",
+    "name": "Lottigna",
+    "zipCode": "6716",
+    "canton": "TI"
+  },
+  {
+    "id": "4932|Lotzwil|BE",
+    "name": "Lotzwil",
+    "zipCode": "4932",
+    "canton": "BE"
+  },
+  {
+    "id": "1948|Lourtier|VS",
+    "name": "Lourtier",
+    "zipCode": "1948",
+    "canton": "VS"
+  },
+  {
+    "id": "1682|Lovatens|VD",
+    "name": "Lovatens",
+    "zipCode": "1682",
+    "canton": "VD"
+  },
+  {
+    "id": "1756|Lovens|FR",
+    "name": "Lovens",
+    "zipCode": "1756",
+    "canton": "FR"
+  },
+  {
+    "id": "2732|Loveresse|BE",
+    "name": "Loveresse",
+    "zipCode": "2732",
+    "canton": "BE"
+  },
+  {
+    "id": "2813|Löwenburg|JU",
+    "name": "Löwenburg",
+    "zipCode": "2813",
+    "canton": "JU"
+  },
+  {
+    "id": "3979|Loye|VS",
+    "name": "Loye",
+    "zipCode": "3979",
+    "canton": "VS"
+  },
+  {
+    "id": "7534|Lü|GR",
+    "name": "Lü",
+    "zipCode": "7534",
+    "canton": "GR"
+  },
+  {
+    "id": "1966|Luc|VS",
+    "name": "Luc",
+    "zipCode": "1966",
+    "canton": "VS"
+  },
+  {
+    "id": "2807|Lucelle|JU",
+    "name": "Lucelle",
+    "zipCode": "2807",
+    "canton": "JU"
+  },
+  {
+    "id": "1522|Lucens|VD",
+    "name": "Lucens",
+    "zipCode": "1522",
+    "canton": "VD"
+  },
+  {
+    "id": "9450|Lüchingen|AI",
+    "name": "Lüchingen",
+    "zipCode": "9450",
+    "canton": "AI"
+  },
+  {
+    "id": "9450|Lüchingen|SG",
+    "name": "Lüchingen",
+    "zipCode": "9450",
+    "canton": "SG"
+  },
+  {
+    "id": "8775|Luchsingen|GL",
+    "name": "Luchsingen",
+    "zipCode": "8775",
+    "canton": "GL"
+  },
+  {
+    "id": "8307|Luckhausen|ZH",
+    "name": "Luckhausen",
+    "zipCode": "8307",
+    "canton": "ZH"
+  },
+  {
+    "id": "7185|Lucomagno|TI",
+    "name": "Lucomagno",
+    "zipCode": "7185",
+    "canton": "TI"
+  },
+  {
+    "id": "8322|Ludetswil|ZH",
+    "name": "Ludetswil",
+    "zipCode": "8322",
+    "canton": "ZH"
+  },
+  {
+    "id": "6721|Ludiano|TI",
+    "name": "Ludiano",
+    "zipCode": "6721",
+    "canton": "TI"
+  },
+  {
+    "id": "8800|Ludretikon|ZH",
+    "name": "Ludretikon",
+    "zipCode": "8800",
+    "canton": "ZH"
+  },
+  {
+    "id": "7027|Lüen|GR",
+    "name": "Lüen",
+    "zipCode": "7027",
+    "canton": "GR"
+  },
+  {
+    "id": "8426|Lufingen|ZH",
+    "name": "Lufingen",
+    "zipCode": "8426",
+    "canton": "ZH"
+  },
+  {
+    "id": "6953|Lugaggia|TI",
+    "name": "Lugaggia",
+    "zipCode": "6953",
+    "canton": "TI"
+  },
+  {
+    "id": "6900|Lugano|TI",
+    "name": "Lugano",
+    "zipCode": "6900",
+    "canton": "TI"
+  },
+  {
+    "id": "2933|Lugnez|JU",
+    "name": "Lugnez",
+    "zipCode": "2933",
+    "canton": "JU"
+  },
+  {
+    "id": "1789|Lugnorre|FR",
+    "name": "Lugnorre",
+    "zipCode": "1789",
+    "canton": "FR"
+  },
+  {
+    "id": "1184|Luins|VD",
+    "name": "Luins",
+    "zipCode": "1184",
+    "canton": "VD"
+  },
+  {
+    "id": "1254|Lullier|GE",
+    "name": "Lullier",
+    "zipCode": "1254",
+    "canton": "GE"
+  },
+  {
+    "id": "1132|Lully|VD",
+    "name": "Lully",
+    "zipCode": "1132",
+    "canton": "VD"
+  },
+  {
+    "id": "1223|Lully|GE",
+    "name": "Lully",
+    "zipCode": "1223",
+    "canton": "GE"
+  },
+  {
+    "id": "1470|Lully|FR",
+    "name": "Lully",
+    "zipCode": "1470",
+    "canton": "FR"
+  },
+  {
+    "id": "7148|Lumbrein|GR",
+    "name": "Lumbrein",
+    "zipCode": "7148",
+    "canton": "GR"
+  },
+  {
+    "id": "6533|Lumino|TI",
+    "name": "Lumino",
+    "zipCode": "6533",
+    "canton": "TI"
+  },
+  {
+    "id": "7166|Lumneins|GR",
+    "name": "Lumneins",
+    "zipCode": "7166",
+    "canton": "GR"
+  },
+  {
+    "id": "7222|Lunden|GR",
+    "name": "Lunden",
+    "zipCode": "7222",
+    "canton": "GR"
+  },
+  {
+    "id": "6078|Lungern|OW",
+    "name": "Lungern",
+    "zipCode": "6078",
+    "canton": "OW"
+  },
+  {
+    "id": "7116|Lunschania|GR",
+    "name": "Lunschania",
+    "zipCode": "7116",
+    "canton": "GR"
+  },
+  {
+    "id": "5242|Lupfig|AG",
+    "name": "Lupfig",
+    "zipCode": "5242",
+    "canton": "AG"
+  },
+  {
+    "id": "4419|Lupsingen|BL",
+    "name": "Lupsingen",
+    "zipCode": "4419",
+    "canton": "BL"
+  },
+  {
+    "id": "6777|Lurengo|TI",
+    "name": "Lurengo",
+    "zipCode": "6777",
+    "canton": "TI"
+  },
+  {
+    "id": "3215|Lurtigen|FR",
+    "name": "Lurtigen",
+    "zipCode": "3215",
+    "canton": "FR"
+  },
+  {
+    "id": "2576|Lüscherz|BE",
+    "name": "Lüscherz",
+    "zipCode": "2576",
+    "canton": "BE"
+  },
+  {
+    "id": "1307|Lussery|VD",
+    "name": "Lussery",
+    "zipCode": "1307",
+    "canton": "VD"
+  },
+  {
+    "id": "4574|Lüsslingen|SO",
+    "name": "Lüsslingen",
+    "zipCode": "4574",
+    "canton": "SO"
+  },
+  {
+    "id": "1690|Lussy|FR",
+    "name": "Lussy",
+    "zipCode": "1690",
+    "canton": "FR"
+  },
+  {
+    "id": "1167|Lussy-sur-Morges|VD",
+    "name": "Lussy-sur-Morges",
+    "zipCode": "1167",
+    "canton": "VD"
+  },
+  {
+    "id": "8512|Lustdorf|TG",
+    "name": "Lustdorf",
+    "zipCode": "8512",
+    "canton": "TG"
+  },
+  {
+    "id": "9062|Lustmühle|AR",
+    "name": "Lustmühle",
+    "zipCode": "9062",
+    "canton": "AR"
+  },
+  {
+    "id": "4542|Luterbach|SO",
+    "name": "Luterbach",
+    "zipCode": "4542",
+    "canton": "SO"
+  },
+  {
+    "id": "4571|Lüterkofen|SO",
+    "name": "Lüterkofen",
+    "zipCode": "4571",
+    "canton": "SO"
+  },
+  {
+    "id": "4584|Lüterswil|SO",
+    "name": "Lüterswil",
+    "zipCode": "4584",
+    "canton": "SO"
+  },
+  {
+    "id": "6156|Luthern|LU",
+    "name": "Luthern",
+    "zipCode": "6156",
+    "canton": "LU"
+  },
+  {
+    "id": "6156|Luthern Bad|LU",
+    "name": "Luthern Bad",
+    "zipCode": "6156",
+    "canton": "LU"
+  },
+  {
+    "id": "8712|Lutikon|ZH",
+    "name": "Lutikon",
+    "zipCode": "8712",
+    "canton": "ZH"
+  },
+  {
+    "id": "9604|Lütisburg|SG",
+    "name": "Lütisburg",
+    "zipCode": "9604",
+    "canton": "SG"
+  },
+  {
+    "id": "9601|Lütisburg Station|SG",
+    "name": "Lütisburg Station",
+    "zipCode": "9601",
+    "canton": "SG"
+  },
+  {
+    "id": "1095|Lutry|VD",
+    "name": "Lutry",
+    "zipCode": "1095",
+    "canton": "VD"
+  },
+  {
+    "id": "3816|Lütschental|BE",
+    "name": "Lütschental",
+    "zipCode": "3816",
+    "canton": "BE"
+  },
+  {
+    "id": "3432|Lützelflüh|BE",
+    "name": "Lützelflüh",
+    "zipCode": "3432",
+    "canton": "BE"
+  },
+  {
+    "id": "9426|Lutzenberg|AR",
+    "name": "Lutzenberg",
+    "zipCode": "9426",
+    "canton": "AR"
+  },
+  {
+    "id": "7141|Luven|GR",
+    "name": "Luven",
+    "zipCode": "7141",
+    "canton": "GR"
+  },
+  {
+    "id": "7242|Luzein|GR",
+    "name": "Luzein",
+    "zipCode": "7242",
+    "canton": "GR"
+  },
+  {
+    "id": "6000|Luzern|LU",
+    "name": "Luzern",
+    "zipCode": "6000",
+    "canton": "LU"
+  },
+  {
+    "id": "3250|Lyss|BE",
+    "name": "Lyss",
+    "zipCode": "3250",
+    "canton": "BE"
+  },
+  {
+    "id": "3421|Lyssach|BE",
+    "name": "Lyssach",
+    "zipCode": "3421",
+    "canton": "BE"
+  },
+  {
+    "id": "1987|Mâche|VS",
+    "name": "Mâche",
+    "zipCode": "1987",
+    "canton": "VS"
+  },
+  {
+    "id": "6475|Maderanerthal|UR",
+    "name": "Maderanerthal",
+    "zipCode": "6475",
+    "canton": "UR"
+  },
+  {
+    "id": "8322|Madetswil|ZH",
+    "name": "Madetswil",
+    "zipCode": "8322",
+    "canton": "ZH"
+  },
+  {
+    "id": "4934|Madiswil|BE",
+    "name": "Madiswil",
+    "zipCode": "4934",
+    "canton": "BE"
+  },
+  {
+    "id": "6995|Madonna del Piano|TI",
+    "name": "Madonna del Piano",
+    "zipCode": "6995",
+    "canton": "TI"
+  },
+  {
+    "id": "6780|Madrano|TI",
+    "name": "Madrano",
+    "zipCode": "6780",
+    "canton": "TI"
+  },
+  {
+    "id": "2500|Madretsch|BE",
+    "name": "Madretsch",
+    "zipCode": "2500",
+    "canton": "BE"
+  },
+  {
+    "id": "8886|Mädris|SG",
+    "name": "Mädris",
+    "zipCode": "8886",
+    "canton": "SG"
+  },
+  {
+    "id": "7523|Madulain|GR",
+    "name": "Madulain",
+    "zipCode": "7523",
+    "canton": "GR"
+  },
+  {
+    "id": "6573|Magadino|TI",
+    "name": "Magadino",
+    "zipCode": "6573",
+    "canton": "TI"
+  },
+  {
+    "id": "4312|Magden|AG",
+    "name": "Magden",
+    "zipCode": "4312",
+    "canton": "AG"
+  },
+  {
+    "id": "9116|Magdenau|SG",
+    "name": "Magdenau",
+    "zipCode": "9116",
+    "canton": "SG"
+  },
+  {
+    "id": "5506|Mägenwil|AG",
+    "name": "Mägenwil",
+    "zipCode": "5506",
+    "canton": "AG"
+  },
+  {
+    "id": "6673|Maggia|TI",
+    "name": "Maggia",
+    "zipCode": "6673",
+    "canton": "TI"
+  },
+  {
+    "id": "2532|Magglingen/Macolin|BE",
+    "name": "Magglingen/Macolin",
+    "zipCode": "2532",
+    "canton": "BE"
+  },
+  {
+    "id": "6987|Magliasina|TI",
+    "name": "Magliasina",
+    "zipCode": "6987",
+    "canton": "TI"
+  },
+  {
+    "id": "6983|Magliaso|TI",
+    "name": "Magliaso",
+    "zipCode": "6983",
+    "canton": "TI"
+  },
+  {
+    "id": "6959|Maglio di Colla|TI",
+    "name": "Maglio di Colla",
+    "zipCode": "6959",
+    "canton": "TI"
+  },
+  {
+    "id": "1727|Magnedens|FR",
+    "name": "Magnedens",
+    "zipCode": "1727",
+    "canton": "FR"
+  },
+  {
+    "id": "1963|Magnot|VS",
+    "name": "Magnot",
+    "zipCode": "1963",
+    "canton": "VS"
+  },
+  {
+    "id": "7442|Magun|GR",
+    "name": "Magun",
+    "zipCode": "7442",
+    "canton": "GR"
+  },
+  {
+    "id": "4654|Mahren|SO",
+    "name": "Mahren",
+    "zipCode": "4654",
+    "canton": "SO"
+  },
+  {
+    "id": "7304|Maienfeld|GR",
+    "name": "Maienfeld",
+    "zipCode": "7304",
+    "canton": "GR"
+  },
+  {
+    "id": "6763|Mairengo|TI",
+    "name": "Mairengo",
+    "zipCode": "6763",
+    "canton": "TI"
+  },
+  {
+    "id": "8357|Maischhusen|TG",
+    "name": "Maischhusen",
+    "zipCode": "8357",
+    "canton": "TG"
+  },
+  {
+    "id": "4464|Maisprach|BL",
+    "name": "Maisprach",
+    "zipCode": "4464",
+    "canton": "BL"
+  },
+  {
+    "id": "7026|Maladers|GR",
+    "name": "Maladers",
+    "zipCode": "7026",
+    "canton": "GR"
+  },
+  {
+    "id": "1294|Malagny|GE",
+    "name": "Malagny",
+    "zipCode": "1294",
+    "canton": "GE"
+  },
+  {
+    "id": "7208|Malans|GR",
+    "name": "Malans",
+    "zipCode": "7208",
+    "canton": "GR"
+  },
+  {
+    "id": "9479|Malans|SG",
+    "name": "Malans",
+    "zipCode": "9479",
+    "canton": "SG"
+  },
+  {
+    "id": "1042|Malapalud|VD",
+    "name": "Malapalud",
+    "zipCode": "1042",
+    "canton": "VD"
+  },
+  {
+    "id": "7074|Malix|GR",
+    "name": "Malix",
+    "zipCode": "7074",
+    "canton": "GR"
+  },
+  {
+    "id": "2735|Malleray|BE",
+    "name": "Malleray",
+    "zipCode": "2735",
+    "canton": "BE"
+  },
+  {
+    "id": "1000|Malley|VD",
+    "name": "Malley",
+    "zipCode": "1000",
+    "canton": "VD"
+  },
+  {
+    "id": "7516|Maloja|GR",
+    "name": "Maloja",
+    "zipCode": "7516",
+    "canton": "GR"
+  },
+  {
+    "id": "6102|Malters|LU",
+    "name": "Malters",
+    "zipCode": "6102",
+    "canton": "LU"
+  },
+  {
+    "id": "6713|Malvaglia|TI",
+    "name": "Malvaglia",
+    "zipCode": "6713",
+    "canton": "TI"
+  },
+  {
+    "id": "1283|Malval|GE",
+    "name": "Malval",
+    "zipCode": "1283",
+    "canton": "GE"
+  },
+  {
+    "id": "2043|Malvilliers|NE",
+    "name": "Malvilliers",
+    "zipCode": "2043",
+    "canton": "NE"
+  },
+  {
+    "id": "3152|Mamishaus|BE",
+    "name": "Mamishaus",
+    "zipCode": "3152",
+    "canton": "BE"
+  },
+  {
+    "id": "8265|Mammern|TG",
+    "name": "Mammern",
+    "zipCode": "8265",
+    "canton": "TG"
+  },
+  {
+    "id": "5318|Mandach|AG",
+    "name": "Mandach",
+    "zipCode": "5318",
+    "canton": "AG"
+  },
+  {
+    "id": "8708|Männedorf|ZH",
+    "name": "Männedorf",
+    "zipCode": "8708",
+    "canton": "ZH"
+  },
+  {
+    "id": "8268|Mannenbach|TG",
+    "name": "Mannenbach",
+    "zipCode": "8268",
+    "canton": "TG"
+  },
+  {
+    "id": "1775|Mannens|FR",
+    "name": "Mannens",
+    "zipCode": "1775",
+    "canton": "FR"
+  },
+  {
+    "id": "3823|Männlichen|BE",
+    "name": "Männlichen",
+    "zipCode": "3823",
+    "canton": "BE"
+  },
+  {
+    "id": "6928|Manno|TI",
+    "name": "Manno",
+    "zipCode": "6928",
+    "canton": "TI"
+  },
+  {
+    "id": "3770|Mannried|BE",
+    "name": "Mannried",
+    "zipCode": "3770",
+    "canton": "BE"
+  },
+  {
+    "id": "8492|Manzenhub|ZH",
+    "name": "Manzenhub",
+    "zipCode": "8492",
+    "canton": "ZH"
+  },
+  {
+    "id": "1613|Maracon|VD",
+    "name": "Maracon",
+    "zipCode": "1613",
+    "canton": "VD"
+  },
+  {
+    "id": "6196|Marbach|LU",
+    "name": "Marbach",
+    "zipCode": "6196",
+    "canton": "LU"
+  },
+  {
+    "id": "9437|Marbach|SG",
+    "name": "Marbach",
+    "zipCode": "9437",
+    "canton": "SG"
+  },
+  {
+    "id": "1261|Marchissy|VD",
+    "name": "Marchissy",
+    "zipCode": "1261",
+    "canton": "VD"
+  },
+  {
+    "id": "3203|Marfeldingen|BE",
+    "name": "Marfeldingen",
+    "zipCode": "3203",
+    "canton": "BE"
+  },
+  {
+    "id": "3186|Mariahilf|FR",
+    "name": "Mariahilf",
+    "zipCode": "3186",
+    "canton": "FR"
+  },
+  {
+    "id": "4115|Mariastein|SO",
+    "name": "Mariastein",
+    "zipCode": "4115",
+    "canton": "SO"
+  },
+  {
+    "id": "2074|Marin|NE",
+    "name": "Marin",
+    "zipCode": "2074",
+    "canton": "NE"
+  },
+  {
+    "id": "1723|Marly|FR",
+    "name": "Marly",
+    "zipCode": "1723",
+    "canton": "FR"
+  },
+  {
+    "id": "7456|Marmorera|GR",
+    "name": "Marmorera",
+    "zipCode": "7456",
+    "canton": "GR"
+  },
+  {
+    "id": "1524|Marnand|VD",
+    "name": "Marnand",
+    "zipCode": "1524",
+    "canton": "VD"
+  },
+  {
+    "id": "6817|Maroggia|TI",
+    "name": "Maroggia",
+    "zipCode": "6817",
+    "canton": "TI"
+  },
+  {
+    "id": "6723|Marolta|TI",
+    "name": "Marolta",
+    "zipCode": "6723",
+    "canton": "TI"
+  },
+  {
+    "id": "1633|Marsens|FR",
+    "name": "Marsens",
+    "zipCode": "1633",
+    "canton": "FR"
+  },
+  {
+    "id": "8560|Märstetten|TG",
+    "name": "Märstetten",
+    "zipCode": "8560",
+    "canton": "TG"
+  },
+  {
+    "id": "8560|Märstetten Station|TG",
+    "name": "Märstetten Station",
+    "zipCode": "8560",
+    "canton": "TG"
+  },
+  {
+    "id": "2316|Martel-Dernier|NE",
+    "name": "Martel-Dernier",
+    "zipCode": "2316",
+    "canton": "NE"
+  },
+  {
+    "id": "8460|Marthalen|ZH",
+    "name": "Marthalen",
+    "zipCode": "8460",
+    "canton": "ZH"
+  },
+  {
+    "id": "1063|Martherenges|VD",
+    "name": "Martherenges",
+    "zipCode": "1063",
+    "canton": "VD"
+  },
+  {
+    "id": "1920|Martigny|VS",
+    "name": "Martigny",
+    "zipCode": "1920",
+    "canton": "VS"
+  },
+  {
+    "id": "1921|Martigny-Combe|VS",
+    "name": "Martigny-Combe",
+    "zipCode": "1921",
+    "canton": "VS"
+  },
+  {
+    "id": "7560|Martina|GR",
+    "name": "Martina",
+    "zipCode": "7560",
+    "canton": "GR"
+  },
+  {
+    "id": "3994|Martisberg|VS",
+    "name": "Martisberg",
+    "zipCode": "3994",
+    "canton": "VS"
+  },
+  {
+    "id": "9562|Märwil|TG",
+    "name": "Märwil",
+    "zipCode": "9562",
+    "canton": "TG"
+  },
+  {
+    "id": "6718|Marzano|TI",
+    "name": "Marzano",
+    "zipCode": "6718",
+    "canton": "TI"
+  },
+  {
+    "id": "7000|Masans|GR",
+    "name": "Masans",
+    "zipCode": "7000",
+    "canton": "GR"
+  },
+  {
+    "id": "8933|Maschwanden|ZH",
+    "name": "Maschwanden",
+    "zipCode": "8933",
+    "canton": "ZH"
+  },
+  {
+    "id": "1968|Mase|VS",
+    "name": "Mase",
+    "zipCode": "1968",
+    "canton": "VS"
+  },
+  {
+    "id": "7425|Masein|GR",
+    "name": "Masein",
+    "zipCode": "7425",
+    "canton": "GR"
+  },
+  {
+    "id": "8723|Maseltrangen|SG",
+    "name": "Maseltrangen",
+    "zipCode": "8723",
+    "canton": "SG"
+  },
+  {
+    "id": "6900|Massagno|TI",
+    "name": "Massagno",
+    "zipCode": "6900",
+    "canton": "TI"
+  },
+  {
+    "id": "1869|Massongex|VS",
+    "name": "Massongex",
+    "zipCode": "1869",
+    "canton": "VS"
+  },
+  {
+    "id": "1692|Massonnens|FR",
+    "name": "Massonnens",
+    "zipCode": "1692",
+    "canton": "FR"
+  },
+  {
+    "id": "7303|Mastrils|GR",
+    "name": "Mastrils",
+    "zipCode": "7303",
+    "canton": "GR"
+  },
+  {
+    "id": "1217|Mategnin|GE",
+    "name": "Mategnin",
+    "zipCode": "1217",
+    "canton": "GE"
+  },
+  {
+    "id": "1438|Mathod|VD",
+    "name": "Mathod",
+    "zipCode": "1438",
+    "canton": "VD"
+  },
+  {
+    "id": "7433|Mathon|GR",
+    "name": "Mathon",
+    "zipCode": "7433",
+    "canton": "GR"
+  },
+  {
+    "id": "1753|Matran|FR",
+    "name": "Matran",
+    "zipCode": "1753",
+    "canton": "FR"
+  },
+  {
+    "id": "8766|Matt|GL",
+    "name": "Matt",
+    "zipCode": "8766",
+    "canton": "GL"
+  },
+  {
+    "id": "3773|Matten|BE",
+    "name": "Matten",
+    "zipCode": "3773",
+    "canton": "BE"
+  },
+  {
+    "id": "3800|Matten bei Interlaken|BE",
+    "name": "Matten bei Interlaken",
+    "zipCode": "3800",
+    "canton": "BE"
+  },
+  {
+    "id": "4934|Mättenbach|BE",
+    "name": "Mättenbach",
+    "zipCode": "4934",
+    "canton": "BE"
+  },
+  {
+    "id": "3000|Mattenhof|BE",
+    "name": "Mattenhof",
+    "zipCode": "3000",
+    "canton": "BE"
+  },
+  {
+    "id": "4000|Matthäus|BS",
+    "name": "Matthäus",
+    "zipCode": "4000",
+    "canton": "BS"
+  },
+  {
+    "id": "3927|Mattsand|VS",
+    "name": "Mattsand",
+    "zipCode": "3927",
+    "canton": "VS"
+  },
+  {
+    "id": "3322|Mattstetten|BE",
+    "name": "Mattstetten",
+    "zipCode": "3322",
+    "canton": "BE"
+  },
+  {
+    "id": "8585|Mattwil|TG",
+    "name": "Mattwil",
+    "zipCode": "8585",
+    "canton": "TG"
+  },
+  {
+    "id": "4713|Matzendorf|SO",
+    "name": "Matzendorf",
+    "zipCode": "4713",
+    "canton": "SO"
+  },
+  {
+    "id": "3000|Matzenried|BE",
+    "name": "Matzenried",
+    "zipCode": "3000",
+    "canton": "BE"
+  },
+  {
+    "id": "9548|Matzingen|TG",
+    "name": "Matzingen",
+    "zipCode": "9548",
+    "canton": "TG"
+  },
+  {
+    "id": "3036|Matzwil|BE",
+    "name": "Matzwil",
+    "zipCode": "3036",
+    "canton": "BE"
+  },
+  {
+    "id": "1453|Mauborget|VD",
+    "name": "Mauborget",
+    "zipCode": "1453",
+    "canton": "VD"
+  },
+  {
+    "id": "6216|Mauensee|LU",
+    "name": "Mauensee",
+    "zipCode": "6216",
+    "canton": "LU"
+  },
+  {
+    "id": "1625|Maules|FR",
+    "name": "Maules",
+    "zipCode": "1625",
+    "canton": "FR"
+  },
+  {
+    "id": "8124|Maur|ZH",
+    "name": "Maur",
+    "zipCode": "8124",
+    "canton": "ZH"
+  },
+  {
+    "id": "3935|Mauracker|VS",
+    "name": "Mauracker",
+    "zipCode": "3935",
+    "canton": "VS"
+  },
+  {
+    "id": "1148|Mauraz|VD",
+    "name": "Mauraz",
+    "zipCode": "1148",
+    "canton": "VD"
+  },
+  {
+    "id": "8576|Mauren|TG",
+    "name": "Mauren",
+    "zipCode": "8576",
+    "canton": "TG"
+  },
+  {
+    "id": "3205|Mauss|BE",
+    "name": "Mauss",
+    "zipCode": "3205",
+    "canton": "BE"
+  },
+  {
+    "id": "1948|Mauvoisin|VS",
+    "name": "Mauvoisin",
+    "zipCode": "1948",
+    "canton": "VS"
+  },
+  {
+    "id": "1899|Mayen|VS",
+    "name": "Mayen",
+    "zipCode": "1899",
+    "canton": "VS"
+  },
+  {
+    "id": "1911|Mayens-de-Chamoson|VS",
+    "name": "Mayens-de-Chamoson",
+    "zipCode": "1911",
+    "canton": "VS"
+  },
+  {
+    "id": "1965|Mayens-de-la-Zour|VS",
+    "name": "Mayens-de-la-Zour",
+    "zipCode": "1965",
+    "canton": "VS"
+  },
+  {
+    "id": "1973|Mayens-de-Nax|VS",
+    "name": "Mayens-de-Nax",
+    "zipCode": "1973",
+    "canton": "VS"
+  },
+  {
+    "id": "1918|Mayens-de-Riddes|VS",
+    "name": "Mayens-de-Riddes",
+    "zipCode": "1918",
+    "canton": "VS"
+  },
+  {
+    "id": "3961|Mayoux|VS",
+    "name": "Mayoux",
+    "zipCode": "3961",
+    "canton": "VS"
+  },
+  {
+    "id": "1926|Mazembroz|VS",
+    "name": "Mazembroz",
+    "zipCode": "1926",
+    "canton": "VS"
+  },
+  {
+    "id": "6809|Medeglia|TI",
+    "name": "Medeglia",
+    "zipCode": "6809",
+    "canton": "TI"
+  },
+  {
+    "id": "7184|Medel|GR",
+    "name": "Medel",
+    "zipCode": "7184",
+    "canton": "GR"
+  },
+  {
+    "id": "7436|Medels im Rheinwald|GR",
+    "name": "Medels im Rheinwald",
+    "zipCode": "7436",
+    "canton": "GR"
+  },
+  {
+    "id": "1936|Médières|VS",
+    "name": "Médières",
+    "zipCode": "1936",
+    "canton": "VS"
+  },
+  {
+    "id": "8620|Medikon|ZH",
+    "name": "Medikon",
+    "zipCode": "8620",
+    "canton": "ZH"
+  },
+  {
+    "id": "6597|Medoscio|TI",
+    "name": "Medoscio",
+    "zipCode": "6597",
+    "canton": "TI"
+  },
+  {
+    "id": "6045|Meggen|LU",
+    "name": "Meggen",
+    "zipCode": "6045",
+    "canton": "LU"
+  },
+  {
+    "id": "6260|Mehlsecken|LU",
+    "name": "Mehlsecken",
+    "zipCode": "6260",
+    "canton": "LU"
+  },
+  {
+    "id": "6485|Meien|UR",
+    "name": "Meien",
+    "zipCode": "6485",
+    "canton": "UR"
+  },
+  {
+    "id": "5643|Meienberg|AG",
+    "name": "Meienberg",
+    "zipCode": "5643",
+    "canton": "AG"
+  },
+  {
+    "id": "3294|Meienried|BE",
+    "name": "Meienried",
+    "zipCode": "3294",
+    "canton": "BE"
+  },
+  {
+    "id": "7134|Meierhof|GR",
+    "name": "Meierhof",
+    "zipCode": "7134",
+    "canton": "GR"
+  },
+  {
+    "id": "6344|Meierskappel|LU",
+    "name": "Meierskappel",
+    "zipCode": "6344",
+    "canton": "LU"
+  },
+  {
+    "id": "3657|Meiersmaad (Sigriswil)|BE",
+    "name": "Meiersmaad (Sigriswil)",
+    "zipCode": "3657",
+    "canton": "BE"
+  },
+  {
+    "id": "3045|Meikirch|BE",
+    "name": "Meikirch",
+    "zipCode": "3045",
+    "canton": "BE"
+  },
+  {
+    "id": "8706|Meilen|ZH",
+    "name": "Meilen",
+    "zipCode": "8706",
+    "canton": "ZH"
+  },
+  {
+    "id": "1252|Meinier|GE",
+    "name": "Meinier",
+    "zipCode": "1252",
+    "canton": "GE"
+  },
+  {
+    "id": "2554|Meinisberg|BE",
+    "name": "Meinisberg",
+    "zipCode": "2554",
+    "canton": "BE"
+  },
+  {
+    "id": "4912|Meiniswil|BE",
+    "name": "Meiniswil",
+    "zipCode": "4912",
+    "canton": "BE"
+  },
+  {
+    "id": "3860|Meiringen|BE",
+    "name": "Meiringen",
+    "zipCode": "3860",
+    "canton": "BE"
+  },
+  {
+    "id": "8543|Meisberg|ZH",
+    "name": "Meisberg",
+    "zipCode": "8543",
+    "canton": "ZH"
+  },
+  {
+    "id": "5616|Meisterschwanden|AG",
+    "name": "Meisterschwanden",
+    "zipCode": "5616",
+    "canton": "AG"
+  },
+  {
+    "id": "9050|Meistersrüte|AI",
+    "name": "Meistersrüte",
+    "zipCode": "9050",
+    "canton": "AI"
+  },
+  {
+    "id": "6818|Melano|TI",
+    "name": "Melano",
+    "zipCode": "6818",
+    "canton": "TI"
+  },
+  {
+    "id": "3073|Melchenbühl|BE",
+    "name": "Melchenbühl",
+    "zipCode": "3073",
+    "canton": "BE"
+  },
+  {
+    "id": "4917|Melchnau|BE",
+    "name": "Melchnau",
+    "zipCode": "4917",
+    "canton": "BE"
+  },
+  {
+    "id": "6068|Melchsee-Frutt|OW",
+    "name": "Melchsee-Frutt",
+    "zipCode": "6068",
+    "canton": "OW"
+  },
+  {
+    "id": "6067|Melchtal|OW",
+    "name": "Melchtal",
+    "zipCode": "6067",
+    "canton": "OW"
+  },
+  {
+    "id": "6584|Melera|TI",
+    "name": "Melera",
+    "zipCode": "6584",
+    "canton": "TI"
+  },
+  {
+    "id": "6815|Melide|TI",
+    "name": "Melide",
+    "zipCode": "6815",
+    "canton": "TI"
+  },
+  {
+    "id": "6584|Melirolo|TI",
+    "name": "Melirolo",
+    "zipCode": "6584",
+    "canton": "TI"
+  },
+  {
+    "id": "5465|Mellikon|AG",
+    "name": "Mellikon",
+    "zipCode": "5465",
+    "canton": "AG"
+  },
+  {
+    "id": "5507|Mellingen|AG",
+    "name": "Mellingen",
+    "zipCode": "5507",
+    "canton": "AG"
+  },
+  {
+    "id": "5463|Mellstorf|AG",
+    "name": "Mellstorf",
+    "zipCode": "5463",
+    "canton": "AG"
+  },
+  {
+    "id": "8887|Mels|SG",
+    "name": "Mels",
+    "zipCode": "8887",
+    "canton": "SG"
+  },
+  {
+    "id": "4233|Meltingen|SO",
+    "name": "Meltingen",
+    "zipCode": "4233",
+    "canton": "SO"
+  },
+  {
+    "id": "6850|Mendrisio|TI",
+    "name": "Mendrisio",
+    "zipCode": "6850",
+    "canton": "TI"
+  },
+  {
+    "id": "3144|Mengestorf|BE",
+    "name": "Mengestorf",
+    "zipCode": "3144",
+    "canton": "BE"
+  },
+  {
+    "id": "1533|Ménières|FR",
+    "name": "Ménières",
+    "zipCode": "1533",
+    "canton": "FR"
+  },
+  {
+    "id": "6125|Menzberg|LU",
+    "name": "Menzberg",
+    "zipCode": "6125",
+    "canton": "LU"
+  },
+  {
+    "id": "8546|Menzengrüt|ZH",
+    "name": "Menzengrüt",
+    "zipCode": "8546",
+    "canton": "ZH"
+  },
+  {
+    "id": "5737|Menziken|AG",
+    "name": "Menziken",
+    "zipCode": "5737",
+    "canton": "AG"
+  },
+  {
+    "id": "6313|Menzingen|ZG",
+    "name": "Menzingen",
+    "zipCode": "6313",
+    "canton": "ZG"
+  },
+  {
+    "id": "6122|Menznau|LU",
+    "name": "Menznau",
+    "zipCode": "6122",
+    "canton": "LU"
+  },
+  {
+    "id": "6692|Menzonio|TI",
+    "name": "Menzonio",
+    "zipCode": "6692",
+    "canton": "TI"
+  },
+  {
+    "id": "5634|Merenschwand|AG",
+    "name": "Merenschwand",
+    "zipCode": "5634",
+    "canton": "AG"
+  },
+  {
+    "id": "6647|Mergoscia|TI",
+    "name": "Mergoscia",
+    "zipCode": "6647",
+    "canton": "TI"
+  },
+  {
+    "id": "6866|Meride|TI",
+    "name": "Meride",
+    "zipCode": "6866",
+    "canton": "TI"
+  },
+  {
+    "id": "8232|Merishausen|SH",
+    "name": "Merishausen",
+    "zipCode": "8232",
+    "canton": "SH"
+  },
+  {
+    "id": "3658|Merligen|BE",
+    "name": "Merligen",
+    "zipCode": "3658",
+    "canton": "BE"
+  },
+  {
+    "id": "1251|Merlinge|GE",
+    "name": "Merlinge",
+    "zipCode": "1251",
+    "canton": "GE"
+  },
+  {
+    "id": "6402|Merlischachen|SZ",
+    "name": "Merlischachen",
+    "zipCode": "6402",
+    "canton": "SZ"
+  },
+  {
+    "id": "2827|Mervelier|JU",
+    "name": "Mervelier",
+    "zipCode": "2827",
+    "canton": "JU"
+  },
+  {
+    "id": "3274|Merzligen|BE",
+    "name": "Merzligen",
+    "zipCode": "3274",
+    "canton": "BE"
+  },
+  {
+    "id": "8308|Mesikon|ZH",
+    "name": "Mesikon",
+    "zipCode": "8308",
+    "canton": "ZH"
+  },
+  {
+    "id": "6563|Mesocco|GR",
+    "name": "Mesocco",
+    "zipCode": "6563",
+    "canton": "GR"
+  },
+  {
+    "id": "3254|Messen|SO",
+    "name": "Messen",
+    "zipCode": "3254",
+    "canton": "SO"
+  },
+  {
+    "id": "2608|Métairie du Bois-Raiguel|BE",
+    "name": "Métairie du Bois-Raiguel",
+    "zipCode": "2608",
+    "canton": "BE"
+  },
+  {
+    "id": "2534|Métairie-d'Evilard|BE",
+    "name": "Métairie-d'Evilard",
+    "zipCode": "2534",
+    "canton": "BE"
+  },
+  {
+    "id": "2500|Mett|BE",
+    "name": "Mett",
+    "zipCode": "2500",
+    "canton": "BE"
+  },
+  {
+    "id": "5274|Mettau|AG",
+    "name": "Mettau",
+    "zipCode": "5274",
+    "canton": "AG"
+  },
+  {
+    "id": "2806|Mettembert|JU",
+    "name": "Mettembert",
+    "zipCode": "2806",
+    "canton": "JU"
+  },
+  {
+    "id": "8553|Mettendorf|TG",
+    "name": "Mettendorf",
+    "zipCode": "8553",
+    "canton": "TG"
+  },
+  {
+    "id": "9200|Mettendorf|SG",
+    "name": "Mettendorf",
+    "zipCode": "9200",
+    "canton": "SG"
+  },
+  {
+    "id": "6204|Mettenwil|LU",
+    "name": "Mettenwil",
+    "zipCode": "6204",
+    "canton": "LU"
+  },
+  {
+    "id": "3665|Mettlen|BE",
+    "name": "Mettlen",
+    "zipCode": "3665",
+    "canton": "BE"
+  },
+  {
+    "id": "6034|Mettlen|LU",
+    "name": "Mettlen",
+    "zipCode": "6034",
+    "canton": "LU"
+  },
+  {
+    "id": "9517|Mettlen|TG",
+    "name": "Mettlen",
+    "zipCode": "9517",
+    "canton": "TG"
+  },
+  {
+    "id": "8155|Mettmenhasli|ZH",
+    "name": "Mettmenhasli",
+    "zipCode": "8155",
+    "canton": "ZH"
+  },
+  {
+    "id": "6288|Mettmenschongau|LU",
+    "name": "Mettmenschongau",
+    "zipCode": "6288",
+    "canton": "LU"
+  },
+  {
+    "id": "8932|Mettmenstetten|ZH",
+    "name": "Mettmenstetten",
+    "zipCode": "8932",
+    "canton": "ZH"
+  },
+  {
+    "id": "8252|Mettschlatt|TG",
+    "name": "Mettschlatt",
+    "zipCode": "8252",
+    "canton": "TG"
+  },
+  {
+    "id": "4116|Metzerlen|SO",
+    "name": "Metzerlen",
+    "zipCode": "4116",
+    "canton": "SO"
+  },
+  {
+    "id": "2126|Meudon|NE",
+    "name": "Meudon",
+    "zipCode": "2126",
+    "canton": "NE"
+  },
+  {
+    "id": "1031|Mex|VD",
+    "name": "Mex",
+    "zipCode": "1031",
+    "canton": "VD"
+  },
+  {
+    "id": "1890|Mex|VS",
+    "name": "Mex",
+    "zipCode": "1890",
+    "canton": "VS"
+  },
+  {
+    "id": "3280|Meyriez|FR",
+    "name": "Meyriez",
+    "zipCode": "3280",
+    "canton": "FR"
+  },
+  {
+    "id": "1217|Meyrin|GE",
+    "name": "Meyrin",
+    "zipCode": "1217",
+    "canton": "GE"
+  },
+  {
+    "id": "1008|Mézery|VD",
+    "name": "Mézery",
+    "zipCode": "1008",
+    "canton": "VD"
+  },
+  {
+    "id": "1407|Mézery-près-Donneloye|VD",
+    "name": "Mézery-près-Donneloye",
+    "zipCode": "1407",
+    "canton": "VD"
+  },
+  {
+    "id": "1083|Mézières|VD",
+    "name": "Mézières",
+    "zipCode": "1083",
+    "canton": "VD"
+  },
+  {
+    "id": "1684|Mézières|FR",
+    "name": "Mézières",
+    "zipCode": "1684",
+    "canton": "FR"
+  },
+  {
+    "id": "9542|Meziken|TG",
+    "name": "Meziken",
+    "zipCode": "9542",
+    "canton": "TG"
+  },
+  {
+    "id": "6828|Mezzana|TI",
+    "name": "Mezzana",
+    "zipCode": "6828",
+    "canton": "TI"
+  },
+  {
+    "id": "7249|Mezzaselva|GR",
+    "name": "Mezzaselva",
+    "zipCode": "7249",
+    "canton": "GR"
+  },
+  {
+    "id": "6805|Mezzovico|TI",
+    "name": "Mezzovico",
+    "zipCode": "6805",
+    "canton": "TI"
+  },
+  {
+    "id": "1749|Middes|FR",
+    "name": "Middes",
+    "zipCode": "1749",
+    "canton": "FR"
+  },
+  {
+    "id": "2946|Miécourt|JU",
+    "name": "Miécourt",
+    "zipCode": "2946",
+    "canton": "JU"
+  },
+  {
+    "id": "3972|Miège|VS",
+    "name": "Miège",
+    "zipCode": "3972",
+    "canton": "VS"
+  },
+  {
+    "id": "1295|Mies|VD",
+    "name": "Mies",
+    "zipCode": "1295",
+    "canton": "VD"
+  },
+  {
+    "id": "1904|Miéville|VS",
+    "name": "Miéville",
+    "zipCode": "1904",
+    "canton": "VS"
+  },
+  {
+    "id": "2314|Miéville|NE",
+    "name": "Miéville",
+    "zipCode": "2314",
+    "canton": "NE"
+  },
+  {
+    "id": "1896|Miex|VS",
+    "name": "Miex",
+    "zipCode": "1896",
+    "canton": "VS"
+  },
+  {
+    "id": "6986|Miglieglia|TI",
+    "name": "Miglieglia",
+    "zipCode": "6986",
+    "canton": "TI"
+  },
+  {
+    "id": "3157|Milken|BE",
+    "name": "Milken",
+    "zipCode": "3157",
+    "canton": "BE"
+  },
+  {
+    "id": "6648|Minusio|TI",
+    "name": "Minusio",
+    "zipCode": "6648",
+    "canton": "TI"
+  },
+  {
+    "id": "7743|Miralago|GR",
+    "name": "Miralago",
+    "zipCode": "7743",
+    "canton": "GR"
+  },
+  {
+    "id": "7134|Miraniga|GR",
+    "name": "Miraniga",
+    "zipCode": "7134",
+    "canton": "GR"
+  },
+  {
+    "id": "3532|Mirchel|BE",
+    "name": "Mirchel",
+    "zipCode": "3532",
+    "canton": "BE"
+  },
+  {
+    "id": "7134|Misanenga|GR",
+    "name": "Misanenga",
+    "zipCode": "7134",
+    "canton": "GR"
+  },
+  {
+    "id": "2946|Miserez-Dessous|JU",
+    "name": "Miserez-Dessous",
+    "zipCode": "2946",
+    "canton": "JU"
+  },
+  {
+    "id": "2947|Miserez-Dessus|JU",
+    "name": "Miserez-Dessus",
+    "zipCode": "2947",
+    "canton": "JU"
+  },
+  {
+    "id": "1991|Misériez|VS",
+    "name": "Misériez",
+    "zipCode": "1991",
+    "canton": "VS"
+  },
+  {
+    "id": "1721|Misery|FR",
+    "name": "Misery",
+    "zipCode": "1721",
+    "canton": "FR"
+  },
+  {
+    "id": "3961|Mission|VS",
+    "name": "Mission",
+    "zipCode": "3961",
+    "canton": "VS"
+  },
+  {
+    "id": "1565|Missy|VD",
+    "name": "Missy",
+    "zipCode": "1565",
+    "canton": "VD"
+  },
+  {
+    "id": "3717|Mitholz|BE",
+    "name": "Mitholz",
+    "zipCode": "3717",
+    "canton": "BE"
+  },
+  {
+    "id": "8756|Mitlödi|GL",
+    "name": "Mitlödi",
+    "zipCode": "8756",
+    "canton": "GL"
+  },
+  {
+    "id": "3147|Mittelhäusern|BE",
+    "name": "Mittelhäusern",
+    "zipCode": "3147",
+    "canton": "BE"
+  },
+  {
+    "id": "7222|Mittellunden|GR",
+    "name": "Mittellunden",
+    "zipCode": "7222",
+    "canton": "GR"
+  },
+  {
+    "id": "9033|Mittlerhof|SG",
+    "name": "Mittlerhof",
+    "zipCode": "9033",
+    "canton": "SG"
+  },
+  {
+    "id": "9122|Mogelsberg|SG",
+    "name": "Mogelsberg",
+    "zipCode": "9122",
+    "canton": "SG"
+  },
+  {
+    "id": "6677|Moghegno|TI",
+    "name": "Moghegno",
+    "zipCode": "6677",
+    "canton": "TI"
+  },
+  {
+    "id": "6695|Mogno|TI",
+    "name": "Mogno",
+    "zipCode": "6695",
+    "canton": "TI"
+  },
+  {
+    "id": "4313|Möhlin|AG",
+    "name": "Möhlin",
+    "zipCode": "4313",
+    "canton": "AG"
+  },
+  {
+    "id": "9411|Mohren|AR",
+    "name": "Mohren",
+    "zipCode": "9411",
+    "canton": "AR"
+  },
+  {
+    "id": "1225|Moillesulaz|GE",
+    "name": "Moillesulaz",
+    "zipCode": "1225",
+    "canton": "GE"
+  },
+  {
+    "id": "1148|Moiry|VD",
+    "name": "Moiry",
+    "zipCode": "1148",
+    "canton": "VD"
+  },
+  {
+    "id": "6760|Molare|TI",
+    "name": "Molare",
+    "zipCode": "6760",
+    "canton": "TI"
+  },
+  {
+    "id": "6524|Moleno|TI",
+    "name": "Moleno",
+    "zipCode": "6524",
+    "canton": "TI"
+  },
+  {
+    "id": "1663|Moléson-Village|FR",
+    "name": "Moléson-Village",
+    "zipCode": "1663",
+    "canton": "FR"
+  },
+  {
+    "id": "1950|Molignon|VS",
+    "name": "Molignon",
+    "zipCode": "1950",
+    "canton": "VS"
+  },
+  {
+    "id": "6500|Molinazzo d'Arbedo|TI",
+    "name": "Molinazzo d'Arbedo",
+    "zipCode": "6500",
+    "canton": "TI"
+  },
+  {
+    "id": "6517|Molinazzo d'Arbedo|TI",
+    "name": "Molinazzo d'Arbedo",
+    "zipCode": "6517",
+    "canton": "TI"
+  },
+  {
+    "id": "6995|Molinazzo di Monteggio|TI",
+    "name": "Molinazzo di Monteggio",
+    "zipCode": "6995",
+    "canton": "TI"
+  },
+  {
+    "id": "7056|Molinis|GR",
+    "name": "Molinis",
+    "zipCode": "7056",
+    "canton": "GR"
+  },
+  {
+    "id": "1148|Mollendruz|VD",
+    "name": "Mollendruz",
+    "zipCode": "1148",
+    "canton": "VD"
+  },
+  {
+    "id": "1146|Mollens|VD",
+    "name": "Mollens",
+    "zipCode": "1146",
+    "canton": "VD"
+  },
+  {
+    "id": "3974|Mollens|VS",
+    "name": "Mollens",
+    "zipCode": "3974",
+    "canton": "VS"
+  },
+  {
+    "id": "1073|Mollie-Margot|VD",
+    "name": "Mollie-Margot",
+    "zipCode": "1073",
+    "canton": "VD"
+  },
+  {
+    "id": "8753|Mollis|GL",
+    "name": "Mollis",
+    "zipCode": "8753",
+    "canton": "GL"
+  },
+  {
+    "id": "1415|Molondin|VD",
+    "name": "Molondin",
+    "zipCode": "1415",
+    "canton": "VD"
+  },
+  {
+    "id": "8885|Mols|SG",
+    "name": "Mols",
+    "zipCode": "8885",
+    "canton": "SG"
+  },
+  {
+    "id": "7186|Mompé Tujetsch|GR",
+    "name": "Mompé Tujetsch",
+    "zipCode": "7186",
+    "canton": "GR"
+  },
+  {
+    "id": "7458|Mon|GR",
+    "name": "Mon",
+    "zipCode": "7458",
+    "canton": "GR"
+  },
+  {
+    "id": "1241|Mon-Idee|GE",
+    "name": "Mon-Idee",
+    "zipCode": "1241",
+    "canton": "GE"
+  },
+  {
+    "id": "7250|Monbiel|GR",
+    "name": "Monbiel",
+    "zipCode": "7250",
+    "canton": "GR"
+  },
+  {
+    "id": "8617|Mönchaltorf|ZH",
+    "name": "Mönchaltorf",
+    "zipCode": "8617",
+    "canton": "ZH"
+  },
+  {
+    "id": "8802|Mönchhof|ZH",
+    "name": "Mönchhof",
+    "zipCode": "8802",
+    "canton": "ZH"
+  },
+  {
+    "id": "1936|Mondzeu|VS",
+    "name": "Mondzeu",
+    "zipCode": "1936",
+    "canton": "VS"
+  },
+  {
+    "id": "6659|Moneto|TI",
+    "name": "Moneto",
+    "zipCode": "6659",
+    "canton": "TI"
+  },
+  {
+    "id": "2715|Monible|BE",
+    "name": "Monible",
+    "zipCode": "2715",
+    "canton": "BE"
+  },
+  {
+    "id": "1125|Monnaz|VD",
+    "name": "Monnaz",
+    "zipCode": "1125",
+    "canton": "VD"
+  },
+  {
+    "id": "1254|Monniaz|GE",
+    "name": "Monniaz",
+    "zipCode": "1254",
+    "canton": "GE"
+  },
+  {
+    "id": "2000|Monruz|NE",
+    "name": "Monruz",
+    "zipCode": "2000",
+    "canton": "NE"
+  },
+  {
+    "id": "7278|Monstein|GR",
+    "name": "Monstein",
+    "zipCode": "7278",
+    "canton": "GR"
+  },
+  {
+    "id": "2610|Mont-Crosin|BE",
+    "name": "Mont-Crosin",
+    "zipCode": "2610",
+    "canton": "BE"
+  },
+  {
+    "id": "2116|Mont-de-Buttes|NE",
+    "name": "Mont-de-Buttes",
+    "zipCode": "2116",
+    "canton": "NE"
+  },
+  {
+    "id": "1148|Mont-la-Ville|VD",
+    "name": "Mont-la-Ville",
+    "zipCode": "1148",
+    "canton": "VD"
+  },
+  {
+    "id": "2206|Mont-Racine|NE",
+    "name": "Mont-Racine",
+    "zipCode": "2206",
+    "canton": "NE"
+  },
+  {
+    "id": "2610|Mont-Soleil|BE",
+    "name": "Mont-Soleil",
+    "zipCode": "2610",
+    "canton": "BE"
+  },
+  {
+    "id": "1185|Mont-sur-Rolle|VD",
+    "name": "Mont-sur-Rolle",
+    "zipCode": "1185",
+    "canton": "VD"
+  },
+  {
+    "id": "2723|Mont-Tramelan|BE",
+    "name": "Mont-Tramelan",
+    "zipCode": "2723",
+    "canton": "BE"
+  },
+  {
+    "id": "2608|Montagne-de-Courtlary|BE",
+    "name": "Montagne-de-Courtlary",
+    "zipCode": "2608",
+    "canton": "BE"
+  },
+  {
+    "id": "2740|Montagne-de-Moutier|BE",
+    "name": "Montagne-de-Moutier",
+    "zipCode": "2740",
+    "canton": "BE"
+  },
+  {
+    "id": "2536|Montagne-de-Romont|BE",
+    "name": "Montagne-de-Romont",
+    "zipCode": "2536",
+    "canton": "BE"
+  },
+  {
+    "id": "2615|Montagne-Sonvilier|BE",
+    "name": "Montagne-Sonvilier",
+    "zipCode": "2615",
+    "canton": "BE"
+  },
+  {
+    "id": "1934|Montagnier|VS",
+    "name": "Montagnier",
+    "zipCode": "1934",
+    "canton": "VS"
+  },
+  {
+    "id": "6926|Montagnola|TI",
+    "name": "Montagnola",
+    "zipCode": "6926",
+    "canton": "TI"
+  },
+  {
+    "id": "1912|Montagnon|VS",
+    "name": "Montagnon",
+    "zipCode": "1912",
+    "canton": "VS"
+  },
+  {
+    "id": "1776|Montagny-la-Ville|FR",
+    "name": "Montagny-la-Ville",
+    "zipCode": "1776",
+    "canton": "FR"
+  },
+  {
+    "id": "1774|Montagny-les-Monts|FR",
+    "name": "Montagny-les-Monts",
+    "zipCode": "1774",
+    "canton": "FR"
+  },
+  {
+    "id": "1442|Montagny-près-Yverdon|VD",
+    "name": "Montagny-près-Yverdon",
+    "zipCode": "1442",
+    "canton": "VD"
+  },
+  {
+    "id": "2027|Montalchez|NE",
+    "name": "Montalchez",
+    "zipCode": "2027",
+    "canton": "NE"
+  },
+  {
+    "id": "3963|Montana|VS",
+    "name": "Montana",
+    "zipCode": "3963",
+    "canton": "VS"
+  },
+  {
+    "id": "3963|Montana-Village|VS",
+    "name": "Montana-Village",
+    "zipCode": "3963",
+    "canton": "VS"
+  },
+  {
+    "id": "1041|Montaubion|VD",
+    "name": "Montaubion",
+    "zipCode": "1041",
+    "canton": "VD"
+  },
+  {
+    "id": "2857|Montavon|JU",
+    "name": "Montavon",
+    "zipCode": "2857",
+    "canton": "JU"
+  },
+  {
+    "id": "1000|Montblesson|VD",
+    "name": "Montblesson",
+    "zipCode": "1000",
+    "canton": "VD"
+  },
+  {
+    "id": "1489|Montborget|FR",
+    "name": "Montborget",
+    "zipCode": "1489",
+    "canton": "FR"
+  },
+  {
+    "id": "1669|Montbovon|FR",
+    "name": "Montbovon",
+    "zipCode": "1669",
+    "canton": "FR"
+  },
+  {
+    "id": "1475|Montbrelloz|FR",
+    "name": "Montbrelloz",
+    "zipCode": "1475",
+    "canton": "FR"
+  },
+  {
+    "id": "1354|Montcherand|VD",
+    "name": "Montcherand",
+    "zipCode": "1354",
+    "canton": "VD"
+  },
+  {
+    "id": "6875|Monte|TI",
+    "name": "Monte",
+    "zipCode": "6875",
+    "canton": "TI"
+  },
+  {
+    "id": "6605|Monte Brè sopra Locarno|TI",
+    "name": "Monte Brè sopra Locarno",
+    "zipCode": "6605",
+    "canton": "TI"
+  },
+  {
+    "id": "6513|Monte Carasso|TI",
+    "name": "Monte Carasso",
+    "zipCode": "6513",
+    "canton": "TI"
+  },
+  {
+    "id": "6802|Monte Ceneri|TI",
+    "name": "Monte Ceneri",
+    "zipCode": "6802",
+    "canton": "TI"
+  },
+  {
+    "id": "6655|Monte di Comino|TI",
+    "name": "Monte di Comino",
+    "zipCode": "6655",
+    "canton": "TI"
+  },
+  {
+    "id": "6825|Monte Genereso|TI",
+    "name": "Monte Genereso",
+    "zipCode": "6825",
+    "canton": "TI"
+  },
+  {
+    "id": "6549|Monte Laura|GR",
+    "name": "Monte Laura",
+    "zipCode": "6549",
+    "canton": "GR"
+  },
+  {
+    "id": "6900|Monte San Salvatore|TI",
+    "name": "Monte San Salvatore",
+    "zipCode": "6900",
+    "canton": "TI"
+  },
+  {
+    "id": "1724|Montécu|FR",
+    "name": "Montécu",
+    "zipCode": "1724",
+    "canton": "FR"
+  },
+  {
+    "id": "6998|Monteggio|TI",
+    "name": "Monteggio",
+    "zipCode": "6998",
+    "canton": "TI"
+  },
+  {
+    "id": "1965|Monteiller-Savièse|VS",
+    "name": "Monteiller-Savièse",
+    "zipCode": "1965",
+    "canton": "VS"
+  },
+  {
+    "id": "2884|Montenol|JU",
+    "name": "Montenol",
+    "zipCode": "2884",
+    "canton": "JU"
+  },
+  {
+    "id": "3212|Monterschu|FR",
+    "name": "Monterschu",
+    "zipCode": "3212",
+    "canton": "FR"
+  },
+  {
+    "id": "1588|Montet|VD",
+    "name": "Montet",
+    "zipCode": "1588",
+    "canton": "VD"
+  },
+  {
+    "id": "1483|Montet (Broye)|FR",
+    "name": "Montet (Broye)",
+    "zipCode": "1483",
+    "canton": "FR"
+  },
+  {
+    "id": "1674|Montet (Glâne)|FR",
+    "name": "Montet (Glâne)",
+    "zipCode": "1674",
+    "canton": "FR"
+  },
+  {
+    "id": "1724|Montévraz|FR",
+    "name": "Montévraz",
+    "zipCode": "1724",
+    "canton": "FR"
+  },
+  {
+    "id": "2037|Montézillon|NE",
+    "name": "Montézillon",
+    "zipCode": "2037",
+    "canton": "NE"
+  },
+  {
+    "id": "2362|Montfaucon|JU",
+    "name": "Montfaucon",
+    "zipCode": "2362",
+    "canton": "JU"
+  },
+  {
+    "id": "2362|Montfavergier|JU",
+    "name": "Montfavergier",
+    "zipCode": "2362",
+    "canton": "JU"
+  },
+  {
+    "id": "1242|Montfleury|GE",
+    "name": "Montfleury",
+    "zipCode": "1242",
+    "canton": "GE"
+  },
+  {
+    "id": "5237|Mönthal|AG",
+    "name": "Mönthal",
+    "zipCode": "5237",
+    "canton": "AG"
+  },
+  {
+    "id": "1174|Montherod|VD",
+    "name": "Montherod",
+    "zipCode": "1174",
+    "canton": "VD"
+  },
+  {
+    "id": "1053|Montheron|VD",
+    "name": "Montheron",
+    "zipCode": "1053",
+    "canton": "VD"
+  },
+  {
+    "id": "1870|Monthey|VS",
+    "name": "Monthey",
+    "zipCode": "1870",
+    "canton": "VS"
+  },
+  {
+    "id": "6600|Monti della Trinità|TI",
+    "name": "Monti della Trinità",
+    "zipCode": "6600",
+    "canton": "TI"
+  },
+  {
+    "id": "6950|Monti di Brena|TI",
+    "name": "Monti di Brena",
+    "zipCode": "6950",
+    "canton": "TI"
+  },
+  {
+    "id": "6576|Monti di Gerra|TI",
+    "name": "Monti di Gerra",
+    "zipCode": "6576",
+    "canton": "TI"
+  },
+  {
+    "id": "6596|Monti di Motti|TI",
+    "name": "Monti di Motti",
+    "zipCode": "6596",
+    "canton": "TI"
+  },
+  {
+    "id": "6500|Monti di Ravecchia|TI",
+    "name": "Monti di Ravecchia",
+    "zipCode": "6500",
+    "canton": "TI"
+  },
+  {
+    "id": "6808|Monti di Torricella|TI",
+    "name": "Monti di Torricella",
+    "zipCode": "6808",
+    "canton": "TI"
+  },
+  {
+    "id": "6533|Monticello|GR",
+    "name": "Monticello",
+    "zipCode": "6533",
+    "canton": "GR"
+  },
+  {
+    "id": "2924|Montignez|JU",
+    "name": "Montignez",
+    "zipCode": "2924",
+    "canton": "JU"
+  },
+  {
+    "id": "9462|Montlingen|SG",
+    "name": "Montlingen",
+    "zipCode": "9462",
+    "canton": "SG"
+  },
+  {
+    "id": "1587|Montmagny|VD",
+    "name": "Montmagny",
+    "zipCode": "1587",
+    "canton": "VD"
+  },
+  {
+    "id": "2883|Montmelon|JU",
+    "name": "Montmelon",
+    "zipCode": "2883",
+    "canton": "JU"
+  },
+  {
+    "id": "2075|Montmirail|NE",
+    "name": "Montmirail",
+    "zipCode": "2075",
+    "canton": "NE"
+  },
+  {
+    "id": "2037|Montmollin|NE",
+    "name": "Montmollin",
+    "zipCode": "2037",
+    "canton": "NE"
+  },
+  {
+    "id": "2738|Montoz-de-Court|BE",
+    "name": "Montoz-de-Court",
+    "zipCode": "2738",
+    "canton": "BE"
+  },
+  {
+    "id": "1081|Montpreveyres|VD",
+    "name": "Montpreveyres",
+    "zipCode": "1081",
+    "canton": "VD"
+  },
+  {
+    "id": "1820|Montreux|VD",
+    "name": "Montreux",
+    "zipCode": "1820",
+    "canton": "VD"
+  },
+  {
+    "id": "1147|Montricher|VD",
+    "name": "Montricher",
+    "zipCode": "1147",
+    "canton": "VD"
+  },
+  {
+    "id": "2828|Montsevelier|JU",
+    "name": "Montsevelier",
+    "zipCode": "2828",
+    "canton": "JU"
+  },
+  {
+    "id": "8580|Moos|TG",
+    "name": "Moos",
+    "zipCode": "8580",
+    "canton": "TG"
+  },
+  {
+    "id": "3256|Moosaffoltern|BE",
+    "name": "Moosaffoltern",
+    "zipCode": "3256",
+    "canton": "BE"
+  },
+  {
+    "id": "3543|Moosegg|BE",
+    "name": "Moosegg",
+    "zipCode": "3543",
+    "canton": "BE"
+  },
+  {
+    "id": "5054|Moosleerau|AG",
+    "name": "Moosleerau",
+    "zipCode": "5054",
+    "canton": "AG"
+  },
+  {
+    "id": "3302|Moosseedorf|BE",
+    "name": "Moosseedorf",
+    "zipCode": "3302",
+    "canton": "BE"
+  },
+  {
+    "id": "6834|Morbio Inferiore|TI",
+    "name": "Morbio Inferiore",
+    "zipCode": "6834",
+    "canton": "TI"
+  },
+  {
+    "id": "6835|Morbio Superiore|TI",
+    "name": "Morbio Superiore",
+    "zipCode": "6835",
+    "canton": "TI"
+  },
+  {
+    "id": "1892|Morcles|VD",
+    "name": "Morcles",
+    "zipCode": "1892",
+    "canton": "VD"
+  },
+  {
+    "id": "6922|Morcote|TI",
+    "name": "Morcote",
+    "zipCode": "6922",
+    "canton": "TI"
+  },
+  {
+    "id": "1462|Mordagne|VD",
+    "name": "Mordagne",
+    "zipCode": "1462",
+    "canton": "VD"
+  },
+  {
+    "id": "3983|Mörel|VS",
+    "name": "Mörel",
+    "zipCode": "3983",
+    "canton": "VS"
+  },
+  {
+    "id": "1541|Morens|FR",
+    "name": "Morens",
+    "zipCode": "1541",
+    "canton": "FR"
+  },
+  {
+    "id": "6315|Morgarten|ZG",
+    "name": "Morgarten",
+    "zipCode": "6315",
+    "canton": "ZG"
+  },
+  {
+    "id": "1110|Morges|VD",
+    "name": "Morges",
+    "zipCode": "1110",
+    "canton": "VD"
+  },
+  {
+    "id": "1875|Morgins|VS",
+    "name": "Morgins",
+    "zipCode": "1875",
+    "canton": "VS"
+  },
+  {
+    "id": "2572|Mörigen|BE",
+    "name": "Mörigen",
+    "zipCode": "2572",
+    "canton": "BE"
+  },
+  {
+    "id": "5103|Möriken|AG",
+    "name": "Möriken",
+    "zipCode": "5103",
+    "canton": "AG"
+  },
+  {
+    "id": "9543|Mörikon|SG",
+    "name": "Mörikon",
+    "zipCode": "9543",
+    "canton": "SG"
+  },
+  {
+    "id": "9543|Mörikon|TG",
+    "name": "Mörikon",
+    "zipCode": "9543",
+    "canton": "TG"
+  },
+  {
+    "id": "7143|Morissen|GR",
+    "name": "Morissen",
+    "zipCode": "7143",
+    "canton": "GR"
+  },
+  {
+    "id": "3043|Möriswil|BE",
+    "name": "Möriswil",
+    "zipCode": "3043",
+    "canton": "BE"
+  },
+  {
+    "id": "1674|Morlens|FR",
+    "name": "Morlens",
+    "zipCode": "1674",
+    "canton": "FR"
+  },
+  {
+    "id": "6074|Mörlialp|OW",
+    "name": "Mörlialp",
+    "zipCode": "6074",
+    "canton": "OW"
+  },
+  {
+    "id": "1638|Morlon|FR",
+    "name": "Morlon",
+    "zipCode": "1638",
+    "canton": "FR"
+  },
+  {
+    "id": "2922|Mormont|JU",
+    "name": "Mormont",
+    "zipCode": "2922",
+    "canton": "JU"
+  },
+  {
+    "id": "2712|Moron|BE",
+    "name": "Moron",
+    "zipCode": "2712",
+    "canton": "BE"
+  },
+  {
+    "id": "2735|Moron|BE",
+    "name": "Moron",
+    "zipCode": "2735",
+    "canton": "BE"
+  },
+  {
+    "id": "1054|Morrens|VD",
+    "name": "Morrens",
+    "zipCode": "1054",
+    "canton": "VD"
+  },
+  {
+    "id": "6443|Morschach|SZ",
+    "name": "Morschach",
+    "zipCode": "6443",
+    "canton": "SZ"
+  },
+  {
+    "id": "9402|Mörschwil|SG",
+    "name": "Mörschwil",
+    "zipCode": "9402",
+    "canton": "SG"
+  },
+  {
+    "id": "7504|Morteratsch|GR",
+    "name": "Morteratsch",
+    "zipCode": "7504",
+    "canton": "GR"
+  },
+  {
+    "id": "3506|Möschberg|BE",
+    "name": "Möschberg",
+    "zipCode": "3506",
+    "canton": "BE"
+  },
+  {
+    "id": "6612|Moscia|TI",
+    "name": "Moscia",
+    "zipCode": "6612",
+    "canton": "TI"
+  },
+  {
+    "id": "6295|Mosen|LU",
+    "name": "Mosen",
+    "zipCode": "6295",
+    "canton": "LU"
+  },
+  {
+    "id": "9607|Mosnang|SG",
+    "name": "Mosnang",
+    "zipCode": "9607",
+    "canton": "SG"
+  },
+  {
+    "id": "6611|Mosogno|TI",
+    "name": "Mosogno",
+    "zipCode": "6611",
+    "canton": "TI"
+  },
+  {
+    "id": "1675|Mossel|FR",
+    "name": "Mossel",
+    "zipCode": "1675",
+    "canton": "FR"
+  },
+  {
+    "id": "1787|Môtier (Vully)|FR",
+    "name": "Môtier (Vully)",
+    "zipCode": "1787",
+    "canton": "FR"
+  },
+  {
+    "id": "2112|Môtiers|NE",
+    "name": "Môtiers",
+    "zipCode": "2112",
+    "canton": "NE"
+  },
+  {
+    "id": "3324|Mötschwil|BE",
+    "name": "Mötschwil",
+    "zipCode": "3324",
+    "canton": "BE"
+  },
+  {
+    "id": "3961|Mottec|VS",
+    "name": "Mottec",
+    "zipCode": "3961",
+    "canton": "VS"
+  },
+  {
+    "id": "6721|Motto|TI",
+    "name": "Motto",
+    "zipCode": "6721",
+    "canton": "TI"
+  },
+  {
+    "id": "1510|Moudon|VD",
+    "name": "Moudon",
+    "zipCode": "1510",
+    "canton": "VD"
+  },
+  {
+    "id": "2740|Moutier|BE",
+    "name": "Moutier",
+    "zipCode": "2740",
+    "canton": "BE"
+  },
+  {
+    "id": "2812|Movelier|JU",
+    "name": "Movelier",
+    "zipCode": "2812",
+    "canton": "JU"
+  },
+  {
+    "id": "6979|Mte. Brè|TI",
+    "name": "Mte. Brè",
+    "zipCode": "6979",
+    "canton": "TI"
+  },
+  {
+    "id": "6939|Mugena|TI",
+    "name": "Mugena",
+    "zipCode": "6939",
+    "canton": "TI"
+  },
+  {
+    "id": "6838|Muggio|TI",
+    "name": "Muggio",
+    "zipCode": "6838",
+    "canton": "TI"
+  },
+  {
+    "id": "5037|Muhen|AG",
+    "name": "Muhen",
+    "zipCode": "5037",
+    "canton": "AG"
+  },
+  {
+    "id": "5642|Mühlau|AG",
+    "name": "Mühlau",
+    "zipCode": "5642",
+    "canton": "AG"
+  },
+  {
+    "id": "3995|Mühlebach|VS",
+    "name": "Mühlebach",
+    "zipCode": "3995",
+    "canton": "VS"
+  },
+  {
+    "id": "8580|Mühlebach|TG",
+    "name": "Mühlebach",
+    "zipCode": "8580",
+    "canton": "TG"
+  },
+  {
+    "id": "3203|Mühleberg|BE",
+    "name": "Mühleberg",
+    "zipCode": "3203",
+    "canton": "BE"
+  },
+  {
+    "id": "3116|Mühledorf|BE",
+    "name": "Mühledorf",
+    "zipCode": "3116",
+    "canton": "BE"
+  },
+  {
+    "id": "4583|Mühledorf|SO",
+    "name": "Mühledorf",
+    "zipCode": "4583",
+    "canton": "SO"
+  },
+  {
+    "id": "8874|Mühlehorn|GL",
+    "name": "Mühlehorn",
+    "zipCode": "8874",
+    "canton": "GL"
+  },
+  {
+    "id": "4812|Mühlethal|AG",
+    "name": "Mühlethal",
+    "zipCode": "4812",
+    "canton": "AG"
+  },
+  {
+    "id": "3127|Mühlethurnen|BE",
+    "name": "Mühlethurnen",
+    "zipCode": "3127",
+    "canton": "BE"
+  },
+  {
+    "id": "3464|Mühleweg im Emmental|BE",
+    "name": "Mühleweg im Emmental",
+    "zipCode": "3464",
+    "canton": "BE"
+  },
+  {
+    "id": "9613|Mühlrüti|SG",
+    "name": "Mühlrüti",
+    "zipCode": "9613",
+    "canton": "SG"
+  },
+  {
+    "id": "9427|Mühltobel|AR",
+    "name": "Mühltobel",
+    "zipCode": "9427",
+    "canton": "AR"
+  },
+  {
+    "id": "3317|Mülchi|BE",
+    "name": "Mülchi",
+    "zipCode": "3317",
+    "canton": "BE"
+  },
+  {
+    "id": "7082|Muldain|GR",
+    "name": "Muldain",
+    "zipCode": "7082",
+    "canton": "GR"
+  },
+  {
+    "id": "7455|Mulegns|GR",
+    "name": "Mulegns",
+    "zipCode": "7455",
+    "canton": "GR"
+  },
+  {
+    "id": "3711|Mülenen|BE",
+    "name": "Mülenen",
+    "zipCode": "3711",
+    "canton": "BE"
+  },
+  {
+    "id": "4713|Müli|SO",
+    "name": "Müli",
+    "zipCode": "4713",
+    "canton": "SO"
+  },
+  {
+    "id": "7016|Mulin|GR",
+    "name": "Mulin",
+    "zipCode": "7016",
+    "canton": "GR"
+  },
+  {
+    "id": "3185|Mülital|FR",
+    "name": "Mülital",
+    "zipCode": "3185",
+    "canton": "FR"
+  },
+  {
+    "id": "8558|Müllberg|TG",
+    "name": "Müllberg",
+    "zipCode": "8558",
+    "canton": "TG"
+  },
+  {
+    "id": "8554|Müllheim|TG",
+    "name": "Müllheim",
+    "zipCode": "8554",
+    "canton": "TG"
+  },
+  {
+    "id": "8555|Müllheim|TG",
+    "name": "Müllheim",
+    "zipCode": "8555",
+    "canton": "TG"
+  },
+  {
+    "id": "5243|Mülligen|AG",
+    "name": "Mülligen",
+    "zipCode": "5243",
+    "canton": "AG"
+  },
+  {
+    "id": "4912|Mumenthal|BE",
+    "name": "Mumenthal",
+    "zipCode": "4912",
+    "canton": "BE"
+  },
+  {
+    "id": "4717|Mümliswil|SO",
+    "name": "Mümliswil",
+    "zipCode": "4717",
+    "canton": "SO"
+  },
+  {
+    "id": "7183|Mumpé Medel|GR",
+    "name": "Mumpé Medel",
+    "zipCode": "7183",
+    "canton": "GR"
+  },
+  {
+    "id": "4322|Mumpf|AG",
+    "name": "Mumpf",
+    "zipCode": "4322",
+    "canton": "AG"
+  },
+  {
+    "id": "3053|Münchenbuchsee|BE",
+    "name": "Münchenbuchsee",
+    "zipCode": "3053",
+    "canton": "BE"
+  },
+  {
+    "id": "4142|Münchenstein|BL",
+    "name": "Münchenstein",
+    "zipCode": "4142",
+    "canton": "BL"
+  },
+  {
+    "id": "1797|Münchenwiler|BE",
+    "name": "Münchenwiler",
+    "zipCode": "1797",
+    "canton": "BE"
+  },
+  {
+    "id": "3303|Münchringen|BE",
+    "name": "Münchringen",
+    "zipCode": "3303",
+    "canton": "BE"
+  },
+  {
+    "id": "4333|Münchwilen|AG",
+    "name": "Münchwilen",
+    "zipCode": "4333",
+    "canton": "AG"
+  },
+  {
+    "id": "9542|Münchwilen|TG",
+    "name": "Münchwilen",
+    "zipCode": "9542",
+    "canton": "TG"
+  },
+  {
+    "id": "3903|Mund|VS",
+    "name": "Mund",
+    "zipCode": "3903",
+    "canton": "VS"
+  },
+  {
+    "id": "3436|Mungnau|BE",
+    "name": "Mungnau",
+    "zipCode": "3436",
+    "canton": "BE"
+  },
+  {
+    "id": "3110|Münsingen|BE",
+    "name": "Münsingen",
+    "zipCode": "3110",
+    "canton": "BE"
+  },
+  {
+    "id": "3985|Münster|VS",
+    "name": "Münster",
+    "zipCode": "3985",
+    "canton": "VS"
+  },
+  {
+    "id": "8596|Münsterlingen|TG",
+    "name": "Münsterlingen",
+    "zipCode": "8596",
+    "canton": "TG"
+  },
+  {
+    "id": "3286|Muntelier|FR",
+    "name": "Muntelier",
+    "zipCode": "3286",
+    "canton": "FR"
+  },
+  {
+    "id": "3225|Müntschemier|BE",
+    "name": "Müntschemier",
+    "zipCode": "3225",
+    "canton": "BE"
+  },
+  {
+    "id": "9313|Muolen|SG",
+    "name": "Muolen",
+    "zipCode": "9313",
+    "canton": "SG"
+  },
+  {
+    "id": "6436|Muotathal|SZ",
+    "name": "Muotathal",
+    "zipCode": "6436",
+    "canton": "SZ"
+  },
+  {
+    "id": "1787|Mur|FR",
+    "name": "Mur",
+    "zipCode": "1787",
+    "canton": "FR"
+  },
+  {
+    "id": "1787|Mur|VD",
+    "name": "Mur",
+    "zipCode": "1787",
+    "canton": "VD"
+  },
+  {
+    "id": "7109|Mura|GR",
+    "name": "Mura",
+    "zipCode": "7109",
+    "canton": "GR"
+  },
+  {
+    "id": "6600|Muralto|TI",
+    "name": "Muralto",
+    "zipCode": "6600",
+    "canton": "TI"
+  },
+  {
+    "id": "1893|Muraz|VS",
+    "name": "Muraz",
+    "zipCode": "1893",
+    "canton": "VS"
+  },
+  {
+    "id": "3960|Muraz|VS",
+    "name": "Muraz",
+    "zipCode": "3960",
+    "canton": "VS"
+  },
+  {
+    "id": "8877|Murg|SG",
+    "name": "Murg",
+    "zipCode": "8877",
+    "canton": "SG"
+  },
+  {
+    "id": "4853|Murgenthal|AG",
+    "name": "Murgenthal",
+    "zipCode": "4853",
+    "canton": "AG"
+  },
+  {
+    "id": "5630|Muri|AG",
+    "name": "Muri",
+    "zipCode": "5630",
+    "canton": "AG"
+  },
+  {
+    "id": "3074|Muri bei Bern|BE",
+    "name": "Muri bei Bern",
+    "zipCode": "3074",
+    "canton": "BE"
+  },
+  {
+    "id": "2338|Muriaux|JU",
+    "name": "Muriaux",
+    "zipCode": "2338",
+    "canton": "JU"
+  },
+  {
+    "id": "1489|Murist|FR",
+    "name": "Murist",
+    "zipCode": "1489",
+    "canton": "FR"
+  },
+  {
+    "id": "9548|Murkart|TG",
+    "name": "Murkart",
+    "zipCode": "9548",
+    "canton": "TG"
+  },
+  {
+    "id": "3825|Mürren|BE",
+    "name": "Mürren",
+    "zipCode": "3825",
+    "canton": "BE"
+  },
+  {
+    "id": "7032|Murschetg|GR",
+    "name": "Murschetg",
+    "zipCode": "7032",
+    "canton": "GR"
+  },
+  {
+    "id": "3280|Murten|FR",
+    "name": "Murten",
+    "zipCode": "3280",
+    "canton": "FR"
+  },
+  {
+    "id": "3034|Murzelen|BE",
+    "name": "Murzelen",
+    "zipCode": "3034",
+    "canton": "BE"
+  },
+  {
+    "id": "9602|Müselbach|SG",
+    "name": "Müselbach",
+    "zipCode": "9602",
+    "canton": "SG"
+  },
+  {
+    "id": "7537|Müstair|GR",
+    "name": "Müstair",
+    "zipCode": "7537",
+    "canton": "GR"
+  },
+  {
+    "id": "6289|Müswangen|LU",
+    "name": "Müswangen",
+    "zipCode": "6289",
+    "canton": "LU"
+  },
+  {
+    "id": "1428|Mutrux|VD",
+    "name": "Mutrux",
+    "zipCode": "1428",
+    "canton": "VD"
+  },
+  {
+    "id": "5621|Mutschellen|AG",
+    "name": "Mutschellen",
+    "zipCode": "5621",
+    "canton": "AG"
+  },
+  {
+    "id": "8964|Mutschellen|AG",
+    "name": "Mutschellen",
+    "zipCode": "8964",
+    "canton": "AG"
+  },
+  {
+    "id": "8965|Mutschellen|AG",
+    "name": "Mutschellen",
+    "zipCode": "8965",
+    "canton": "AG"
+  },
+  {
+    "id": "8967|Mutschellen|AG",
+    "name": "Mutschellen",
+    "zipCode": "8967",
+    "canton": "AG"
+  },
+  {
+    "id": "7185|Mutschnengia|GR",
+    "name": "Mutschnengia",
+    "zipCode": "7185",
+    "canton": "GR"
+  },
+  {
+    "id": "7431|Mutten|GR",
+    "name": "Mutten",
+    "zipCode": "7431",
+    "canton": "GR"
+  },
+  {
+    "id": "4132|Muttenz|BL",
+    "name": "Muttenz",
+    "zipCode": "4132",
+    "canton": "BL"
+  },
+  {
+    "id": "6933|Muzzano|TI",
+    "name": "Muzzano",
+    "zipCode": "6933",
+    "canton": "TI"
+  },
+  {
+    "id": "8752|Näfels|GL",
+    "name": "Näfels",
+    "zipCode": "8752",
+    "canton": "GL"
+  },
+  {
+    "id": "8606|Nänikon|ZH",
+    "name": "Nänikon",
+    "zipCode": "8606",
+    "canton": "ZH"
+  },
+  {
+    "id": "1786|Nant|FR",
+    "name": "Nant",
+    "zipCode": "1786",
+    "canton": "FR"
+  },
+  {
+    "id": "1804|Nant|VD",
+    "name": "Nant",
+    "zipCode": "1804",
+    "canton": "VD"
+  },
+  {
+    "id": "6780|Nante|TI",
+    "name": "Nante",
+    "zipCode": "6780",
+    "canton": "TI"
+  },
+  {
+    "id": "9123|Nassen|SG",
+    "name": "Nassen",
+    "zipCode": "9123",
+    "canton": "SG"
+  },
+  {
+    "id": "8155|Nassenwil|ZH",
+    "name": "Nassenwil",
+    "zipCode": "8155",
+    "canton": "ZH"
+  },
+  {
+    "id": "3904|Naters|VS",
+    "name": "Naters",
+    "zipCode": "3904",
+    "canton": "VS"
+  },
+  {
+    "id": "1973|Nax|VS",
+    "name": "Nax",
+    "zipCode": "1973",
+    "canton": "VS"
+  },
+  {
+    "id": "1041|Naz|VD",
+    "name": "Naz",
+    "zipCode": "1041",
+    "canton": "VD"
+  },
+  {
+    "id": "6244|Nebikon|LU",
+    "name": "Nebikon",
+    "zipCode": "6244",
+    "canton": "LU"
+  },
+  {
+    "id": "9126|Necker|SG",
+    "name": "Necker",
+    "zipCode": "9126",
+    "canton": "SG"
+  },
+  {
+    "id": "8173|Neerach|ZH",
+    "name": "Neerach",
+    "zipCode": "8173",
+    "canton": "ZH"
+  },
+  {
+    "id": "8413|Neftenbach|ZH",
+    "name": "Neftenbach",
+    "zipCode": "8413",
+    "canton": "ZH"
+  },
+  {
+    "id": "6991|Neggio|TI",
+    "name": "Neggio",
+    "zipCode": "6991",
+    "canton": "TI"
+  },
+  {
+    "id": "1669|Neirivue|FR",
+    "name": "Neirivue",
+    "zipCode": "1669",
+    "canton": "FR"
+  },
+  {
+    "id": "1955|Némiaz|VS",
+    "name": "Némiaz",
+    "zipCode": "1955",
+    "canton": "VS"
+  },
+  {
+    "id": "4574|Nennigkofen|SO",
+    "name": "Nennigkofen",
+    "zipCode": "4574",
+    "canton": "SO"
+  },
+  {
+    "id": "4224|Nenzlingen|BL",
+    "name": "Nenzlingen",
+    "zipCode": "4224",
+    "canton": "BL"
+  },
+  {
+    "id": "8484|Neschwil|ZH",
+    "name": "Neschwil",
+    "zipCode": "8484",
+    "canton": "ZH"
+  },
+  {
+    "id": "5524|Nesselnbach|AG",
+    "name": "Nesselnbach",
+    "zipCode": "5524",
+    "canton": "AG"
+  },
+  {
+    "id": "3863|Nessental|BE",
+    "name": "Nessental",
+    "zipCode": "3863",
+    "canton": "BE"
+  },
+  {
+    "id": "9650|Nesslau|SG",
+    "name": "Nesslau",
+    "zipCode": "9650",
+    "canton": "SG"
+  },
+  {
+    "id": "8754|Netstal|GL",
+    "name": "Netstal",
+    "zipCode": "8754",
+    "canton": "GL"
+  },
+  {
+    "id": "9652|Neu St. Johann|SG",
+    "name": "Neu St. Johann",
+    "zipCode": "9652",
+    "canton": "SG"
+  },
+  {
+    "id": "6314|Neuägeri|ZG",
+    "name": "Neuägeri",
+    "zipCode": "6314",
+    "canton": "ZG"
+  },
+  {
+    "id": "4123|Neuallschwil|BL",
+    "name": "Neuallschwil",
+    "zipCode": "4123",
+    "canton": "BL"
+  },
+  {
+    "id": "8164|Neubachs|ZH",
+    "name": "Neubachs",
+    "zipCode": "8164",
+    "canton": "ZH"
+  },
+  {
+    "id": "3000|Neubrück|BE",
+    "name": "Neubrück",
+    "zipCode": "3000",
+    "canton": "BE"
+  },
+  {
+    "id": "3037|Neubrück|BE",
+    "name": "Neubrück",
+    "zipCode": "3037",
+    "canton": "BE"
+  },
+  {
+    "id": "8488|Neubrunn|ZH",
+    "name": "Neubrunn",
+    "zipCode": "8488",
+    "canton": "ZH"
+  },
+  {
+    "id": "2000|Neuchâtel|NE",
+    "name": "Neuchâtel",
+    "zipCode": "2000",
+    "canton": "NE"
+  },
+  {
+    "id": "9200|Neuchlen|SG",
+    "name": "Neuchlen",
+    "zipCode": "9200",
+    "canton": "SG"
+  },
+  {
+    "id": "9615|Neudietfurt|SG",
+    "name": "Neudietfurt",
+    "zipCode": "9615",
+    "canton": "SG"
+  },
+  {
+    "id": "6025|Neudorf|LU",
+    "name": "Neudorf",
+    "zipCode": "6025",
+    "canton": "LU"
+  },
+  {
+    "id": "9000|Neudorf|SG",
+    "name": "Neudorf",
+    "zipCode": "9000",
+    "canton": "SG"
+  },
+  {
+    "id": "4623|Neuendorf|SO",
+    "name": "Neuendorf",
+    "zipCode": "4623",
+    "canton": "SO"
+  },
+  {
+    "id": "3176|Neuenegg|BE",
+    "name": "Neuenegg",
+    "zipCode": "3176",
+    "canton": "BE"
+  },
+  {
+    "id": "5432|Neuenhof|AG",
+    "name": "Neuenhof",
+    "zipCode": "5432",
+    "canton": "AG"
+  },
+  {
+    "id": "6206|Neuenkirch|LU",
+    "name": "Neuenkirch",
+    "zipCode": "6206",
+    "canton": "LU"
+  },
+  {
+    "id": "4142|Neuewelt|BL",
+    "name": "Neuewelt",
+    "zipCode": "4142",
+    "canton": "BL"
+  },
+  {
+    "id": "3600|Neufeld|BE",
+    "name": "Neufeld",
+    "zipCode": "3600",
+    "canton": "BE"
+  },
+  {
+    "id": "8304|Neugut|ZH",
+    "name": "Neugut",
+    "zipCode": "8304",
+    "canton": "ZH"
+  },
+  {
+    "id": "8732|Neuhaus|SG",
+    "name": "Neuhaus",
+    "zipCode": "8732",
+    "canton": "SG"
+  },
+  {
+    "id": "8132|Neuhaus bei Hinteregg|ZH",
+    "name": "Neuhaus bei Hinteregg",
+    "zipCode": "8132",
+    "canton": "ZH"
+  },
+  {
+    "id": "8212|Neuhausen am Rheinfall|SH",
+    "name": "Neuhausen am Rheinfall",
+    "zipCode": "8212",
+    "canton": "SH"
+  },
+  {
+    "id": "6345|Neuheim|ZG",
+    "name": "Neuheim",
+    "zipCode": "6345",
+    "canton": "ZG"
+  },
+  {
+    "id": "7107|Neukirch|GR",
+    "name": "Neukirch",
+    "zipCode": "7107",
+    "canton": "GR"
+  },
+  {
+    "id": "9315|Neukirch|TG",
+    "name": "Neukirch",
+    "zipCode": "9315",
+    "canton": "TG"
+  },
+  {
+    "id": "9217|Neukirch an der Thur|TG",
+    "name": "Neukirch an der Thur",
+    "zipCode": "9217",
+    "canton": "TG"
+  },
+  {
+    "id": "4142|Neumünchenstein|BL",
+    "name": "Neumünchenstein",
+    "zipCode": "4142",
+    "canton": "BL"
+  },
+  {
+    "id": "8213|Neunkirch|SH",
+    "name": "Neunkirch",
+    "zipCode": "8213",
+    "canton": "SH"
+  },
+  {
+    "id": "8252|Neuparadies|TG",
+    "name": "Neuparadies",
+    "zipCode": "8252",
+    "canton": "TG"
+  },
+  {
+    "id": "8462|Neurheinau|ZH",
+    "name": "Neurheinau",
+    "zipCode": "8462",
+    "canton": "ZH"
+  },
+  {
+    "id": "5225|Neustalden|AG",
+    "name": "Neustalden",
+    "zipCode": "5225",
+    "canton": "AG"
+  },
+  {
+    "id": "8344|Neuthal|ZH",
+    "name": "Neuthal",
+    "zipCode": "8344",
+    "canton": "ZH"
+  },
+  {
+    "id": "8566|Neuwilen|TG",
+    "name": "Neuwilen",
+    "zipCode": "8566",
+    "canton": "TG"
+  },
+  {
+    "id": "1740|Neyruz|FR",
+    "name": "Neyruz",
+    "zipCode": "1740",
+    "canton": "FR"
+  },
+  {
+    "id": "1515|Neyruz-sur-Moudon|VD",
+    "name": "Neyruz-sur-Moudon",
+    "zipCode": "1515",
+    "canton": "VD"
+  },
+  {
+    "id": "2560|Nidau|BE",
+    "name": "Nidau",
+    "zipCode": "2560",
+    "canton": "BE"
+  },
+  {
+    "id": "8803|Nidelbad|ZH",
+    "name": "Nidelbad",
+    "zipCode": "8803",
+    "canton": "ZH"
+  },
+  {
+    "id": "9200|Niderdorf|SG",
+    "name": "Niderdorf",
+    "zipCode": "9200",
+    "canton": "SG"
+  },
+  {
+    "id": "1714|Nidermonten|FR",
+    "name": "Nidermonten",
+    "zipCode": "1714",
+    "canton": "FR"
+  },
+  {
+    "id": "9630|Niderwil|SG",
+    "name": "Niderwil",
+    "zipCode": "9630",
+    "canton": "SG"
+  },
+  {
+    "id": "8772|Nidfurn|GL",
+    "name": "Nidfurn",
+    "zipCode": "8772",
+    "canton": "GL"
+  },
+  {
+    "id": "1462|Niédens|VD",
+    "name": "Niédens",
+    "zipCode": "1462",
+    "canton": "VD"
+  },
+  {
+    "id": "8587|Niederaach|TG",
+    "name": "Niederaach",
+    "zipCode": "8587",
+    "canton": "TG"
+  },
+  {
+    "id": "4704|Niederbipp|BE",
+    "name": "Niederbipp",
+    "zipCode": "4704",
+    "canton": "BE"
+  },
+  {
+    "id": "3000|Niederbottigen|BE",
+    "name": "Niederbottigen",
+    "zipCode": "3000",
+    "canton": "BE"
+  },
+  {
+    "id": "4626|Niederbuchsiten|SO",
+    "name": "Niederbuchsiten",
+    "zipCode": "4626",
+    "canton": "SO"
+  },
+  {
+    "id": "9246|Niederbüren|SG",
+    "name": "Niederbüren",
+    "zipCode": "9246",
+    "canton": "SG"
+  },
+  {
+    "id": "4435|Niederdorf|BL",
+    "name": "Niederdorf",
+    "zipCode": "4435",
+    "canton": "BL"
+  },
+  {
+    "id": "6375|Niederdorf|NW",
+    "name": "Niederdorf",
+    "zipCode": "6375",
+    "canton": "NW"
+  },
+  {
+    "id": "5015|Niedererlinsbach|SO",
+    "name": "Niedererlinsbach",
+    "zipCode": "5015",
+    "canton": "SO"
+  },
+  {
+    "id": "3945|Niedergampel|VS",
+    "name": "Niedergampel",
+    "zipCode": "3945",
+    "canton": "VS"
+  },
+  {
+    "id": "3942|Niedergesteln|VS",
+    "name": "Niedergesteln",
+    "zipCode": "3942",
+    "canton": "VS"
+  },
+  {
+    "id": "8172|Niederglatt|ZH",
+    "name": "Niederglatt",
+    "zipCode": "8172",
+    "canton": "ZH"
+  },
+  {
+    "id": "9240|Niederglatt|SG",
+    "name": "Niederglatt",
+    "zipCode": "9240",
+    "canton": "SG"
+  },
+  {
+    "id": "5013|Niedergösgen|SO",
+    "name": "Niedergösgen",
+    "zipCode": "5013",
+    "canton": "SO"
+  },
+  {
+    "id": "8155|Niederhasli|ZH",
+    "name": "Niederhasli",
+    "zipCode": "8155",
+    "canton": "ZH"
+  },
+  {
+    "id": "9527|Niederhelfenschwil|SG",
+    "name": "Niederhelfenschwil",
+    "zipCode": "9527",
+    "canton": "SG"
+  },
+  {
+    "id": "8181|Niederhöri|ZH",
+    "name": "Niederhöri",
+    "zipCode": "8181",
+    "canton": "ZH"
+  },
+  {
+    "id": "3504|Niederhünigen|BE",
+    "name": "Niederhünigen",
+    "zipCode": "3504",
+    "canton": "BE"
+  },
+  {
+    "id": "5702|Niederlenz|AG",
+    "name": "Niederlenz",
+    "zipCode": "5702",
+    "canton": "AG"
+  },
+  {
+    "id": "3087|Niedermuhlern|BE",
+    "name": "Niedermuhlern",
+    "zipCode": "3087",
+    "canton": "BE"
+  },
+  {
+    "id": "1714|Niedermuhren|FR",
+    "name": "Niedermuhren",
+    "zipCode": "1714",
+    "canton": "FR"
+  },
+  {
+    "id": "8525|Niederneunforn|TG",
+    "name": "Niederneunforn",
+    "zipCode": "8525",
+    "canton": "TG"
+  },
+  {
+    "id": "3362|Niederönz|BE",
+    "name": "Niederönz",
+    "zipCode": "3362",
+    "canton": "BE"
+  },
+  {
+    "id": "3424|Niederösch|BE",
+    "name": "Niederösch",
+    "zipCode": "3424",
+    "canton": "BE"
+  },
+  {
+    "id": "6383|Niederrickenbach|NW",
+    "name": "Niederrickenbach",
+    "zipCode": "6383",
+    "canton": "NW"
+  },
+  {
+    "id": "3853|Niederried bei Interlaken|BE",
+    "name": "Niederried bei Interlaken",
+    "zipCode": "3853",
+    "canton": "BE"
+  },
+  {
+    "id": "3283|Niederried bei Kallnach|BE",
+    "name": "Niederried bei Kallnach",
+    "zipCode": "3283",
+    "canton": "BE"
+  },
+  {
+    "id": "5443|Niederrohrdorf|AG",
+    "name": "Niederrohrdorf",
+    "zipCode": "5443",
+    "canton": "AG"
+  },
+  {
+    "id": "3145|Niederscherli|BE",
+    "name": "Niederscherli",
+    "zipCode": "3145",
+    "canton": "BE"
+  },
+  {
+    "id": "6288|Niederschongau|LU",
+    "name": "Niederschongau",
+    "zipCode": "6288",
+    "canton": "LU"
+  },
+  {
+    "id": "8162|Niedersteinmaur|ZH",
+    "name": "Niedersteinmaur",
+    "zipCode": "8162",
+    "canton": "ZH"
+  },
+  {
+    "id": "9249|Niederstetten|SG",
+    "name": "Niederstetten",
+    "zipCode": "9249",
+    "canton": "SG"
+  },
+  {
+    "id": "3632|Niederstocken|BE",
+    "name": "Niederstocken",
+    "zipCode": "3632",
+    "canton": "BE"
+  },
+  {
+    "id": "9052|Niederteufen|AR",
+    "name": "Niederteufen",
+    "zipCode": "9052",
+    "canton": "AR"
+  },
+  {
+    "id": "8867|Niederurnen|GL",
+    "name": "Niederurnen",
+    "zipCode": "8867",
+    "canton": "GL"
+  },
+  {
+    "id": "9244|Niederuzwil|SG",
+    "name": "Niederuzwil",
+    "zipCode": "9244",
+    "canton": "SG"
+  },
+  {
+    "id": "3989|Niederwald|VS",
+    "name": "Niederwald",
+    "zipCode": "3989",
+    "canton": "VS"
+  },
+  {
+    "id": "3172|Niederwangen bei Bern|BE",
+    "name": "Niederwangen bei Bern",
+    "zipCode": "3172",
+    "canton": "BE"
+  },
+  {
+    "id": "8166|Niederweningen|ZH",
+    "name": "Niederweningen",
+    "zipCode": "8166",
+    "canton": "ZH"
+  },
+  {
+    "id": "3114|Niederwichtrach|BE",
+    "name": "Niederwichtrach",
+    "zipCode": "3114",
+    "canton": "BE"
+  },
+  {
+    "id": "4523|Niederwil|SO",
+    "name": "Niederwil",
+    "zipCode": "4523",
+    "canton": "SO"
+  },
+  {
+    "id": "5524|Niederwil|AG",
+    "name": "Niederwil",
+    "zipCode": "5524",
+    "canton": "AG"
+  },
+  {
+    "id": "6221|Niederwil|LU",
+    "name": "Niederwil",
+    "zipCode": "6221",
+    "canton": "LU"
+  },
+  {
+    "id": "8452|Niederwil|ZH",
+    "name": "Niederwil",
+    "zipCode": "8452",
+    "canton": "ZH"
+  },
+  {
+    "id": "8500|Niederwil|TG",
+    "name": "Niederwil",
+    "zipCode": "8500",
+    "canton": "TG"
+  },
+  {
+    "id": "9203|Niederwil|SG",
+    "name": "Niederwil",
+    "zipCode": "9203",
+    "canton": "SG"
+  },
+  {
+    "id": "1740|Nierlet-le-Toit|FR",
+    "name": "Nierlet-le-Toit",
+    "zipCode": "1740",
+    "canton": "FR"
+  },
+  {
+    "id": "1772|Nierlet-les-Bois|FR",
+    "name": "Nierlet-les-Bois",
+    "zipCode": "1772",
+    "canton": "FR"
+  },
+  {
+    "id": "3711|Niesen Kulm|BE",
+    "name": "Niesen Kulm",
+    "zipCode": "3711",
+    "canton": "BE"
+  },
+  {
+    "id": "3960|Niouc|VS",
+    "name": "Niouc",
+    "zipCode": "3960",
+    "canton": "VS"
+  },
+  {
+    "id": "6683|Niva (Vallemaggia)|TI",
+    "name": "Niva (Vallemaggia)",
+    "zipCode": "6683",
+    "canton": "TI"
+  },
+  {
+    "id": "6746|Nivo|TI",
+    "name": "Nivo",
+    "zipCode": "6746",
+    "canton": "TI"
+  },
+  {
+    "id": "2518|Nods|BE",
+    "name": "Nods",
+    "zipCode": "2518",
+    "canton": "BE"
+  },
+  {
+    "id": "3976|Noës|VS",
+    "name": "Noës",
+    "zipCode": "3976",
+    "canton": "VS"
+  },
+  {
+    "id": "3116|Noflen|BE",
+    "name": "Noflen",
+    "zipCode": "3116",
+    "canton": "BE"
+  },
+  {
+    "id": "3178|Noflen|FR",
+    "name": "Noflen",
+    "zipCode": "3178",
+    "canton": "FR"
+  },
+  {
+    "id": "8212|Nohl|ZH",
+    "name": "Nohl",
+    "zipCode": "8212",
+    "canton": "ZH"
+  },
+  {
+    "id": "2103|Noiraigue|NE",
+    "name": "Noiraigue",
+    "zipCode": "2103",
+    "canton": "NE"
+  },
+  {
+    "id": "2115|Noirvaux|NE",
+    "name": "Noirvaux",
+    "zipCode": "2115",
+    "canton": "NE"
+  },
+  {
+    "id": "1417|Nonfoux|VD",
+    "name": "Nonfoux",
+    "zipCode": "1417",
+    "canton": "VD"
+  },
+  {
+    "id": "6915|Noranco|TI",
+    "name": "Noranco",
+    "zipCode": "6915",
+    "canton": "TI"
+  },
+  {
+    "id": "1400|Noréaz|VD",
+    "name": "Noréaz",
+    "zipCode": "1400",
+    "canton": "VD"
+  },
+  {
+    "id": "1757|Noréaz|FR",
+    "name": "Noréaz",
+    "zipCode": "1757",
+    "canton": "FR"
+  },
+  {
+    "id": "8172|Nöschikon|ZH",
+    "name": "Nöschikon",
+    "zipCode": "8172",
+    "canton": "ZH"
+  },
+  {
+    "id": "8610|Nossikon|ZH",
+    "name": "Nossikon",
+    "zipCode": "8610",
+    "canton": "ZH"
+  },
+  {
+    "id": "9000|Notkersegg|SG",
+    "name": "Notkersegg",
+    "zipCode": "9000",
+    "canton": "SG"
+  },
+  {
+    "id": "6207|Nottwil|LU",
+    "name": "Nottwil",
+    "zipCode": "6207",
+    "canton": "LU"
+  },
+  {
+    "id": "6986|Novaggio|TI",
+    "name": "Novaggio",
+    "zipCode": "6986",
+    "canton": "TI"
+  },
+  {
+    "id": "1431|Novalles|VD",
+    "name": "Novalles",
+    "zipCode": "1431",
+    "canton": "VD"
+  },
+  {
+    "id": "6883|Novazzano|TI",
+    "name": "Novazzano",
+    "zipCode": "6883",
+    "canton": "TI"
+  },
+  {
+    "id": "1845|Noville|VD",
+    "name": "Noville",
+    "zipCode": "1845",
+    "canton": "VD"
+  },
+  {
+    "id": "7437|Nufenen|GR",
+    "name": "Nufenen",
+    "zipCode": "7437",
+    "canton": "GR"
+  },
+  {
+    "id": "4412|Nuglar|SO",
+    "name": "Nuglar",
+    "zipCode": "4412",
+    "canton": "SO"
+  },
+  {
+    "id": "4208|Nunningen|SO",
+    "name": "Nunningen",
+    "zipCode": "4208",
+    "canton": "SO"
+  },
+  {
+    "id": "6283|Nunwil|LU",
+    "name": "Nunwil",
+    "zipCode": "6283",
+    "canton": "LU"
+  },
+  {
+    "id": "8855|Nuolen|SZ",
+    "name": "Nuolen",
+    "zipCode": "8855",
+    "canton": "SZ"
+  },
+  {
+    "id": "8309|Nürensdorf|ZH",
+    "name": "Nürensdorf",
+    "zipCode": "8309",
+    "canton": "ZH"
+  },
+  {
+    "id": "8843|Nüseeben|SZ",
+    "name": "Nüseeben",
+    "zipCode": "8843",
+    "canton": "SZ"
+  },
+  {
+    "id": "8180|Nussbaumen|ZH",
+    "name": "Nussbaumen",
+    "zipCode": "8180",
+    "canton": "ZH"
+  },
+  {
+    "id": "8537|Nussbaumen|TG",
+    "name": "Nussbaumen",
+    "zipCode": "8537",
+    "canton": "TG"
+  },
+  {
+    "id": "5415|Nussbaumen bei Baden|AG",
+    "name": "Nussbaumen bei Baden",
+    "zipCode": "5415",
+    "canton": "AG"
+  },
+  {
+    "id": "8418|Nussberg|ZH",
+    "name": "Nussberg",
+    "zipCode": "8418",
+    "canton": "ZH"
+  },
+  {
+    "id": "4453|Nusshof|BL",
+    "name": "Nusshof",
+    "zipCode": "4453",
+    "canton": "BL"
+  },
+  {
+    "id": "1485|Nuvilly|FR",
+    "name": "Nuvilly",
+    "zipCode": "1485",
+    "canton": "FR"
+  },
+  {
+    "id": "1260|Nyon|VD",
+    "name": "Nyon",
+    "zipCode": "1260",
+    "canton": "VD"
+  },
+  {
+    "id": "6363|Obbürgen|NW",
+    "name": "Obbürgen",
+    "zipCode": "6363",
+    "canton": "NW"
+  },
+  {
+    "id": "8587|Oberaach|TG",
+    "name": "Oberaach",
+    "zipCode": "8587",
+    "canton": "TG"
+  },
+  {
+    "id": "6315|Oberägeri|ZG",
+    "name": "Oberägeri",
+    "zipCode": "6315",
+    "canton": "ZG"
+  },
+  {
+    "id": "6490|Oberalp|UR",
+    "name": "Oberalp",
+    "zipCode": "6490",
+    "canton": "UR"
+  },
+  {
+    "id": "6490|Oberalp|GR",
+    "name": "Oberalp",
+    "zipCode": "6490",
+    "canton": "GR"
+  },
+  {
+    "id": "9212|Oberarnegg|SG",
+    "name": "Oberarnegg",
+    "zipCode": "9212",
+    "canton": "SG"
+  },
+  {
+    "id": "6414|Oberarth|SZ",
+    "name": "Oberarth",
+    "zipCode": "6414",
+    "canton": "SZ"
+  },
+  {
+    "id": "3096|Oberbalm|BE",
+    "name": "Oberbalm",
+    "zipCode": "3096",
+    "canton": "BE"
+  },
+  {
+    "id": "4524|Oberbalmberg|SO",
+    "name": "Oberbalmberg",
+    "zipCode": "4524",
+    "canton": "SO"
+  },
+  {
+    "id": "4538|Oberbipp|BE",
+    "name": "Oberbipp",
+    "zipCode": "4538",
+    "canton": "BE"
+  },
+  {
+    "id": "3780|Oberbort|BE",
+    "name": "Oberbort",
+    "zipCode": "3780",
+    "canton": "BE"
+  },
+  {
+    "id": "3000|Oberbottigen|BE",
+    "name": "Oberbottigen",
+    "zipCode": "3000",
+    "canton": "BE"
+  },
+  {
+    "id": "5225|Oberbözberg|AG",
+    "name": "Oberbözberg",
+    "zipCode": "5225",
+    "canton": "AG"
+  },
+  {
+    "id": "4625|Oberbuchsiten|SO",
+    "name": "Oberbuchsiten",
+    "zipCode": "4625",
+    "canton": "SO"
+  },
+  {
+    "id": "6344|Oberbuonas|LU",
+    "name": "Oberbuonas",
+    "zipCode": "6344",
+    "canton": "LU"
+  },
+  {
+    "id": "9245|Oberbüren|SG",
+    "name": "Oberbüren",
+    "zipCode": "9245",
+    "canton": "SG"
+  },
+  {
+    "id": "3414|Oberburg|BE",
+    "name": "Oberburg",
+    "zipCode": "3414",
+    "canton": "BE"
+  },
+  {
+    "id": "9565|Oberbussnang|TG",
+    "name": "Oberbussnang",
+    "zipCode": "9565",
+    "canton": "TG"
+  },
+  {
+    "id": "3088|Oberbütschel|BE",
+    "name": "Oberbütschel",
+    "zipCode": "3088",
+    "canton": "BE"
+  },
+  {
+    "id": "3672|Oberdiessbach|BE",
+    "name": "Oberdiessbach",
+    "zipCode": "3672",
+    "canton": "BE"
+  },
+  {
+    "id": "4436|Oberdorf|BL",
+    "name": "Oberdorf",
+    "zipCode": "4436",
+    "canton": "BL"
+  },
+  {
+    "id": "4515|Oberdorf|SO",
+    "name": "Oberdorf",
+    "zipCode": "4515",
+    "canton": "SO"
+  },
+  {
+    "id": "6370|Oberdorf|NW",
+    "name": "Oberdorf",
+    "zipCode": "6370",
+    "canton": "NW"
+  },
+  {
+    "id": "6375|Oberdorf|NW",
+    "name": "Oberdorf",
+    "zipCode": "6375",
+    "canton": "NW"
+  },
+  {
+    "id": "9200|Oberdorf|SG",
+    "name": "Oberdorf",
+    "zipCode": "9200",
+    "canton": "SG"
+  },
+  {
+    "id": "8105|Oberdorf bei Regensdorf|ZH",
+    "name": "Oberdorf bei Regensdorf",
+    "zipCode": "8105",
+    "canton": "ZH"
+  },
+  {
+    "id": "8635|Oberdürnten|ZH",
+    "name": "Oberdürnten",
+    "zipCode": "8635",
+    "canton": "ZH"
+  },
+  {
+    "id": "8589|Oberegg|SG",
+    "name": "Oberegg",
+    "zipCode": "8589",
+    "canton": "SG"
+  },
+  {
+    "id": "9413|Oberegg|AI",
+    "name": "Oberegg",
+    "zipCode": "9413",
+    "canton": "AI"
+  },
+  {
+    "id": "5420|Oberehrendingen|AG",
+    "name": "Oberehrendingen",
+    "zipCode": "5420",
+    "canton": "AG"
+  },
+  {
+    "id": "3203|Oberei|BE",
+    "name": "Oberei",
+    "zipCode": "3203",
+    "canton": "BE"
+  },
+  {
+    "id": "3618|Oberei bei Süderen|BE",
+    "name": "Oberei bei Süderen",
+    "zipCode": "3618",
+    "canton": "BE"
+  },
+  {
+    "id": "8425|Oberembrach|ZH",
+    "name": "Oberembrach",
+    "zipCode": "8425",
+    "canton": "ZH"
+  },
+  {
+    "id": "3948|Oberems|VS",
+    "name": "Oberems",
+    "zipCode": "3948",
+    "canton": "VS"
+  },
+  {
+    "id": "8102|Oberengstringen|ZH",
+    "name": "Oberengstringen",
+    "zipCode": "8102",
+    "canton": "ZH"
+  },
+  {
+    "id": "5036|Oberentfelden|AG",
+    "name": "Oberentfelden",
+    "zipCode": "5036",
+    "canton": "AG"
+  },
+  {
+    "id": "9434|Oberfar|SG",
+    "name": "Oberfar",
+    "zipCode": "9434",
+    "canton": "SG"
+  },
+  {
+    "id": "5108|Oberflachs|AG",
+    "name": "Oberflachs",
+    "zipCode": "5108",
+    "canton": "AG"
+  },
+  {
+    "id": "5073|Oberfrick|AG",
+    "name": "Oberfrick",
+    "zipCode": "5073",
+    "canton": "AG"
+  },
+  {
+    "id": "3551|Oberfrittenbach|BE",
+    "name": "Oberfrittenbach",
+    "zipCode": "3551",
+    "canton": "BE"
+  },
+  {
+    "id": "4564|Obergerlafingen|SO",
+    "name": "Obergerlafingen",
+    "zipCode": "4564",
+    "canton": "SO"
+  },
+  {
+    "id": "3988|Obergesteln|VS",
+    "name": "Obergesteln",
+    "zipCode": "3988",
+    "canton": "VS"
+  },
+  {
+    "id": "8154|Oberglatt|ZH",
+    "name": "Oberglatt",
+    "zipCode": "8154",
+    "canton": "ZH"
+  },
+  {
+    "id": "9230|Oberglatt|SG",
+    "name": "Oberglatt",
+    "zipCode": "9230",
+    "canton": "SG"
+  },
+  {
+    "id": "3434|Obergoldbach|BE",
+    "name": "Obergoldbach",
+    "zipCode": "3434",
+    "canton": "BE"
+  },
+  {
+    "id": "4653|Obergösgen|SO",
+    "name": "Obergösgen",
+    "zipCode": "4653",
+    "canton": "SO"
+  },
+  {
+    "id": "8216|Oberhallau|SH",
+    "name": "Oberhallau",
+    "zipCode": "8216",
+    "canton": "SH"
+  },
+  {
+    "id": "8156|Oberhasli|ZH",
+    "name": "Oberhasli",
+    "zipCode": "8156",
+    "canton": "ZH"
+  },
+  {
+    "id": "9621|Oberhelfenschwil|SG",
+    "name": "Oberhelfenschwil",
+    "zipCode": "9621",
+    "canton": "SG"
+  },
+  {
+    "id": "8335|Oberhittnau|ZH",
+    "name": "Oberhittnau",
+    "zipCode": "8335",
+    "canton": "ZH"
+  },
+  {
+    "id": "5062|Oberhof|AG",
+    "name": "Oberhof",
+    "zipCode": "5062",
+    "canton": "AG"
+  },
+  {
+    "id": "5273|Oberhofen|AG",
+    "name": "Oberhofen",
+    "zipCode": "5273",
+    "canton": "AG"
+  },
+  {
+    "id": "8488|Oberhofen|ZH",
+    "name": "Oberhofen",
+    "zipCode": "8488",
+    "canton": "ZH"
+  },
+  {
+    "id": "9542|Oberhofen|TG",
+    "name": "Oberhofen",
+    "zipCode": "9542",
+    "canton": "TG"
+  },
+  {
+    "id": "3653|Oberhofen am Thunersee|BE",
+    "name": "Oberhofen am Thunersee",
+    "zipCode": "3653",
+    "canton": "BE"
+  },
+  {
+    "id": "8574|Oberhofen bei Kreuzlingen|TG",
+    "name": "Oberhofen bei Kreuzlingen",
+    "zipCode": "8574",
+    "canton": "TG"
+  },
+  {
+    "id": "3533|Oberhofen im Emmental|BE",
+    "name": "Oberhofen im Emmental",
+    "zipCode": "3533",
+    "canton": "BE"
+  },
+  {
+    "id": "8636|Oberholz|SG",
+    "name": "Oberholz",
+    "zipCode": "8636",
+    "canton": "SG"
+  },
+  {
+    "id": "8181|Oberhöri|ZH",
+    "name": "Oberhöri",
+    "zipCode": "8181",
+    "canton": "ZH"
+  },
+  {
+    "id": "8508|Oberhörstetten|TG",
+    "name": "Oberhörstetten",
+    "zipCode": "8508",
+    "canton": "TG"
+  },
+  {
+    "id": "3504|Oberhünigen|BE",
+    "name": "Oberhünigen",
+    "zipCode": "3504",
+    "canton": "BE"
+  },
+  {
+    "id": "8843|Oberiberg|SZ",
+    "name": "Oberiberg",
+    "zipCode": "8843",
+    "canton": "SZ"
+  },
+  {
+    "id": "4234|Oberkirch|SO",
+    "name": "Oberkirch",
+    "zipCode": "4234",
+    "canton": "SO"
+  },
+  {
+    "id": "6208|Oberkirch|LU",
+    "name": "Oberkirch",
+    "zipCode": "6208",
+    "canton": "LU"
+  },
+  {
+    "id": "5727|Oberkulm|AG",
+    "name": "Oberkulm",
+    "zipCode": "5727",
+    "canton": "AG"
+  },
+  {
+    "id": "3616|Oberlangenegg|BE",
+    "name": "Oberlangenegg",
+    "zipCode": "3616",
+    "canton": "BE"
+  },
+  {
+    "id": "8134|Oberleimbach|ZH",
+    "name": "Oberleimbach",
+    "zipCode": "8134",
+    "canton": "ZH"
+  },
+  {
+    "id": "3038|Oberlindach|BE",
+    "name": "Oberlindach",
+    "zipCode": "3038",
+    "canton": "BE"
+  },
+  {
+    "id": "8917|Oberlunkhofen|AG",
+    "name": "Oberlunkhofen",
+    "zipCode": "8917",
+    "canton": "AG"
+  },
+  {
+    "id": "8912|Oberlunnern|ZH",
+    "name": "Oberlunnern",
+    "zipCode": "8912",
+    "canton": "ZH"
+  },
+  {
+    "id": "3550|Obermatt|BE",
+    "name": "Obermatt",
+    "zipCode": "3550",
+    "canton": "BE"
+  },
+  {
+    "id": "8706|Obermeilen|ZH",
+    "name": "Obermeilen",
+    "zipCode": "8706",
+    "canton": "ZH"
+  },
+  {
+    "id": "1713|Obermonten|FR",
+    "name": "Obermonten",
+    "zipCode": "1713",
+    "canton": "FR"
+  },
+  {
+    "id": "5037|Obermuhen|AG",
+    "name": "Obermuhen",
+    "zipCode": "5037",
+    "canton": "AG"
+  },
+  {
+    "id": "4324|Obermumpf|AG",
+    "name": "Obermumpf",
+    "zipCode": "4324",
+    "canton": "AG"
+  },
+  {
+    "id": "7431|Obermutten|GR",
+    "name": "Obermutten",
+    "zipCode": "7431",
+    "canton": "GR"
+  },
+  {
+    "id": "6012|Obernau|LU",
+    "name": "Obernau",
+    "zipCode": "6012",
+    "canton": "LU"
+  },
+  {
+    "id": "8526|Oberneunforn|TG",
+    "name": "Oberneunforn",
+    "zipCode": "8526",
+    "canton": "TG"
+  },
+  {
+    "id": "8472|Oberohringen|ZH",
+    "name": "Oberohringen",
+    "zipCode": "8472",
+    "canton": "ZH"
+  },
+  {
+    "id": "3363|Oberönz|BE",
+    "name": "Oberönz",
+    "zipCode": "3363",
+    "canton": "BE"
+  },
+  {
+    "id": "3424|Oberösch|BE",
+    "name": "Oberösch",
+    "zipCode": "3424",
+    "canton": "BE"
+  },
+  {
+    "id": "4588|Oberramsern|SO",
+    "name": "Oberramsern",
+    "zipCode": "4588",
+    "canton": "SO"
+  },
+  {
+    "id": "6387|Oberrickenbach|NW",
+    "name": "Oberrickenbach",
+    "zipCode": "6387",
+    "canton": "NW"
+  },
+  {
+    "id": "3433|Oberried (Thalgraben)|BE",
+    "name": "Oberried (Thalgraben)",
+    "zipCode": "3433",
+    "canton": "BE"
+  },
+  {
+    "id": "3854|Oberried am Brienzersee|BE",
+    "name": "Oberried am Brienzersee",
+    "zipCode": "3854",
+    "canton": "BE"
+  },
+  {
+    "id": "3145|Oberried bei Niederscherli|BE",
+    "name": "Oberried bei Niederscherli",
+    "zipCode": "3145",
+    "canton": "BE"
+  },
+  {
+    "id": "8942|Oberrieden|ZH",
+    "name": "Oberrieden",
+    "zipCode": "8942",
+    "canton": "ZH"
+  },
+  {
+    "id": "1724|Oberriet|FR",
+    "name": "Oberriet",
+    "zipCode": "1724",
+    "canton": "FR"
+  },
+  {
+    "id": "9463|Oberriet|SG",
+    "name": "Oberriet",
+    "zipCode": "9463",
+    "canton": "SG"
+  },
+  {
+    "id": "9604|Oberrindal|SG",
+    "name": "Oberrindal",
+    "zipCode": "9604",
+    "canton": "SG"
+  },
+  {
+    "id": "5452|Oberrohrdorf|AG",
+    "name": "Oberrohrdorf",
+    "zipCode": "5452",
+    "canton": "AG"
+  },
+  {
+    "id": "3036|Oberruntigen|BE",
+    "name": "Oberruntigen",
+    "zipCode": "3036",
+    "canton": "BE"
+  },
+  {
+    "id": "5647|Oberrüti|AG",
+    "name": "Oberrüti",
+    "zipCode": "5647",
+    "canton": "AG"
+  },
+  {
+    "id": "7134|Obersaxen|GR",
+    "name": "Obersaxen",
+    "zipCode": "7134",
+    "canton": "GR"
+  },
+  {
+    "id": "9479|Oberschan|SG",
+    "name": "Oberschan",
+    "zipCode": "9479",
+    "canton": "SG"
+  },
+  {
+    "id": "3145|Oberscherli|BE",
+    "name": "Oberscherli",
+    "zipCode": "3145",
+    "canton": "BE"
+  },
+  {
+    "id": "8418|Oberschlatt|ZH",
+    "name": "Oberschlatt",
+    "zipCode": "8418",
+    "canton": "ZH"
+  },
+  {
+    "id": "8523|Oberschneit|ZH",
+    "name": "Oberschneit",
+    "zipCode": "8523",
+    "canton": "ZH"
+  },
+  {
+    "id": "6438|Oberschönenbuch|SZ",
+    "name": "Oberschönenbuch",
+    "zipCode": "6438",
+    "canton": "SZ"
+  },
+  {
+    "id": "6288|Oberschongau|LU",
+    "name": "Oberschongau",
+    "zipCode": "6288",
+    "canton": "LU"
+  },
+  {
+    "id": "1716|Oberschrot|FR",
+    "name": "Oberschrot",
+    "zipCode": "1716",
+    "canton": "FR"
+  },
+  {
+    "id": "5415|Obersiggenthal|AG",
+    "name": "Obersiggenthal",
+    "zipCode": "5415",
+    "canton": "AG"
+  },
+  {
+    "id": "5417|Obersiggingen|AG",
+    "name": "Obersiggingen",
+    "zipCode": "5417",
+    "canton": "AG"
+  },
+  {
+    "id": "8477|Oberstammheim|ZH",
+    "name": "Oberstammheim",
+    "zipCode": "8477",
+    "canton": "ZH"
+  },
+  {
+    "id": "4924|Obersteckholz|BE",
+    "name": "Obersteckholz",
+    "zipCode": "4924",
+    "canton": "BE"
+  },
+  {
+    "id": "9323|Obersteinach|SG",
+    "name": "Obersteinach",
+    "zipCode": "9323",
+    "canton": "SG"
+  },
+  {
+    "id": "8162|Obersteinmaur|ZH",
+    "name": "Obersteinmaur",
+    "zipCode": "8162",
+    "canton": "ZH"
+  },
+  {
+    "id": "9249|Oberstetten|SG",
+    "name": "Oberstetten",
+    "zipCode": "9249",
+    "canton": "SG"
+  },
+  {
+    "id": "3632|Oberstocken|BE",
+    "name": "Oberstocken",
+    "zipCode": "3632",
+    "canton": "BE"
+  },
+  {
+    "id": "8000|Oberstrass|ZH",
+    "name": "Oberstrass",
+    "zipCode": "8000",
+    "canton": "ZH"
+  },
+  {
+    "id": "5085|Obersulz|AG",
+    "name": "Obersulz",
+    "zipCode": "5085",
+    "canton": "AG"
+  },
+  {
+    "id": "8884|Oberterzen|SG",
+    "name": "Oberterzen",
+    "zipCode": "8884",
+    "canton": "SG"
+  },
+  {
+    "id": "3531|Oberthal|BE",
+    "name": "Oberthal",
+    "zipCode": "3531",
+    "canton": "BE"
+  },
+  {
+    "id": "3144|Oberulmiz|BE",
+    "name": "Oberulmiz",
+    "zipCode": "3144",
+    "canton": "BE"
+  },
+  {
+    "id": "8902|Oberurdorf|ZH",
+    "name": "Oberurdorf",
+    "zipCode": "8902",
+    "canton": "ZH"
+  },
+  {
+    "id": "8868|Oberurnen|GL",
+    "name": "Oberurnen",
+    "zipCode": "8868",
+    "canton": "GL"
+  },
+  {
+    "id": "9242|Oberuzwil|SG",
+    "name": "Oberuzwil",
+    "zipCode": "9242",
+    "canton": "SG"
+  },
+  {
+    "id": "3999|Oberwald|VS",
+    "name": "Oberwald",
+    "zipCode": "3999",
+    "canton": "VS"
+  },
+  {
+    "id": "8374|Oberwangen|TG",
+    "name": "Oberwangen",
+    "zipCode": "8374",
+    "canton": "TG"
+  },
+  {
+    "id": "3173|Oberwangen bei Bern|BE",
+    "name": "Oberwangen bei Bern",
+    "zipCode": "3173",
+    "canton": "BE"
+  },
+  {
+    "id": "8165|Oberweningen|ZH",
+    "name": "Oberweningen",
+    "zipCode": "8165",
+    "canton": "ZH"
+  },
+  {
+    "id": "8620|Oberwetzikon|ZH",
+    "name": "Oberwetzikon",
+    "zipCode": "8620",
+    "canton": "ZH"
+  },
+  {
+    "id": "3114|Oberwichtrach|BE",
+    "name": "Oberwichtrach",
+    "zipCode": "3114",
+    "canton": "BE"
+  },
+  {
+    "id": "8226|Oberwiesen|SH",
+    "name": "Oberwiesen",
+    "zipCode": "8226",
+    "canton": "SH"
+  },
+  {
+    "id": "4104|Oberwil|BL",
+    "name": "Oberwil",
+    "zipCode": "4104",
+    "canton": "BL"
+  },
+  {
+    "id": "8500|Oberwil|TG",
+    "name": "Oberwil",
+    "zipCode": "8500",
+    "canton": "TG"
+  },
+  {
+    "id": "8966|Oberwil|AG",
+    "name": "Oberwil",
+    "zipCode": "8966",
+    "canton": "AG"
+  },
+  {
+    "id": "3298|Oberwil bei Büren|BE",
+    "name": "Oberwil bei Büren",
+    "zipCode": "3298",
+    "canton": "BE"
+  },
+  {
+    "id": "8471|Oberwil bei Dägerlen|ZH",
+    "name": "Oberwil bei Dägerlen",
+    "zipCode": "8471",
+    "canton": "ZH"
+  },
+  {
+    "id": "8309|Oberwil bei Nürensdorf|ZH",
+    "name": "Oberwil bei Nürensdorf",
+    "zipCode": "8309",
+    "canton": "ZH"
+  },
+  {
+    "id": "6317|Oberwil bei Zug|ZG",
+    "name": "Oberwil bei Zug",
+    "zipCode": "6317",
+    "canton": "ZG"
+  },
+  {
+    "id": "3765|Oberwil im Simmental|BE",
+    "name": "Oberwil im Simmental",
+    "zipCode": "3765",
+    "canton": "BE"
+  },
+  {
+    "id": "6062|Oberwilen|OW",
+    "name": "Oberwilen",
+    "zipCode": "6062",
+    "canton": "OW"
+  },
+  {
+    "id": "8404|Oberwinterthur|ZH",
+    "name": "Oberwinterthur",
+    "zipCode": "8404",
+    "canton": "ZH"
+  },
+  {
+    "id": "5079|Oberzeihen|AG",
+    "name": "Oberzeihen",
+    "zipCode": "5079",
+    "canton": "AG"
+  },
+  {
+    "id": "3052|Oberzollikofen|BE",
+    "name": "Oberzollikofen",
+    "zipCode": "3052",
+    "canton": "BE"
+  },
+  {
+    "id": "8912|Obfelden|ZH",
+    "name": "Obfelden",
+    "zipCode": "8912",
+    "canton": "ZH"
+  },
+  {
+    "id": "6874|Obino|TI",
+    "name": "Obino",
+    "zipCode": "6874",
+    "canton": "TI"
+  },
+  {
+    "id": "6078|Obsee|OW",
+    "name": "Obsee",
+    "zipCode": "6078",
+    "canton": "OW"
+  },
+  {
+    "id": "8758|Obstalden|GL",
+    "name": "Obstalden",
+    "zipCode": "8758",
+    "canton": "GL"
+  },
+  {
+    "id": "3367|Ochlenberg|BE",
+    "name": "Ochlenberg",
+    "zipCode": "3367",
+    "canton": "BE"
+  },
+  {
+    "id": "2889|Ocourt|JU",
+    "name": "Ocourt",
+    "zipCode": "2889",
+    "canton": "JU"
+  },
+  {
+    "id": "6960|Odogno|TI",
+    "name": "Odogno",
+    "zipCode": "6960",
+    "canton": "TI"
+  },
+  {
+    "id": "4566|Oekingen|SO",
+    "name": "Oekingen",
+    "zipCode": "4566",
+    "canton": "SO"
+  },
+  {
+    "id": "4702|Oensingen|SO",
+    "name": "Oensingen",
+    "zipCode": "4702",
+    "canton": "SO"
+  },
+  {
+    "id": "8000|Oerlikon|ZH",
+    "name": "Oerlikon",
+    "zipCode": "8000",
+    "canton": "ZH"
+  },
+  {
+    "id": "8461|Oerlingen|ZH",
+    "name": "Oerlingen",
+    "zipCode": "8461",
+    "canton": "ZH"
+  },
+  {
+    "id": "3425|Oeschberg|BE",
+    "name": "Oeschberg",
+    "zipCode": "3425",
+    "canton": "BE"
+  },
+  {
+    "id": "4943|Oeschenbach|BE",
+    "name": "Oeschenbach",
+    "zipCode": "4943",
+    "canton": "BE"
+  },
+  {
+    "id": "5072|Oeschgen|AG",
+    "name": "Oeschgen",
+    "zipCode": "5072",
+    "canton": "AG"
+  },
+  {
+    "id": "3776|Oeschseite|BE",
+    "name": "Oeschseite",
+    "zipCode": "3776",
+    "canton": "BE"
+  },
+  {
+    "id": "8618|Oetwil am See|ZH",
+    "name": "Oetwil am See",
+    "zipCode": "8618",
+    "canton": "ZH"
+  },
+  {
+    "id": "8955|Oetwil an der Limmat|ZH",
+    "name": "Oetwil an der Limmat",
+    "zipCode": "8955",
+    "canton": "ZH"
+  },
+  {
+    "id": "3753|Oey|BE",
+    "name": "Oey",
+    "zipCode": "3753",
+    "canton": "BE"
+  },
+  {
+    "id": "7530|Ofenpass|GR",
+    "name": "Ofenpass",
+    "zipCode": "7530",
+    "canton": "GR"
+  },
+  {
+    "id": "4665|Oftringen|AG",
+    "name": "Oftringen",
+    "zipCode": "4665",
+    "canton": "AG"
+  },
+  {
+    "id": "1045|Ogens|VD",
+    "name": "Ogens",
+    "zipCode": "1045",
+    "canton": "VD"
+  },
+  {
+    "id": "6955|Oggio|TI",
+    "name": "Oggio",
+    "zipCode": "6955",
+    "canton": "TI"
+  },
+  {
+    "id": "6143|Ohmstal|LU",
+    "name": "Ohmstal",
+    "zipCode": "6143",
+    "canton": "LU"
+  },
+  {
+    "id": "8472|Ohringen|ZH",
+    "name": "Ohringen",
+    "zipCode": "8472",
+    "canton": "ZH"
+  },
+  {
+    "id": "1580|Oleyres|VD",
+    "name": "Oleyres",
+    "zipCode": "1580",
+    "canton": "VD"
+  },
+  {
+    "id": "6922|Olivella|TI",
+    "name": "Olivella",
+    "zipCode": "6922",
+    "canton": "TI"
+  },
+  {
+    "id": "6718|Olivone|TI",
+    "name": "Olivone",
+    "zipCode": "6718",
+    "canton": "TI"
+  },
+  {
+    "id": "1867|Ollon|VD",
+    "name": "Ollon",
+    "zipCode": "1867",
+    "canton": "VD"
+  },
+  {
+    "id": "3971|Ollon|VS",
+    "name": "Ollon",
+    "zipCode": "3971",
+    "canton": "VS"
+  },
+  {
+    "id": "4305|Olsberg|BL",
+    "name": "Olsberg",
+    "zipCode": "4305",
+    "canton": "BL"
+  },
+  {
+    "id": "4305|Olsberg|AG",
+    "name": "Olsberg",
+    "zipCode": "4305",
+    "canton": "AG"
+  },
+  {
+    "id": "4600|Olten|SO",
+    "name": "Olten",
+    "zipCode": "4600",
+    "canton": "SO"
+  },
+  {
+    "id": "3036|Oltigen|BE",
+    "name": "Oltigen",
+    "zipCode": "3036",
+    "canton": "BE"
+  },
+  {
+    "id": "4494|Oltingen|BL",
+    "name": "Oltingen",
+    "zipCode": "4494",
+    "canton": "BL"
+  },
+  {
+    "id": "1213|Onex|GE",
+    "name": "Onex",
+    "zipCode": "1213",
+    "canton": "GE"
+  },
+  {
+    "id": "1425|Onnens|VD",
+    "name": "Onnens",
+    "zipCode": "1425",
+    "canton": "VD"
+  },
+  {
+    "id": "1756|Onnens|FR",
+    "name": "Onnens",
+    "zipCode": "1756",
+    "canton": "FR"
+  },
+  {
+    "id": "8584|Opfershofen|TG",
+    "name": "Opfershofen",
+    "zipCode": "8584",
+    "canton": "TG"
+  },
+  {
+    "id": "8236|Opfertshofen|SH",
+    "name": "Opfertshofen",
+    "zipCode": "8236",
+    "canton": "SH"
+  },
+  {
+    "id": "8152|Opfikon|ZH",
+    "name": "Opfikon",
+    "zipCode": "8152",
+    "canton": "ZH"
+  },
+  {
+    "id": "1047|Oppens|VD",
+    "name": "Oppens",
+    "zipCode": "1047",
+    "canton": "VD"
+  },
+  {
+    "id": "9565|Oppikon|TG",
+    "name": "Oppikon",
+    "zipCode": "9565",
+    "canton": "TG"
+  },
+  {
+    "id": "3629|Oppligen|BE",
+    "name": "Oppligen",
+    "zipCode": "3629",
+    "canton": "BE"
+  },
+  {
+    "id": "1350|Orbe|VD",
+    "name": "Orbe",
+    "zipCode": "1350",
+    "canton": "VD"
+  },
+  {
+    "id": "6513|Orenno|TI",
+    "name": "Orenno",
+    "zipCode": "6513",
+    "canton": "TI"
+  },
+  {
+    "id": "1430|Orges|VD",
+    "name": "Orges",
+    "zipCode": "1430",
+    "canton": "VD"
+  },
+  {
+    "id": "6945|Origlio|TI",
+    "name": "Origlio",
+    "zipCode": "6945",
+    "canton": "TI"
+  },
+  {
+    "id": "6713|Orino|TI",
+    "name": "Orino",
+    "zipCode": "6713",
+    "canton": "TI"
+  },
+  {
+    "id": "4466|Ormalingen|BL",
+    "name": "Ormalingen",
+    "zipCode": "4466",
+    "canton": "BL"
+  },
+  {
+    "id": "1965|Ormône|VS",
+    "name": "Ormône",
+    "zipCode": "1965",
+    "canton": "VS"
+  },
+  {
+    "id": "1862|Ormont-Dessous|VD",
+    "name": "Ormont-Dessous",
+    "zipCode": "1862",
+    "canton": "VD"
+  },
+  {
+    "id": "1865|Ormont-Dessus|VD",
+    "name": "Ormont-Dessus",
+    "zipCode": "1865",
+    "canton": "VD"
+  },
+  {
+    "id": "1317|Orny|VD",
+    "name": "Orny",
+    "zipCode": "1317",
+    "canton": "VD"
+  },
+  {
+    "id": "1610|Oron-la-Ville|VD",
+    "name": "Oron-la-Ville",
+    "zipCode": "1610",
+    "canton": "VD"
+  },
+  {
+    "id": "1608|Oron-le-Châtel|VD",
+    "name": "Oron-le-Châtel",
+    "zipCode": "1608",
+    "canton": "VD"
+  },
+  {
+    "id": "2552|Orpund|BE",
+    "name": "Orpund",
+    "zipCode": "2552",
+    "canton": "BE"
+  },
+  {
+    "id": "6644|Orselina|TI",
+    "name": "Orselina",
+    "zipCode": "6644",
+    "canton": "TI"
+  },
+  {
+    "id": "1937|Orsières|VS",
+    "name": "Orsières",
+    "zipCode": "1937",
+    "canton": "VS"
+  },
+  {
+    "id": "1694|Orsonnens|FR",
+    "name": "Orsonnens",
+    "zipCode": "1694",
+    "canton": "FR"
+  },
+  {
+    "id": "3042|Ortschwaben|BE",
+    "name": "Ortschwaben",
+    "zipCode": "3042",
+    "canton": "BE"
+  },
+  {
+    "id": "2534|Orvin|BE",
+    "name": "Orvin",
+    "zipCode": "2534",
+    "canton": "BE"
+  },
+  {
+    "id": "1413|Orzens|VD",
+    "name": "Orzens",
+    "zipCode": "1413",
+    "canton": "VD"
+  },
+  {
+    "id": "3476|Oschwand|BE",
+    "name": "Oschwand",
+    "zipCode": "3476",
+    "canton": "BE"
+  },
+  {
+    "id": "6763|Osco|TI",
+    "name": "Osco",
+    "zipCode": "6763",
+    "canton": "TI"
+  },
+  {
+    "id": "6703|Osogna|TI",
+    "name": "Osogna",
+    "zipCode": "6703",
+    "canton": "TI"
+  },
+  {
+    "id": "6703|Osogna Stazione|TI",
+    "name": "Osogna Stazione",
+    "zipCode": "6703",
+    "canton": "TI"
+  },
+  {
+    "id": "7710|Ospizio Bernina|GR",
+    "name": "Ospizio Bernina",
+    "zipCode": "7710",
+    "canton": "GR"
+  },
+  {
+    "id": "6781|Ossasco|TI",
+    "name": "Ossasco",
+    "zipCode": "6781",
+    "canton": "TI"
+  },
+  {
+    "id": "8475|Ossingen|ZH",
+    "name": "Ossingen",
+    "zipCode": "8475",
+    "canton": "ZH"
+  },
+  {
+    "id": "6814|Ostarietta|TI",
+    "name": "Ostarietta",
+    "zipCode": "6814",
+    "canton": "TI"
+  },
+  {
+    "id": "8218|Osterfingen|SH",
+    "name": "Osterfingen",
+    "zipCode": "8218",
+    "canton": "SH"
+  },
+  {
+    "id": "6130|Ostergau|LU",
+    "name": "Ostergau",
+    "zipCode": "6130",
+    "canton": "LU"
+  },
+  {
+    "id": "8500|Osterhalden|TG",
+    "name": "Osterhalden",
+    "zipCode": "8500",
+    "canton": "TG"
+  },
+  {
+    "id": "3036|Ostermanigen|BE",
+    "name": "Ostermanigen",
+    "zipCode": "3036",
+    "canton": "BE"
+  },
+  {
+    "id": "3072|Ostermundigen|BE",
+    "name": "Ostermundigen",
+    "zipCode": "3072",
+    "canton": "BE"
+  },
+  {
+    "id": "8112|Otelfingen|ZH",
+    "name": "Otelfingen",
+    "zipCode": "8112",
+    "canton": "ZH"
+  },
+  {
+    "id": "5504|Othmarsingen|AG",
+    "name": "Othmarsingen",
+    "zipCode": "5504",
+    "canton": "AG"
+  },
+  {
+    "id": "8712|Ötikon|ZH",
+    "name": "Ötikon",
+    "zipCode": "8712",
+    "canton": "ZH"
+  },
+  {
+    "id": "8913|Ottenbach|ZH",
+    "name": "Ottenbach",
+    "zipCode": "8913",
+    "canton": "ZH"
+  },
+  {
+    "id": "8492|Ottenhub|ZH",
+    "name": "Ottenhub",
+    "zipCode": "8492",
+    "canton": "ZH"
+  },
+  {
+    "id": "6275|Ottenhusen|LU",
+    "name": "Ottenhusen",
+    "zipCode": "6275",
+    "canton": "LU"
+  },
+  {
+    "id": "1738|Ottenleue Bad|BE",
+    "name": "Ottenleue Bad",
+    "zipCode": "1738",
+    "canton": "BE"
+  },
+  {
+    "id": "8626|Ottikon|ZH",
+    "name": "Ottikon",
+    "zipCode": "8626",
+    "canton": "ZH"
+  },
+  {
+    "id": "8307|Ottikon bei Kemptthal|ZH",
+    "name": "Ottikon bei Kemptthal",
+    "zipCode": "8307",
+    "canton": "ZH"
+  },
+  {
+    "id": "3257|Ottiswil|BE",
+    "name": "Ottiswil",
+    "zipCode": "3257",
+    "canton": "BE"
+  },
+  {
+    "id": "8561|Ottoberg|TG",
+    "name": "Ottoberg",
+    "zipCode": "8561",
+    "canton": "TG"
+  },
+  {
+    "id": "1000|Ouchy|VD",
+    "name": "Ouchy",
+    "zipCode": "1000",
+    "canton": "VD"
+  },
+  {
+    "id": "1377|Oulens-sous-Echallens|VD",
+    "name": "Oulens-sous-Echallens",
+    "zipCode": "1377",
+    "canton": "VD"
+  },
+  {
+    "id": "1522|Oulens-sur-Lucens|VD",
+    "name": "Oulens-sur-Lucens",
+    "zipCode": "1522",
+    "canton": "VD"
+  },
+  {
+    "id": "2950|Outremont|JU",
+    "name": "Outremont",
+    "zipCode": "2950",
+    "canton": "JU"
+  },
+  {
+    "id": "1911|Ovronnaz|VS",
+    "name": "Ovronnaz",
+    "zipCode": "1911",
+    "canton": "VS"
+  },
+  {
+    "id": "7028|Pagig|GR",
+    "name": "Pagig",
+    "zipCode": "7028",
+    "canton": "GR"
+  },
+  {
+    "id": "1416|Pailly|VD",
+    "name": "Pailly",
+    "zipCode": "1416",
+    "canton": "VD"
+  },
+  {
+    "id": "6657|Palagnedra|TI",
+    "name": "Palagnedra",
+    "zipCode": "6657",
+    "canton": "TI"
+  },
+  {
+    "id": "1945|Palasuit|VS",
+    "name": "Palasuit",
+    "zipCode": "1945",
+    "canton": "VS"
+  },
+  {
+    "id": "1607|Palézieux-Gare|VD",
+    "name": "Palézieux-Gare",
+    "zipCode": "1607",
+    "canton": "VD"
+  },
+  {
+    "id": "1607|Palézieux-Village|VD",
+    "name": "Palézieux-Village",
+    "zipCode": "1607",
+    "canton": "VD"
+  },
+  {
+    "id": "6915|Pambio|TI",
+    "name": "Pambio",
+    "zipCode": "6915",
+    "canton": "TI"
+  },
+  {
+    "id": "1142|Pampigny|VD",
+    "name": "Pampigny",
+    "zipCode": "1142",
+    "canton": "VD"
+  },
+  {
+    "id": "1867|Panex|VD",
+    "name": "Panex",
+    "zipCode": "1867",
+    "canton": "VD"
+  },
+  {
+    "id": "7243|Pany|GR",
+    "name": "Pany",
+    "zipCode": "7243",
+    "canton": "GR"
+  },
+  {
+    "id": "3063|Papiermühle|BE",
+    "name": "Papiermühle",
+    "zipCode": "3063",
+    "canton": "BE"
+  },
+  {
+    "id": "8246|Paradies|TG",
+    "name": "Paradies",
+    "zipCode": "8246",
+    "canton": "TG"
+  },
+  {
+    "id": "6900|Paradiso|TI",
+    "name": "Paradiso",
+    "zipCode": "6900",
+    "canton": "TI"
+  },
+  {
+    "id": "7185|Pardé|GR",
+    "name": "Pardé",
+    "zipCode": "7185",
+    "canton": "GR"
+  },
+  {
+    "id": "7212|Pardisla|GR",
+    "name": "Pardisla",
+    "zipCode": "7212",
+    "canton": "GR"
+  },
+  {
+    "id": "7076|Parpan|GR",
+    "name": "Parpan",
+    "zipCode": "7076",
+    "canton": "GR"
+  },
+  {
+    "id": "7464|Parsonz|GR",
+    "name": "Parsonz",
+    "zipCode": "7464",
+    "canton": "GR"
+  },
+  {
+    "id": "7417|Paspels|GR",
+    "name": "Paspels",
+    "zipCode": "7417",
+    "canton": "GR"
+  },
+  {
+    "id": "3988|Passo della Novena|TI",
+    "name": "Passo della Novena",
+    "zipCode": "3988",
+    "canton": "TI"
+  },
+  {
+    "id": "7062|Passugg-Araschgen|GR",
+    "name": "Passugg-Araschgen",
+    "zipCode": "7062",
+    "canton": "GR"
+  },
+  {
+    "id": "2353|Patalour|JU",
+    "name": "Patalour",
+    "zipCode": "2353",
+    "canton": "JU"
+  },
+  {
+    "id": "7433|Patzen|GR",
+    "name": "Patzen",
+    "zipCode": "7433",
+    "canton": "GR"
+  },
+  {
+    "id": "1094|Paudex|VD",
+    "name": "Paudex",
+    "zipCode": "1094",
+    "canton": "VD"
+  },
+  {
+    "id": "6582|Paudo|TI",
+    "name": "Paudo",
+    "zipCode": "6582",
+    "canton": "TI"
+  },
+  {
+    "id": "1530|Payerne|VD",
+    "name": "Payerne",
+    "zipCode": "1530",
+    "canton": "VD"
+  },
+  {
+    "id": "6912|Pazzallo|TI",
+    "name": "Pazzallo",
+    "zipCode": "6912",
+    "canton": "TI"
+  },
+  {
+    "id": "6695|Peccia|TI",
+    "name": "Peccia",
+    "zipCode": "6695",
+    "canton": "TI"
+  },
+  {
+    "id": "6513|Pedemonte|TI",
+    "name": "Pedemonte",
+    "zipCode": "6513",
+    "canton": "TI"
+  },
+  {
+    "id": "6512|Pedevilla|TI",
+    "name": "Pedevilla",
+    "zipCode": "6512",
+    "canton": "TI"
+  },
+  {
+    "id": "6832|Pedrinate|TI",
+    "name": "Pedrinate",
+    "zipCode": "6832",
+    "canton": "TI"
+  },
+  {
+    "id": "7110|Peiden|GR",
+    "name": "Peiden",
+    "zipCode": "7110",
+    "canton": "GR"
+  },
+  {
+    "id": "7112|Peiden Bas|GR",
+    "name": "Peiden Bas",
+    "zipCode": "7112",
+    "canton": "GR"
+  },
+  {
+    "id": "7112|Peiden Dorf|GR",
+    "name": "Peiden Dorf",
+    "zipCode": "7112",
+    "canton": "GR"
+  },
+  {
+    "id": "1242|Peissy|GE",
+    "name": "Peissy",
+    "zipCode": "1242",
+    "canton": "GE"
+  },
+  {
+    "id": "7029|Peist|GR",
+    "name": "Peist",
+    "zipCode": "7029",
+    "canton": "GR"
+  },
+  {
+    "id": "1242|Peney|GE",
+    "name": "Peney",
+    "zipCode": "1242",
+    "canton": "GE"
+  },
+  {
+    "id": "1445|Peney (Vuiteboeuf)|VD",
+    "name": "Peney (Vuiteboeuf)",
+    "zipCode": "1445",
+    "canton": "VD"
+  },
+  {
+    "id": "1059|Peney-le-Jorat|VD",
+    "name": "Peney-le-Jorat",
+    "zipCode": "1059",
+    "canton": "VD"
+  },
+  {
+    "id": "1783|Pensier|FR",
+    "name": "Pensier",
+    "zipCode": "1783",
+    "canton": "FR"
+  },
+  {
+    "id": "1305|Penthalaz|VD",
+    "name": "Penthalaz",
+    "zipCode": "1305",
+    "canton": "VD"
+  },
+  {
+    "id": "1303|Penthaz|VD",
+    "name": "Penthaz",
+    "zipCode": "1303",
+    "canton": "VD"
+  },
+  {
+    "id": "1375|Penthéréaz|VD",
+    "name": "Penthéréaz",
+    "zipCode": "1375",
+    "canton": "VD"
+  },
+  {
+    "id": "6035|Perlen|LU",
+    "name": "Perlen",
+    "zipCode": "6035",
+    "canton": "LU"
+  },
+  {
+    "id": "1258|Perly|GE",
+    "name": "Perly",
+    "zipCode": "1258",
+    "canton": "GE"
+  },
+  {
+    "id": "2742|Perrefitte|BE",
+    "name": "Perrefitte",
+    "zipCode": "2742",
+    "canton": "BE"
+  },
+  {
+    "id": "2017|Perreux|NE",
+    "name": "Perreux",
+    "zipCode": "2017",
+    "canton": "NE"
+  },
+  {
+    "id": "1166|Perroy|VD",
+    "name": "Perroy",
+    "zipCode": "1166",
+    "canton": "VD"
+  },
+  {
+    "id": "6744|Personico|TI",
+    "name": "Personico",
+    "zipCode": "6744",
+    "canton": "TI"
+  },
+  {
+    "id": "2603|Péry|BE",
+    "name": "Péry",
+    "zipCode": "2603",
+    "canton": "BE"
+  },
+  {
+    "id": "2034|Peseux|NE",
+    "name": "Peseux",
+    "zipCode": "2034",
+    "canton": "NE"
+  },
+  {
+    "id": "1052|Petit Mont|VD",
+    "name": "Petit Mont",
+    "zipCode": "1052",
+    "canton": "VD"
+  },
+  {
+    "id": "1945|Petit Vichères|VS",
+    "name": "Petit Vichères",
+    "zipCode": "1945",
+    "canton": "VS"
+  },
+  {
+    "id": "2740|Petit-Champoz|BE",
+    "name": "Petit-Champoz",
+    "zipCode": "2740",
+    "canton": "BE"
+  },
+  {
+    "id": "1213|Petit-Lancy|GE",
+    "name": "Petit-Lancy",
+    "zipCode": "1213",
+    "canton": "GE"
+  },
+  {
+    "id": "2316|Petit-Martel|NE",
+    "name": "Petit-Martel",
+    "zipCode": "2316",
+    "canton": "NE"
+  },
+  {
+    "id": "2065|Petit-Savagnier|NE",
+    "name": "Petit-Savagnier",
+    "zipCode": "2065",
+    "canton": "NE"
+  },
+  {
+    "id": "1063|Peyres-Possens|VD",
+    "name": "Peyres-Possens",
+    "zipCode": "1063",
+    "canton": "VD"
+  },
+  {
+    "id": "7312|Pfäfers|SG",
+    "name": "Pfäfers",
+    "zipCode": "7312",
+    "canton": "SG"
+  },
+  {
+    "id": "7310|Pfäfers Bad|SG",
+    "name": "Pfäfers Bad",
+    "zipCode": "7310",
+    "canton": "SG"
+  },
+  {
+    "id": "3184|Pfaffenholz|FR",
+    "name": "Pfaffenholz",
+    "zipCode": "3184",
+    "canton": "FR"
+  },
+  {
+    "id": "8118|Pfaffhausen|ZH",
+    "name": "Pfaffhausen",
+    "zipCode": "8118",
+    "canton": "ZH"
+  },
+  {
+    "id": "8330|Pfäffikon|ZH",
+    "name": "Pfäffikon",
+    "zipCode": "8330",
+    "canton": "ZH"
+  },
+  {
+    "id": "8808|Pfäffikon|SZ",
+    "name": "Pfäffikon",
+    "zipCode": "8808",
+    "canton": "SZ"
+  },
+  {
+    "id": "6264|Pfaffnau|LU",
+    "name": "Pfaffnau",
+    "zipCode": "6264",
+    "canton": "LU"
+  },
+  {
+    "id": "6034|Pfaffwil|LU",
+    "name": "Pfaffwil",
+    "zipCode": "6034",
+    "canton": "LU"
+  },
+  {
+    "id": "5735|Pfeffikon|LU",
+    "name": "Pfeffikon",
+    "zipCode": "5735",
+    "canton": "LU"
+  },
+  {
+    "id": "4148|Pfeffingen|BL",
+    "name": "Pfeffingen",
+    "zipCode": "4148",
+    "canton": "BL"
+  },
+  {
+    "id": "8422|Pfungen|ZH",
+    "name": "Pfungen",
+    "zipCode": "8422",
+    "canton": "ZH"
+  },
+  {
+    "id": "8505|Pfyn|TG",
+    "name": "Pfyn",
+    "zipCode": "8505",
+    "canton": "TG"
+  },
+  {
+    "id": "6563|Pian San Giacomo|GR",
+    "name": "Pian San Giacomo",
+    "zipCode": "6563",
+    "canton": "GR"
+  },
+  {
+    "id": "6959|Piandera Paese|TI",
+    "name": "Piandera Paese",
+    "zipCode": "6959",
+    "canton": "TI"
+  },
+  {
+    "id": "6582|Pianezzo|TI",
+    "name": "Pianezzo",
+    "zipCode": "6582",
+    "canton": "TI"
+  },
+  {
+    "id": "6557|Piani di Verbabbio|GR",
+    "name": "Piani di Verbabbio",
+    "zipCode": "6557",
+    "canton": "GR"
+  },
+  {
+    "id": "6684|Piano di Campo|TI",
+    "name": "Piano di Campo",
+    "zipCode": "6684",
+    "canton": "TI"
+  },
+  {
+    "id": "6695|Piano di Peccia|TI",
+    "name": "Piano di Peccia",
+    "zipCode": "6695",
+    "canton": "TI"
+  },
+  {
+    "id": "6579|Piazzogna|TI",
+    "name": "Piazzogna",
+    "zipCode": "6579",
+    "canton": "TI"
+  },
+  {
+    "id": "1723|Pierrafortscha|FR",
+    "name": "Pierrafortscha",
+    "zipCode": "1723",
+    "canton": "FR"
+  },
+  {
+    "id": "2608|Pierrefeu|BE",
+    "name": "Pierrefeu",
+    "zipCode": "2608",
+    "canton": "BE"
+  },
+  {
+    "id": "2542|Pieterlen|BE",
+    "name": "Pieterlen",
+    "zipCode": "2542",
+    "canton": "BE"
+  },
+  {
+    "id": "7443|Pignia|GR",
+    "name": "Pignia",
+    "zipCode": "7443",
+    "canton": "GR"
+  },
+  {
+    "id": "7156|Pigniu|GR",
+    "name": "Pigniu",
+    "zipCode": "7156",
+    "canton": "GR"
+  },
+  {
+    "id": "1348|Piguet-Dessous|VD",
+    "name": "Piguet-Dessous",
+    "zipCode": "1348",
+    "canton": "VD"
+  },
+  {
+    "id": "1348|Piguet-Dessus|VD",
+    "name": "Piguet-Dessus",
+    "zipCode": "1348",
+    "canton": "VD"
+  },
+  {
+    "id": "6010|Pilatus Kulm|OW",
+    "name": "Pilatus Kulm",
+    "zipCode": "6010",
+    "canton": "OW"
+  },
+  {
+    "id": "1234|Pinchat|GE",
+    "name": "Pinchat",
+    "zipCode": "1234",
+    "canton": "GE"
+  },
+  {
+    "id": "3961|Pinsec|VS",
+    "name": "Pinsec",
+    "zipCode": "3961",
+    "canton": "VS"
+  },
+  {
+    "id": "6614|Piodina|TI",
+    "name": "Piodina",
+    "zipCode": "6614",
+    "canton": "TI"
+  },
+  {
+    "id": "6776|Piora|TI",
+    "name": "Piora",
+    "zipCode": "6776",
+    "canton": "TI"
+  },
+  {
+    "id": "6776|Piotta|TI",
+    "name": "Piotta",
+    "zipCode": "6776",
+    "canton": "TI"
+  },
+  {
+    "id": "7111|Pitasch|GR",
+    "name": "Pitasch",
+    "zipCode": "7111",
+    "canton": "GR"
+  },
+  {
+    "id": "7323|Pizol|SG",
+    "name": "Pizol",
+    "zipCode": "7323",
+    "canton": "SG"
+  },
+  {
+    "id": "1174|Pizy|VD",
+    "name": "Pizy",
+    "zipCode": "1174",
+    "canton": "VD"
+  },
+  {
+    "id": "6833|Pizzamiglio|TI",
+    "name": "Pizzamiglio",
+    "zipCode": "6833",
+    "canton": "TI"
+  },
+  {
+    "id": "1716|Plaffeien|FR",
+    "name": "Plaffeien",
+    "zipCode": "1716",
+    "canton": "FR"
+  },
+  {
+    "id": "2536|Plagne|BE",
+    "name": "Plagne",
+    "zipCode": "2536",
+    "canton": "BE"
+  },
+  {
+    "id": "1200|Plainpalais|GE",
+    "name": "Plainpalais",
+    "zipCode": "1200",
+    "canton": "GE"
+  },
+  {
+    "id": "2314|Plamboz|NE",
+    "name": "Plamboz",
+    "zipCode": "2314",
+    "canton": "NE"
+  },
+  {
+    "id": "1867|Plambuit|VD",
+    "name": "Plambuit",
+    "zipCode": "1867",
+    "canton": "VD"
+  },
+  {
+    "id": "1964|Plan Conthey|VS",
+    "name": "Plan Conthey",
+    "zipCode": "1964",
+    "canton": "VS"
+  },
+  {
+    "id": "1228|Plan-les-Ouates|GE",
+    "name": "Plan-les-Ouates",
+    "zipCode": "1228",
+    "canton": "GE"
+  },
+  {
+    "id": "3855|Planalp|BE",
+    "name": "Planalp",
+    "zipCode": "3855",
+    "canton": "BE"
+  },
+  {
+    "id": "2108|Plancemont|NE",
+    "name": "Plancemont",
+    "zipCode": "2108",
+    "canton": "NE"
+  },
+  {
+    "id": "1815|Planchamp|VD",
+    "name": "Planchamp",
+    "zipCode": "1815",
+    "canton": "VD"
+  },
+  {
+    "id": "1737|Plasselb|FR",
+    "name": "Plasselb",
+    "zipCode": "1737",
+    "canton": "FR"
+  },
+  {
+    "id": "7134|Platenga|GR",
+    "name": "Platenga",
+    "zipCode": "7134",
+    "canton": "GR"
+  },
+  {
+    "id": "7185|Platta|GR",
+    "name": "Platta",
+    "zipCode": "7185",
+    "canton": "GR"
+  },
+  {
+    "id": "9428|Platz|AR",
+    "name": "Platz",
+    "zipCode": "9428",
+    "canton": "AR"
+  },
+  {
+    "id": "7517|Plaun da Lej|GR",
+    "name": "Plaun da Lej",
+    "zipCode": "7517",
+    "canton": "GR"
+  },
+  {
+    "id": "2807|Pleigne|JU",
+    "name": "Pleigne",
+    "zipCode": "2807",
+    "canton": "JU"
+  },
+  {
+    "id": "3951|Pletschen|VS",
+    "name": "Pletschen",
+    "zipCode": "3951",
+    "canton": "VS"
+  },
+  {
+    "id": "2953|Pleujouse|JU",
+    "name": "Pleujouse",
+    "zipCode": "2953",
+    "canton": "JU"
+  },
+  {
+    "id": "8889|Plons|SG",
+    "name": "Plons",
+    "zipCode": "8889",
+    "canton": "SG"
+  },
+  {
+    "id": "3638|Pohlern|BE",
+    "name": "Pohlern",
+    "zipCode": "3638",
+    "canton": "BE"
+  },
+  {
+    "id": "6827|Poiana|TI",
+    "name": "Poiana",
+    "zipCode": "6827",
+    "canton": "TI"
+  },
+  {
+    "id": "1041|Poliez-le-Grand|VD",
+    "name": "Poliez-le-Grand",
+    "zipCode": "1041",
+    "canton": "VD"
+  },
+  {
+    "id": "1041|Poliez-Pittet|VD",
+    "name": "Poliez-Pittet",
+    "zipCode": "1041",
+    "canton": "VD"
+  },
+  {
+    "id": "6742|Pollegio|TI",
+    "name": "Pollegio",
+    "zipCode": "6742",
+    "canton": "TI"
+  },
+  {
+    "id": "1976|Pomeyron|VS",
+    "name": "Pomeyron",
+    "zipCode": "1976",
+    "canton": "VS"
+  },
+  {
+    "id": "1318|Pompaples|VD",
+    "name": "Pompaples",
+    "zipCode": "1318",
+    "canton": "VD"
+  },
+  {
+    "id": "1405|Pomy|VD",
+    "name": "Pomy",
+    "zipCode": "1405",
+    "canton": "VD"
+  },
+  {
+    "id": "1699|Pont (Veveyse)|FR",
+    "name": "Pont (Veveyse)",
+    "zipCode": "1699",
+    "canton": "FR"
+  },
+  {
+    "id": "1962|Pont-de-la-Morge|VS",
+    "name": "Pont-de-la-Morge",
+    "zipCode": "1962",
+    "canton": "VS"
+  },
+  {
+    "id": "1863|Pont-de-la-Tine|VD",
+    "name": "Pont-de-la-Tine",
+    "zipCode": "1863",
+    "canton": "VD"
+  },
+  {
+    "id": "1649|Pont-la-Ville|FR",
+    "name": "Pont-la-Ville",
+    "zipCode": "1649",
+    "canton": "FR"
+  },
+  {
+    "id": "6652|Ponte Brolla|TI",
+    "name": "Ponte Brolla",
+    "zipCode": "6652",
+    "canton": "TI"
+  },
+  {
+    "id": "6946|Ponte Capriasca|TI",
+    "name": "Ponte Capriasca",
+    "zipCode": "6946",
+    "canton": "TI"
+  },
+  {
+    "id": "6996|Ponte Cremenaga|TI",
+    "name": "Ponte Cremenaga",
+    "zipCode": "6996",
+    "canton": "TI"
+  },
+  {
+    "id": "6988|Ponte Tresa|TI",
+    "name": "Ponte Tresa",
+    "zipCode": "6988",
+    "canton": "TI"
+  },
+  {
+    "id": "2733|Pontenet|BE",
+    "name": "Pontenet",
+    "zipCode": "2733",
+    "canton": "BE"
+  },
+  {
+    "id": "1772|Ponthaux|FR",
+    "name": "Ponthaux",
+    "zipCode": "1772",
+    "canton": "FR"
+  },
+  {
+    "id": "6713|Pontirone|TI",
+    "name": "Pontirone",
+    "zipCode": "6713",
+    "canton": "TI"
+  },
+  {
+    "id": "6724|Ponto Valentino|TI",
+    "name": "Ponto Valentino",
+    "zipCode": "6724",
+    "canton": "TI"
+  },
+  {
+    "id": "7504|Pontresina|GR",
+    "name": "Pontresina",
+    "zipCode": "7504",
+    "canton": "GR"
+  },
+  {
+    "id": "2900|Porrentruy|JU",
+    "name": "Porrentruy",
+    "zipCode": "2900",
+    "canton": "JU"
+  },
+  {
+    "id": "1699|Porsel|FR",
+    "name": "Porsel",
+    "zipCode": "1699",
+    "canton": "FR"
+  },
+  {
+    "id": "2562|Port|BE",
+    "name": "Port",
+    "zipCode": "2562",
+    "canton": "BE"
+  },
+  {
+    "id": "1897|Port-Valais|VS",
+    "name": "Port-Valais",
+    "zipCode": "1897",
+    "canton": "VS"
+  },
+  {
+    "id": "1568|Portalban|FR",
+    "name": "Portalban",
+    "zipCode": "1568",
+    "canton": "FR"
+  },
+  {
+    "id": "7423|Portein|GR",
+    "name": "Portein",
+    "zipCode": "7423",
+    "canton": "GR"
+  },
+  {
+    "id": "8895|Portels|SG",
+    "name": "Portels",
+    "zipCode": "8895",
+    "canton": "SG"
+  },
+  {
+    "id": "6613|Porto Ronco|TI",
+    "name": "Porto Ronco",
+    "zipCode": "6613",
+    "canton": "TI"
+  },
+  {
+    "id": "6948|Porza|TI",
+    "name": "Porza",
+    "zipCode": "6948",
+    "canton": "TI"
+  },
+  {
+    "id": "1726|Posat|FR",
+    "name": "Posat",
+    "zipCode": "1726",
+    "canton": "FR"
+  },
+  {
+    "id": "3775|Pöschenried|BE",
+    "name": "Pöschenried",
+    "zipCode": "3775",
+    "canton": "BE"
+  },
+  {
+    "id": "7742|Poschiavo|GR",
+    "name": "Poschiavo",
+    "zipCode": "7742",
+    "canton": "GR"
+  },
+  {
+    "id": "1725|Posieux|FR",
+    "name": "Posieux",
+    "zipCode": "1725",
+    "canton": "FR"
+  },
+  {
+    "id": "7745|Prada|GR",
+    "name": "Prada",
+    "zipCode": "7745",
+    "canton": "GR"
+  },
+  {
+    "id": "7063|Praden|GR",
+    "name": "Praden",
+    "zipCode": "7063",
+    "canton": "GR"
+  },
+  {
+    "id": "7231|Pragg-Jenaz|GR",
+    "name": "Pragg-Jenaz",
+    "zipCode": "7231",
+    "canton": "GR"
+  },
+  {
+    "id": "1408|Prahins|VD",
+    "name": "Prahins",
+    "zipCode": "1408",
+    "canton": "VD"
+  },
+  {
+    "id": "1987|Pralong|VS",
+    "name": "Pralong",
+    "zipCode": "1987",
+    "canton": "VS"
+  },
+  {
+    "id": "3979|Pramagnon|VS",
+    "name": "Pramagnon",
+    "zipCode": "3979",
+    "canton": "VS"
+  },
+  {
+    "id": "1197|Prangins|VD",
+    "name": "Prangins",
+    "zipCode": "1197",
+    "canton": "VD"
+  },
+  {
+    "id": "1528|Praratoud|FR",
+    "name": "Praratoud",
+    "zipCode": "1528",
+    "canton": "FR"
+  },
+  {
+    "id": "1724|Praroman|FR",
+    "name": "Praroman",
+    "zipCode": "1724",
+    "canton": "FR"
+  },
+  {
+    "id": "1947|Prarreyer|VS",
+    "name": "Prarreyer",
+    "zipCode": "1947",
+    "canton": "VS"
+  },
+  {
+    "id": "1937|Prassurny|VS",
+    "name": "Prassurny",
+    "zipCode": "1937",
+    "canton": "VS"
+  },
+  {
+    "id": "6694|Prato|TI",
+    "name": "Prato",
+    "zipCode": "6694",
+    "canton": "TI"
+  },
+  {
+    "id": "6773|Prato (Leventina)|TI",
+    "name": "Prato (Leventina)",
+    "zipCode": "6773",
+    "canton": "TI"
+  },
+  {
+    "id": "4133|Pratteln|BL",
+    "name": "Pratteln",
+    "zipCode": "4133",
+    "canton": "BL"
+  },
+  {
+    "id": "7415|Pratval|GR",
+    "name": "Pratval",
+    "zipCode": "7415",
+    "canton": "GR"
+  },
+  {
+    "id": "1991|Pravidondaz|VS",
+    "name": "Pravidondaz",
+    "zipCode": "1991",
+    "canton": "VS"
+  },
+  {
+    "id": "1944|Prayon|VS",
+    "name": "Prayon",
+    "zipCode": "1944",
+    "canton": "VS"
+  },
+  {
+    "id": "1618|Prayoud|FR",
+    "name": "Prayoud",
+    "zipCode": "1618",
+    "canton": "FR"
+  },
+  {
+    "id": "7424|Präz|GR",
+    "name": "Präz",
+    "zipCode": "7424",
+    "canton": "GR"
+  },
+  {
+    "id": "1788|Praz (Vully)|FR",
+    "name": "Praz (Vully)",
+    "zipCode": "1788",
+    "canton": "FR"
+  },
+  {
+    "id": "1943|Praz-de-Fort|VS",
+    "name": "Praz-de-Fort",
+    "zipCode": "1943",
+    "canton": "VS"
+  },
+  {
+    "id": "1982|Praz-Jean|VS",
+    "name": "Praz-Jean",
+    "zipCode": "1982",
+    "canton": "VS"
+  },
+  {
+    "id": "7482|Preda|GR",
+    "name": "Preda",
+    "zipCode": "7482",
+    "canton": "GR"
+  },
+  {
+    "id": "2074|Préfargier|NE",
+    "name": "Préfargier",
+    "zipCode": "2074",
+    "canton": "NE"
+  },
+  {
+    "id": "6963|Pregassona|TI",
+    "name": "Pregassona",
+    "zipCode": "6963",
+    "canton": "TI"
+  },
+  {
+    "id": "1292|Pregny|GE",
+    "name": "Pregny",
+    "zipCode": "1292",
+    "canton": "GE"
+  },
+  {
+    "id": "2515|Prêles|BE",
+    "name": "Prêles",
+    "zipCode": "2515",
+    "canton": "BE"
+  },
+  {
+    "id": "1324|Premier|VD",
+    "name": "Premier",
+    "zipCode": "1324",
+    "canton": "VD"
+  },
+  {
+    "id": "1976|Premploz|VS",
+    "name": "Premploz",
+    "zipCode": "1976",
+    "canton": "VS"
+  },
+  {
+    "id": "6523|Preonzo|TI",
+    "name": "Preonzo",
+    "zipCode": "6523",
+    "canton": "TI"
+  },
+  {
+    "id": "2608|Prés-de-Cortébert|BE",
+    "name": "Prés-de-Cortébert",
+    "zipCode": "2608",
+    "canton": "BE"
+  },
+  {
+    "id": "1243|Presinge|GE",
+    "name": "Presinge",
+    "zipCode": "1243",
+    "canton": "GE"
+  },
+  {
+    "id": "1253|Pressy|GE",
+    "name": "Pressy",
+    "zipCode": "1253",
+    "canton": "GE"
+  },
+  {
+    "id": "1028|Préverenges|VD",
+    "name": "Préverenges",
+    "zipCode": "1028",
+    "canton": "VD"
+  },
+  {
+    "id": "1410|Prévondavaux|FR",
+    "name": "Prévondavaux",
+    "zipCode": "1410",
+    "canton": "FR"
+  },
+  {
+    "id": "1682|Prévonloup|VD",
+    "name": "Prévonloup",
+    "zipCode": "1682",
+    "canton": "VD"
+  },
+  {
+    "id": "1746|Prez-vers-Noréaz|FR",
+    "name": "Prez-vers-Noréaz",
+    "zipCode": "1746",
+    "canton": "FR"
+  },
+  {
+    "id": "1677|Prez-vers-Siviriez|FR",
+    "name": "Prez-vers-Siviriez",
+    "zipCode": "1677",
+    "canton": "FR"
+  },
+  {
+    "id": "1008|Prilly|VD",
+    "name": "Prilly",
+    "zipCode": "1008",
+    "canton": "VD"
+  },
+  {
+    "id": "6760|Primadengo|TI",
+    "name": "Primadengo",
+    "zipCode": "6760",
+    "canton": "TI"
+  },
+  {
+    "id": "1663|Pringy|FR",
+    "name": "Pringy",
+    "zipCode": "1663",
+    "canton": "FR"
+  },
+  {
+    "id": "7741|Privilasco|GR",
+    "name": "Privilasco",
+    "zipCode": "7741",
+    "canton": "GR"
+  },
+  {
+    "id": "1912|Produit|VS",
+    "name": "Produit",
+    "zipCode": "1912",
+    "canton": "VS"
+  },
+  {
+    "id": "1624|Progens|FR",
+    "name": "Progens",
+    "zipCode": "1624",
+    "canton": "FR"
+  },
+  {
+    "id": "6515|Progero|TI",
+    "name": "Progero",
+    "zipCode": "6515",
+    "canton": "TI"
+  },
+  {
+    "id": "1987|Prolin|VS",
+    "name": "Prolin",
+    "zipCode": "1987",
+    "canton": "VS"
+  },
+  {
+    "id": "1673|Promasens|FR",
+    "name": "Promasens",
+    "zipCode": "1673",
+    "canton": "FR"
+  },
+  {
+    "id": "7440|Promischur|GR",
+    "name": "Promischur",
+    "zipCode": "7440",
+    "canton": "GR"
+  },
+  {
+    "id": "7606|Promontogno|GR",
+    "name": "Promontogno",
+    "zipCode": "7606",
+    "canton": "GR"
+  },
+  {
+    "id": "6526|Prosito|TI",
+    "name": "Prosito",
+    "zipCode": "6526",
+    "canton": "TI"
+  },
+  {
+    "id": "1428|Provence|VD",
+    "name": "Provence",
+    "zipCode": "1428",
+    "canton": "VD"
+  },
+  {
+    "id": "6723|Prugiasco|TI",
+    "name": "Prugiasco",
+    "zipCode": "6723",
+    "canton": "TI"
+  },
+  {
+    "id": "6823|Pugerna|TI",
+    "name": "Pugerna",
+    "zipCode": "6823",
+    "canton": "TI"
+  },
+  {
+    "id": "1070|Puidoux|VD",
+    "name": "Puidoux",
+    "zipCode": "1070",
+    "canton": "VD"
+  },
+  {
+    "id": "1070|Puidoux-Gare|VD",
+    "name": "Puidoux-Gare",
+    "zipCode": "1070",
+    "canton": "VD"
+  },
+  {
+    "id": "1009|Pully|VD",
+    "name": "Pully",
+    "zipCode": "1009",
+    "canton": "VD"
+  },
+  {
+    "id": "7503|Punt Muragl|GR",
+    "name": "Punt Muragl",
+    "zipCode": "7503",
+    "canton": "GR"
+  },
+  {
+    "id": "1241|Puplinge|GE",
+    "name": "Puplinge",
+    "zipCode": "1241",
+    "canton": "GE"
+  },
+  {
+    "id": "6984|Pura|TI",
+    "name": "Pura",
+    "zipCode": "6984",
+    "canton": "TI"
+  },
+  {
+    "id": "6989|Purasca|TI",
+    "name": "Purasca",
+    "zipCode": "6989",
+    "canton": "TI"
+  },
+  {
+    "id": "7447|Pürt|GR",
+    "name": "Pürt",
+    "zipCode": "7447",
+    "canton": "GR"
+  },
+  {
+    "id": "7228|Pusserein|GR",
+    "name": "Pusserein",
+    "zipCode": "7228",
+    "canton": "GR"
+  },
+  {
+    "id": "7224|Putz|GR",
+    "name": "Putz",
+    "zipCode": "7224",
+    "canton": "GR"
+  },
+  {
+    "id": "8883|Quarten|SG",
+    "name": "Quarten",
+    "zipCode": "8883",
+    "canton": "SG"
+  },
+  {
+    "id": "6572|Quartino|TI",
+    "name": "Quartino",
+    "zipCode": "6572",
+    "canton": "TI"
+  },
+  {
+    "id": "8878|Quinten|SG",
+    "name": "Quinten",
+    "zipCode": "8878",
+    "canton": "SG"
+  },
+  {
+    "id": "6777|Quinto|TI",
+    "name": "Quinto",
+    "zipCode": "6777",
+    "canton": "TI"
+  },
+  {
+    "id": "8498|Raad|ZH",
+    "name": "Raad",
+    "zipCode": "8498",
+    "canton": "ZH"
+  },
+  {
+    "id": "8175|Raat bei Windlach|ZH",
+    "name": "Raat bei Windlach",
+    "zipCode": "8175",
+    "canton": "ZH"
+  },
+  {
+    "id": "7172|Rabius|GR",
+    "name": "Rabius",
+    "zipCode": "7172",
+    "canton": "GR"
+  },
+  {
+    "id": "3271|Radelfingen bei Aarberg|BE",
+    "name": "Radelfingen bei Aarberg",
+    "zipCode": "3271",
+    "canton": "BE"
+  },
+  {
+    "id": "9470|Räfis|SG",
+    "name": "Räfis",
+    "zipCode": "9470",
+    "canton": "SG"
+  },
+  {
+    "id": "8197|Rafz|ZH",
+    "name": "Rafz",
+    "zipCode": "8197",
+    "canton": "ZH"
+  },
+  {
+    "id": "6026|Rain|LU",
+    "name": "Rain",
+    "zipCode": "6026",
+    "canton": "LU"
+  },
+  {
+    "id": "6060|Ramersberg|OW",
+    "name": "Ramersberg",
+    "zipCode": "6060",
+    "canton": "OW"
+  },
+  {
+    "id": "8487|Rämismühle|ZH",
+    "name": "Rämismühle",
+    "zipCode": "8487",
+    "canton": "ZH"
+  },
+  {
+    "id": "4719|Ramiswil|SO",
+    "name": "Ramiswil",
+    "zipCode": "4719",
+    "canton": "SO"
+  },
+  {
+    "id": "4433|Ramlinsburg|BL",
+    "name": "Ramlinsburg",
+    "zipCode": "4433",
+    "canton": "BL"
+  },
+  {
+    "id": "7556|Ramosch|GR",
+    "name": "Ramosch",
+    "zipCode": "7556",
+    "canton": "GR"
+  },
+  {
+    "id": "4448|Ramsach Bad|BL",
+    "name": "Ramsach Bad",
+    "zipCode": "4448",
+    "canton": "BL"
+  },
+  {
+    "id": "8488|Ramsberg|ZH",
+    "name": "Ramsberg",
+    "zipCode": "8488",
+    "canton": "ZH"
+  },
+  {
+    "id": "3435|Ramsei|BE",
+    "name": "Ramsei",
+    "zipCode": "3435",
+    "canton": "BE"
+  },
+  {
+    "id": "8262|Ramsen|SH",
+    "name": "Ramsen",
+    "zipCode": "8262",
+    "canton": "SH"
+  },
+  {
+    "id": "3421|Ramsi bei Lyssach|BE",
+    "name": "Ramsi bei Lyssach",
+    "zipCode": "3421",
+    "canton": "BE"
+  },
+  {
+    "id": "6862|Rancate|TI",
+    "name": "Rancate",
+    "zipCode": "6862",
+    "canton": "TI"
+  },
+  {
+    "id": "1439|Rances|VD",
+    "name": "Rances",
+    "zipCode": "1439",
+    "canton": "VD"
+  },
+  {
+    "id": "3928|Randa|VS",
+    "name": "Randa",
+    "zipCode": "3928",
+    "canton": "VS"
+  },
+  {
+    "id": "3975|Randogne|VS",
+    "name": "Randogne",
+    "zipCode": "3975",
+    "canton": "VS"
+  },
+  {
+    "id": "3439|Ranflüh|BE",
+    "name": "Ranflüh",
+    "zipCode": "3439",
+    "canton": "BE"
+  },
+  {
+    "id": "9475|Rans|SG",
+    "name": "Rans",
+    "zipCode": "9475",
+    "canton": "SG"
+  },
+  {
+    "id": "6577|Ranzo|TI",
+    "name": "Ranzo",
+    "zipCode": "6577",
+    "canton": "TI"
+  },
+  {
+    "id": "8558|Raperswilen|TG",
+    "name": "Raperswilen",
+    "zipCode": "8558",
+    "canton": "TG"
+  },
+  {
+    "id": "3255|Rapperswil|BE",
+    "name": "Rapperswil",
+    "zipCode": "3255",
+    "canton": "BE"
+  },
+  {
+    "id": "8640|Rapperswil|SG",
+    "name": "Rapperswil",
+    "zipCode": "8640",
+    "canton": "SG"
+  },
+  {
+    "id": "3942|Raron|VS",
+    "name": "Raron",
+    "zipCode": "3942",
+    "canton": "VS"
+  },
+  {
+    "id": "6655|Rasa|TI",
+    "name": "Rasa",
+    "zipCode": "6655",
+    "canton": "TI"
+  },
+  {
+    "id": "8352|Räterschen|ZH",
+    "name": "Räterschen",
+    "zipCode": "8352",
+    "canton": "ZH"
+  },
+  {
+    "id": "6032|Rathausen|LU",
+    "name": "Rathausen",
+    "zipCode": "6032",
+    "canton": "LU"
+  },
+  {
+    "id": "8580|Räuchlisberg|TG",
+    "name": "Räuchlisberg",
+    "zipCode": "8580",
+    "canton": "TG"
+  },
+  {
+    "id": "6500|Ravecchia|TI",
+    "name": "Ravecchia",
+    "zipCode": "6500",
+    "canton": "TI"
+  },
+  {
+    "id": "1928|Ravoire|VS",
+    "name": "Ravoire",
+    "zipCode": "1928",
+    "canton": "VS"
+  },
+  {
+    "id": "6491|Realp|UR",
+    "name": "Realp",
+    "zipCode": "6491",
+    "canton": "UR"
+  },
+  {
+    "id": "7408|Realta|GR",
+    "name": "Realta",
+    "zipCode": "7408",
+    "canton": "GR"
+  },
+  {
+    "id": "2832|Rebeuvelier|JU",
+    "name": "Rebeuvelier",
+    "zipCode": "2832",
+    "canton": "JU"
+  },
+  {
+    "id": "2717|Rebévelier|BE",
+    "name": "Rebévelier",
+    "zipCode": "2717",
+    "canton": "BE"
+  },
+  {
+    "id": "9445|Rebstein|SG",
+    "name": "Rebstein",
+    "zipCode": "9445",
+    "canton": "SG"
+  },
+  {
+    "id": "4565|Recherswil|SO",
+    "name": "Recherswil",
+    "zipCode": "4565",
+    "canton": "SO"
+  },
+  {
+    "id": "1718|Rechthalten|FR",
+    "name": "Rechthalten",
+    "zipCode": "1718",
+    "canton": "FR"
+  },
+  {
+    "id": "3966|Réchy|VS",
+    "name": "Réchy",
+    "zipCode": "3966",
+    "canton": "VS"
+  },
+  {
+    "id": "8508|Reckenwil|TG",
+    "name": "Reckenwil",
+    "zipCode": "8508",
+    "canton": "TG"
+  },
+  {
+    "id": "3998|Reckingen|VS",
+    "name": "Reckingen",
+    "zipCode": "3998",
+    "canton": "VS"
+  },
+  {
+    "id": "2912|Réclère|JU",
+    "name": "Réclère",
+    "zipCode": "2912",
+    "canton": "JU"
+  },
+  {
+    "id": "2824|Recolaine|JU",
+    "name": "Recolaine",
+    "zipCode": "2824",
+    "canton": "JU"
+  },
+  {
+    "id": "2732|Reconvilier|BE",
+    "name": "Reconvilier",
+    "zipCode": "2732",
+    "canton": "BE"
+  },
+  {
+    "id": "8158|Regensberg|ZH",
+    "name": "Regensberg",
+    "zipCode": "8158",
+    "canton": "ZH"
+  },
+  {
+    "id": "8105|Regensdorf|ZH",
+    "name": "Regensdorf",
+    "zipCode": "8105",
+    "canton": "ZH"
+  },
+  {
+    "id": "9038|Rehetobel|AR",
+    "name": "Rehetobel",
+    "zipCode": "9038",
+    "canton": "AR"
+  },
+  {
+    "id": "3294|Reiben|BE",
+    "name": "Reiben",
+    "zipCode": "3294",
+    "canton": "BE"
+  },
+  {
+    "id": "7015|Reichenau|GR",
+    "name": "Reichenau",
+    "zipCode": "7015",
+    "canton": "GR"
+  },
+  {
+    "id": "3713|Reichenbach im Kandertal|BE",
+    "name": "Reichenbach im Kandertal",
+    "zipCode": "3713",
+    "canton": "BE"
+  },
+  {
+    "id": "8864|Reichenburg|SZ",
+    "name": "Reichenburg",
+    "zipCode": "8864",
+    "canton": "SZ"
+  },
+  {
+    "id": "6260|Reiden|LU",
+    "name": "Reiden",
+    "zipCode": "6260",
+    "canton": "LU"
+  },
+  {
+    "id": "3766|Reidenbach|BE",
+    "name": "Reidenbach",
+    "zipCode": "3766",
+    "canton": "BE"
+  },
+  {
+    "id": "6260|Reidermoos|LU",
+    "name": "Reidermoos",
+    "zipCode": "6260",
+    "canton": "LU"
+  },
+  {
+    "id": "4418|Reigoldswil|BL",
+    "name": "Reigoldswil",
+    "zipCode": "4418",
+    "canton": "BL"
+  },
+  {
+    "id": "4153|Reinach|BL",
+    "name": "Reinach",
+    "zipCode": "4153",
+    "canton": "BL"
+  },
+  {
+    "id": "5734|Reinach|AG",
+    "name": "Reinach",
+    "zipCode": "5734",
+    "canton": "AG"
+  },
+  {
+    "id": "7432|Reischen|GR",
+    "name": "Reischen",
+    "zipCode": "7432",
+    "canton": "GR"
+  },
+  {
+    "id": "4919|Reisiswil|BE",
+    "name": "Reisiswil",
+    "zipCode": "4919",
+    "canton": "BE"
+  },
+  {
+    "id": "5057|Reitnau|AG",
+    "name": "Reitnau",
+    "zipCode": "5057",
+    "canton": "AG"
+  },
+  {
+    "id": "5332|Rekingen|AG",
+    "name": "Rekingen",
+    "zipCode": "5332",
+    "canton": "AG"
+  },
+  {
+    "id": "1617|Remaufens|FR",
+    "name": "Remaufens",
+    "zipCode": "1617",
+    "canton": "FR"
+  },
+  {
+    "id": "5453|Remetschwil|AG",
+    "name": "Remetschwil",
+    "zipCode": "5453",
+    "canton": "AG"
+  },
+  {
+    "id": "5236|Remigen|AG",
+    "name": "Remigen",
+    "zipCode": "5236",
+    "canton": "AG"
+  },
+  {
+    "id": "2616|Renan|BE",
+    "name": "Renan",
+    "zipCode": "2616",
+    "canton": "BE"
+  },
+  {
+    "id": "1020|Renens|VD",
+    "name": "Renens",
+    "zipCode": "1020",
+    "canton": "VD"
+  },
+  {
+    "id": "1024|Renges|VD",
+    "name": "Renges",
+    "zipCode": "1024",
+    "canton": "VD"
+  },
+  {
+    "id": "6162|Rengg|LU",
+    "name": "Rengg",
+    "zipCode": "6162",
+    "canton": "LU"
+  },
+  {
+    "id": "1847|Rennaz|VD",
+    "name": "Rennaz",
+    "zipCode": "1847",
+    "canton": "VD"
+  },
+  {
+    "id": "1937|Reppaz|VS",
+    "name": "Reppaz",
+    "zipCode": "1937",
+    "canton": "VS"
+  },
+  {
+    "id": "1543|Ressudens|VD",
+    "name": "Ressudens",
+    "zipCode": "1543",
+    "canton": "VD"
+  },
+  {
+    "id": "6285|Retschwil|LU",
+    "name": "Retschwil",
+    "zipCode": "6285",
+    "canton": "LU"
+  },
+  {
+    "id": "5703|Retterswil|AG",
+    "name": "Retterswil",
+    "zipCode": "5703",
+    "canton": "AG"
+  },
+  {
+    "id": "2603|Reuchenette|BE",
+    "name": "Reuchenette",
+    "zipCode": "2603",
+    "canton": "BE"
+  },
+  {
+    "id": "5324|Reuenthal|AG",
+    "name": "Reuenthal",
+    "zipCode": "5324",
+    "canton": "AG"
+  },
+  {
+    "id": "5412|Reuss|AG",
+    "name": "Reuss",
+    "zipCode": "5412",
+    "canton": "AG"
+  },
+  {
+    "id": "6015|Reussbühl|LU",
+    "name": "Reussbühl",
+    "zipCode": "6015",
+    "canton": "LU"
+  },
+  {
+    "id": "5643|Reussegg|AG",
+    "name": "Reussegg",
+    "zipCode": "5643",
+    "canton": "AG"
+  },
+  {
+    "id": "6014|Reussthal|LU",
+    "name": "Reussthal",
+    "zipCode": "6014",
+    "canton": "LU"
+  },
+  {
+    "id": "3623|Reust|BE",
+    "name": "Reust",
+    "zipCode": "3623",
+    "canton": "BE"
+  },
+  {
+    "id": "9411|Reute|AR",
+    "name": "Reute",
+    "zipCode": "9411",
+    "canton": "AR"
+  },
+  {
+    "id": "8507|Reutenen|TG",
+    "name": "Reutenen",
+    "zipCode": "8507",
+    "canton": "TG"
+  },
+  {
+    "id": "6086|Reuti|BE",
+    "name": "Reuti",
+    "zipCode": "6086",
+    "canton": "BE"
+  },
+  {
+    "id": "8500|Reuti|TG",
+    "name": "Reuti",
+    "zipCode": "8500",
+    "canton": "TG"
+  },
+  {
+    "id": "9517|Reuti bei Weinfelden|TG",
+    "name": "Reuti bei Weinfelden",
+    "zipCode": "9517",
+    "canton": "TG"
+  },
+  {
+    "id": "3647|Reutigen|BE",
+    "name": "Reutigen",
+    "zipCode": "3647",
+    "canton": "BE"
+  },
+  {
+    "id": "8404|Reutlingen|ZH",
+    "name": "Reutlingen",
+    "zipCode": "8404",
+    "canton": "ZH"
+  },
+  {
+    "id": "1899|Revereulaz|VS",
+    "name": "Revereulaz",
+    "zipCode": "1899",
+    "canton": "VS"
+  },
+  {
+    "id": "1128|Reverolle|VD",
+    "name": "Reverolle",
+    "zipCode": "1128",
+    "canton": "VD"
+  },
+  {
+    "id": "7403|Rhäzüns|GR",
+    "name": "Rhäzüns",
+    "zipCode": "7403",
+    "canton": "GR"
+  },
+  {
+    "id": "8462|Rheinau|ZH",
+    "name": "Rheinau",
+    "zipCode": "8462",
+    "canton": "ZH"
+  },
+  {
+    "id": "9424|Rheineck|SG",
+    "name": "Rheineck",
+    "zipCode": "9424",
+    "canton": "SG"
+  },
+  {
+    "id": "4310|Rheinfelden|AG",
+    "name": "Rheinfelden",
+    "zipCode": "4310",
+    "canton": "AG"
+  },
+  {
+    "id": "8259|Rheinklingen|TG",
+    "name": "Rheinklingen",
+    "zipCode": "8259",
+    "canton": "TG"
+  },
+  {
+    "id": "5084|Rheinsulz|AG",
+    "name": "Rheinsulz",
+    "zipCode": "5084",
+    "canton": "AG"
+  },
+  {
+    "id": "1632|Riaz|FR",
+    "name": "Riaz",
+    "zipCode": "1632",
+    "canton": "FR"
+  },
+  {
+    "id": "6595|Riazzino|TI",
+    "name": "Riazzino",
+    "zipCode": "6595",
+    "canton": "TI"
+  },
+  {
+    "id": "4313|Riburg|AG",
+    "name": "Riburg",
+    "zipCode": "4313",
+    "canton": "AG"
+  },
+  {
+    "id": "3763|Richenbach|BE",
+    "name": "Richenbach",
+    "zipCode": "3763",
+    "canton": "BE"
+  },
+  {
+    "id": "6285|Richensee|LU",
+    "name": "Richensee",
+    "zipCode": "6285",
+    "canton": "LU"
+  },
+  {
+    "id": "6263|Richenthal|LU",
+    "name": "Richenthal",
+    "zipCode": "6263",
+    "canton": "LU"
+  },
+  {
+    "id": "3078|Richigen|BE",
+    "name": "Richigen",
+    "zipCode": "3078",
+    "canton": "BE"
+  },
+  {
+    "id": "8805|Richterswil|ZH",
+    "name": "Richterswil",
+    "zipCode": "8805",
+    "canton": "ZH"
+  },
+  {
+    "id": "3178|Richterwil|FR",
+    "name": "Richterwil",
+    "zipCode": "3178",
+    "canton": "FR"
+  },
+  {
+    "id": "8726|Ricken|SG",
+    "name": "Ricken",
+    "zipCode": "8726",
+    "canton": "SG"
+  },
+  {
+    "id": "4462|Rickenbach|BL",
+    "name": "Rickenbach",
+    "zipCode": "4462",
+    "canton": "BL"
+  },
+  {
+    "id": "4613|Rickenbach|SO",
+    "name": "Rickenbach",
+    "zipCode": "4613",
+    "canton": "SO"
+  },
+  {
+    "id": "5634|Rickenbach|AG",
+    "name": "Rickenbach",
+    "zipCode": "5634",
+    "canton": "AG"
+  },
+  {
+    "id": "6221|Rickenbach|LU",
+    "name": "Rickenbach",
+    "zipCode": "6221",
+    "canton": "LU"
+  },
+  {
+    "id": "6432|Rickenbach|SZ",
+    "name": "Rickenbach",
+    "zipCode": "6432",
+    "canton": "SZ"
+  },
+  {
+    "id": "8545|Rickenbach|ZH",
+    "name": "Rickenbach",
+    "zipCode": "8545",
+    "canton": "ZH"
+  },
+  {
+    "id": "8913|Rickenbach bei Ottenbach|ZH",
+    "name": "Rickenbach bei Ottenbach",
+    "zipCode": "8913",
+    "canton": "ZH"
+  },
+  {
+    "id": "9532|Rickenbach bei Wil|TG",
+    "name": "Rickenbach bei Wil",
+    "zipCode": "9532",
+    "canton": "TG"
+  },
+  {
+    "id": "8352|Ricketwil|ZH",
+    "name": "Ricketwil",
+    "zipCode": "8352",
+    "canton": "ZH"
+  },
+  {
+    "id": "1908|Riddes|VS",
+    "name": "Riddes",
+    "zipCode": "1908",
+    "canton": "VS"
+  },
+  {
+    "id": "3724|Ried|BE",
+    "name": "Ried",
+    "zipCode": "3724",
+    "canton": "BE"
+  },
+  {
+    "id": "3772|Ried|BE",
+    "name": "Ried",
+    "zipCode": "3772",
+    "canton": "BE"
+  },
+  {
+    "id": "3997|Ried|VS",
+    "name": "Ried",
+    "zipCode": "3997",
+    "canton": "VS"
+  },
+  {
+    "id": "6436|Ried|SZ",
+    "name": "Ried",
+    "zipCode": "6436",
+    "canton": "SZ"
+  },
+  {
+    "id": "6476|Ried|UR",
+    "name": "Ried",
+    "zipCode": "6476",
+    "canton": "UR"
+  },
+  {
+    "id": "3919|Ried (Lötschen)|VS",
+    "name": "Ried (Lötschen)",
+    "zipCode": "3919",
+    "canton": "VS"
+  },
+  {
+    "id": "3216|Ried bei Kerzers|FR",
+    "name": "Ried bei Kerzers",
+    "zipCode": "3216",
+    "canton": "FR"
+  },
+  {
+    "id": "3082|Ried bei Worb|BE",
+    "name": "Ried bei Worb",
+    "zipCode": "3082",
+    "canton": "BE"
+  },
+  {
+    "id": "3911|Ried-Brig|VS",
+    "name": "Ried-Brig",
+    "zipCode": "3911",
+    "canton": "VS"
+  },
+  {
+    "id": "3986|Ried-Mörel|VS",
+    "name": "Ried-Mörel",
+    "zipCode": "3986",
+    "canton": "VS"
+  },
+  {
+    "id": "3000|Riedbach|BE",
+    "name": "Riedbach",
+    "zipCode": "3000",
+    "canton": "BE"
+  },
+  {
+    "id": "8304|Rieden|ZH",
+    "name": "Rieden",
+    "zipCode": "8304",
+    "canton": "ZH"
+  },
+  {
+    "id": "8739|Rieden|SG",
+    "name": "Rieden",
+    "zipCode": "8739",
+    "canton": "SG"
+  },
+  {
+    "id": "5415|Rieden bei Nussbaumen|AG",
+    "name": "Rieden bei Nussbaumen",
+    "zipCode": "5415",
+    "canton": "AG"
+  },
+  {
+    "id": "3987|Riederalp|VS",
+    "name": "Riederalp",
+    "zipCode": "3987",
+    "canton": "VS"
+  },
+  {
+    "id": "3178|Riederberg|FR",
+    "name": "Riederberg",
+    "zipCode": "3178",
+    "canton": "FR"
+  },
+  {
+    "id": "8750|Riedern|GL",
+    "name": "Riedern",
+    "zipCode": "8750",
+    "canton": "GL"
+  },
+  {
+    "id": "4533|Riedholz|SO",
+    "name": "Riedholz",
+    "zipCode": "4533",
+    "canton": "SO"
+  },
+  {
+    "id": "8616|Riedikon|ZH",
+    "name": "Riedikon",
+    "zipCode": "8616",
+    "canton": "ZH"
+  },
+  {
+    "id": "3159|Riedstätt|BE",
+    "name": "Riedstätt",
+    "zipCode": "3159",
+    "canton": "BE"
+  },
+  {
+    "id": "8586|Riedt bei Erlen|TG",
+    "name": "Riedt bei Erlen",
+    "zipCode": "8586",
+    "canton": "TG"
+  },
+  {
+    "id": "8173|Riedt bei Neerach|ZH",
+    "name": "Riedt bei Neerach",
+    "zipCode": "8173",
+    "canton": "ZH"
+  },
+  {
+    "id": "3475|Riedtwil|BE",
+    "name": "Riedtwil",
+    "zipCode": "3475",
+    "canton": "BE"
+  },
+  {
+    "id": "4125|Riehen|BS",
+    "name": "Riehen",
+    "zipCode": "4125",
+    "canton": "BS"
+  },
+  {
+    "id": "7128|Riein|GR",
+    "name": "Riein",
+    "zipCode": "7128",
+    "canton": "GR"
+  },
+  {
+    "id": "6452|Riemenstalden|SZ",
+    "name": "Riemenstalden",
+    "zipCode": "6452",
+    "canton": "SZ"
+  },
+  {
+    "id": "8000|Riesbach|ZH",
+    "name": "Riesbach",
+    "zipCode": "8000",
+    "canton": "ZH"
+  },
+  {
+    "id": "8498|Riet bei Gibswil|ZH",
+    "name": "Riet bei Gibswil",
+    "zipCode": "8498",
+    "canton": "ZH"
+  },
+  {
+    "id": "8412|Riet bei Neftenbach|ZH",
+    "name": "Riet bei Neftenbach",
+    "zipCode": "8412",
+    "canton": "ZH"
+  },
+  {
+    "id": "9651|Rietbad|SG",
+    "name": "Rietbad",
+    "zipCode": "9651",
+    "canton": "SG"
+  },
+  {
+    "id": "5323|Rietheim|AG",
+    "name": "Rietheim",
+    "zipCode": "5323",
+    "canton": "AG"
+  },
+  {
+    "id": "9000|Riethüsli|SG",
+    "name": "Riethüsli",
+    "zipCode": "9000",
+    "canton": "SG"
+  },
+  {
+    "id": "1097|Riex|VD",
+    "name": "Riex",
+    "zipCode": "1097",
+    "canton": "VD"
+  },
+  {
+    "id": "3920|Riffelalp|VS",
+    "name": "Riffelalp",
+    "zipCode": "3920",
+    "canton": "VS"
+  },
+  {
+    "id": "3156|Riffenmatt|BE",
+    "name": "Riffenmatt",
+    "zipCode": "3156",
+    "canton": "BE"
+  },
+  {
+    "id": "8911|Rifferswil|ZH",
+    "name": "Rifferswil",
+    "zipCode": "8911",
+    "canton": "ZH"
+  },
+  {
+    "id": "6020|Riffig|LU",
+    "name": "Riffig",
+    "zipCode": "6020",
+    "canton": "LU"
+  },
+  {
+    "id": "9248|Riggenschwil|SG",
+    "name": "Riggenschwil",
+    "zipCode": "9248",
+    "canton": "SG"
+  },
+  {
+    "id": "3132|Riggisberg|BE",
+    "name": "Riggisberg",
+    "zipCode": "3132",
+    "canton": "BE"
+  },
+  {
+    "id": "6356|Rigi Kaltbad|LU",
+    "name": "Rigi Kaltbad",
+    "zipCode": "6356",
+    "canton": "LU"
+  },
+  {
+    "id": "6410|Rigi Klösterli|SZ",
+    "name": "Rigi Klösterli",
+    "zipCode": "6410",
+    "canton": "SZ"
+  },
+  {
+    "id": "6410|Rigi Kulm|SZ",
+    "name": "Rigi Kulm",
+    "zipCode": "6410",
+    "canton": "SZ"
+  },
+  {
+    "id": "6410|Rigi Scheidegg|SZ",
+    "name": "Rigi Scheidegg",
+    "zipCode": "6410",
+    "canton": "SZ"
+  },
+  {
+    "id": "6410|Rigi Staffel|SZ",
+    "name": "Rigi Staffel",
+    "zipCode": "6410",
+    "canton": "SZ"
+  },
+  {
+    "id": "4853|Riken|AG",
+    "name": "Riken",
+    "zipCode": "4853",
+    "canton": "AG"
+  },
+  {
+    "id": "8307|Rikon bei Effretikon|ZH",
+    "name": "Rikon bei Effretikon",
+    "zipCode": "8307",
+    "canton": "ZH"
+  },
+  {
+    "id": "8486|Rikon im Tösstal|ZH",
+    "name": "Rikon im Tösstal",
+    "zipCode": "8486",
+    "canton": "ZH"
+  },
+  {
+    "id": "3852|Ringgenberg|BE",
+    "name": "Ringgenberg",
+    "zipCode": "3852",
+    "canton": "BE"
+  },
+  {
+    "id": "8142|Ringlikon|ZH",
+    "name": "Ringlikon",
+    "zipCode": "8142",
+    "canton": "ZH"
+  },
+  {
+    "id": "3762|Ringoldingen|BE",
+    "name": "Ringoldingen",
+    "zipCode": "3762",
+    "canton": "BE"
+  },
+  {
+    "id": "3656|Ringoldswil|BE",
+    "name": "Ringoldswil",
+    "zipCode": "3656",
+    "canton": "BE"
+  },
+  {
+    "id": "8340|Ringwil|ZH",
+    "name": "Ringwil",
+    "zipCode": "8340",
+    "canton": "ZH"
+  },
+  {
+    "id": "5223|Riniken|AG",
+    "name": "Riniken",
+    "zipCode": "5223",
+    "canton": "AG"
+  },
+  {
+    "id": "7463|Riom|GR",
+    "name": "Riom",
+    "zipCode": "7463",
+    "canton": "GR"
+  },
+  {
+    "id": "6343|Risch|ZG",
+    "name": "Risch",
+    "zipCode": "6343",
+    "canton": "ZG"
+  },
+  {
+    "id": "9548|Ristenbühl|TG",
+    "name": "Ristenbühl",
+    "zipCode": "9548",
+    "canton": "TG"
+  },
+  {
+    "id": "3989|Ritzingen|VS",
+    "name": "Ritzingen",
+    "zipCode": "3989",
+    "canton": "VS"
+  },
+  {
+    "id": "8577|Ritzisbuhwil|TG",
+    "name": "Ritzisbuhwil",
+    "zipCode": "8577",
+    "canton": "TG"
+  },
+  {
+    "id": "6826|Riva S. Vitale|TI",
+    "name": "Riva S. Vitale",
+    "zipCode": "6826",
+    "canton": "TI"
+  },
+  {
+    "id": "6648|Rivapiana|TI",
+    "name": "Rivapiana",
+    "zipCode": "6648",
+    "canton": "TI"
+  },
+  {
+    "id": "1071|Rivaz|VD",
+    "name": "Rivaz",
+    "zipCode": "1071",
+    "canton": "VD"
+  },
+  {
+    "id": "1945|Rive Haute|VS",
+    "name": "Rive Haute",
+    "zipCode": "1945",
+    "canton": "VS"
+  },
+  {
+    "id": "6674|Riveo|TI",
+    "name": "Riveo",
+    "zipCode": "6674",
+    "canton": "TI"
+  },
+  {
+    "id": "6802|Rivera|TI",
+    "name": "Rivera",
+    "zipCode": "6802",
+    "canton": "TI"
+  },
+  {
+    "id": "3206|Rizenbach|BE",
+    "name": "Rizenbach",
+    "zipCode": "3206",
+    "canton": "BE"
+  },
+  {
+    "id": "6599|Robasacco|TI",
+    "name": "Robasacco",
+    "zipCode": "6599",
+    "canton": "TI"
+  },
+  {
+    "id": "8620|Robenhausen|ZH",
+    "name": "Robenhausen",
+    "zipCode": "8620",
+    "canton": "ZH"
+  },
+  {
+    "id": "6690|Robiei|TI",
+    "name": "Robiei",
+    "zipCode": "6690",
+    "canton": "TI"
+  },
+  {
+    "id": "1852|Roche|VD",
+    "name": "Roche",
+    "zipCode": "1852",
+    "canton": "VD"
+  },
+  {
+    "id": "2912|Roche-d'Or|JU",
+    "name": "Roche-d'Or",
+    "zipCode": "2912",
+    "canton": "JU"
+  },
+  {
+    "id": "2019|Rochefort|NE",
+    "name": "Rochefort",
+    "zipCode": "2019",
+    "canton": "NE"
+  },
+  {
+    "id": "2762|Roches|BE",
+    "name": "Roches",
+    "zipCode": "2762",
+    "canton": "BE"
+  },
+  {
+    "id": "2907|Rocourt|JU",
+    "name": "Rocourt",
+    "zipCode": "2907",
+    "canton": "JU"
+  },
+  {
+    "id": "7415|Rodels|GR",
+    "name": "Rodels",
+    "zipCode": "7415",
+    "canton": "GR"
+  },
+  {
+    "id": "4118|Rodersdorf|SO",
+    "name": "Rodersdorf",
+    "zipCode": "4118",
+    "canton": "SO"
+  },
+  {
+    "id": "6772|Rodi|TI",
+    "name": "Rodi",
+    "zipCode": "6772",
+    "canton": "TI"
+  },
+  {
+    "id": "9468|Rofisbach|SG",
+    "name": "Rofisbach",
+    "zipCode": "9468",
+    "canton": "SG"
+  },
+  {
+    "id": "2814|Roggenburg|BL",
+    "name": "Roggenburg",
+    "zipCode": "2814",
+    "canton": "BL"
+  },
+  {
+    "id": "6833|Roggiana|TI",
+    "name": "Roggiana",
+    "zipCode": "6833",
+    "canton": "TI"
+  },
+  {
+    "id": "6265|Roggliswil|LU",
+    "name": "Roggliswil",
+    "zipCode": "6265",
+    "canton": "LU"
+  },
+  {
+    "id": "4914|Roggwil|BE",
+    "name": "Roggwil",
+    "zipCode": "4914",
+    "canton": "BE"
+  },
+  {
+    "id": "9325|Roggwil|TG",
+    "name": "Roggwil",
+    "zipCode": "9325",
+    "canton": "TG"
+  },
+  {
+    "id": "5032|Rohr|AG",
+    "name": "Rohr",
+    "zipCode": "5032",
+    "canton": "AG"
+  },
+  {
+    "id": "4655|Rohr bei Olten|SO",
+    "name": "Rohr bei Olten",
+    "zipCode": "4655",
+    "canton": "SO"
+  },
+  {
+    "id": "4938|Rohrbach|BE",
+    "name": "Rohrbach",
+    "zipCode": "4938",
+    "canton": "BE"
+  },
+  {
+    "id": "4938|Rohrbachgraben|BE",
+    "name": "Rohrbachgraben",
+    "zipCode": "4938",
+    "canton": "BE"
+  },
+  {
+    "id": "6132|Rohrmatt|LU",
+    "name": "Rohrmatt",
+    "zipCode": "6132",
+    "canton": "LU"
+  },
+  {
+    "id": "3421|Rohrmoos bei Lyssach|BE",
+    "name": "Rohrmoos bei Lyssach",
+    "zipCode": "3421",
+    "canton": "BE"
+  },
+  {
+    "id": "1180|Rolle|VD",
+    "name": "Rolle",
+    "zipCode": "1180",
+    "canton": "VD"
+  },
+  {
+    "id": "1323|Romainmôtier|VD",
+    "name": "Romainmôtier",
+    "zipCode": "1323",
+    "canton": "VD"
+  },
+  {
+    "id": "1423|Romairon|VD",
+    "name": "Romairon",
+    "zipCode": "1423",
+    "canton": "VD"
+  },
+  {
+    "id": "1032|Romanel-sur-Lausanne|VD",
+    "name": "Romanel-sur-Lausanne",
+    "zipCode": "1032",
+    "canton": "VD"
+  },
+  {
+    "id": "1122|Romanel-sur-Morges|VD",
+    "name": "Romanel-sur-Morges",
+    "zipCode": "1122",
+    "canton": "VD"
+  },
+  {
+    "id": "1626|Romanens|FR",
+    "name": "Romanens",
+    "zipCode": "1626",
+    "canton": "FR"
+  },
+  {
+    "id": "8590|Romanshorn|TG",
+    "name": "Romanshorn",
+    "zipCode": "8590",
+    "canton": "TG"
+  },
+  {
+    "id": "5022|Rombach|AG",
+    "name": "Rombach",
+    "zipCode": "5022",
+    "canton": "AG"
+  },
+  {
+    "id": "1722|Römerswil|FR",
+    "name": "Römerswil",
+    "zipCode": "1722",
+    "canton": "FR"
+  },
+  {
+    "id": "6027|Römerswil|LU",
+    "name": "Römerswil",
+    "zipCode": "6027",
+    "canton": "LU"
+  },
+  {
+    "id": "1680|Romont|FR",
+    "name": "Romont",
+    "zipCode": "1680",
+    "canton": "FR"
+  },
+  {
+    "id": "2538|Romont|BE",
+    "name": "Romont",
+    "zipCode": "2538",
+    "canton": "BE"
+  },
+  {
+    "id": "6113|Romoos|LU",
+    "name": "Romoos",
+    "zipCode": "6113",
+    "canton": "LU"
+  },
+  {
+    "id": "7454|Rona|GR",
+    "name": "Rona",
+    "zipCode": "7454",
+    "canton": "GR"
+  },
+  {
+    "id": "6622|Ronco sopra Ascona|TI",
+    "name": "Ronco sopra Ascona",
+    "zipCode": "6622",
+    "canton": "TI"
+  },
+  {
+    "id": "7430|Rongellen|GR",
+    "name": "Rongellen",
+    "zipCode": "7430",
+    "canton": "GR"
+  },
+  {
+    "id": "6713|Rongie|TI",
+    "name": "Rongie",
+    "zipCode": "6713",
+    "canton": "TI"
+  },
+  {
+    "id": "6037|Root|LU",
+    "name": "Root",
+    "zipCode": "6037",
+    "canton": "LU"
+  },
+  {
+    "id": "1088|Ropraz|VD",
+    "name": "Ropraz",
+    "zipCode": "1088",
+    "canton": "VD"
+  },
+  {
+    "id": "8427|Rorbas|ZH",
+    "name": "Rorbas",
+    "zipCode": "8427",
+    "canton": "ZH"
+  },
+  {
+    "id": "9400|Rorschach|SG",
+    "name": "Rorschach",
+    "zipCode": "9400",
+    "canton": "SG"
+  },
+  {
+    "id": "9404|Rorschacherberg|SG",
+    "name": "Rorschacherberg",
+    "zipCode": "9404",
+    "canton": "SG"
+  },
+  {
+    "id": "4244|Röschenz|BL",
+    "name": "Röschenz",
+    "zipCode": "4244",
+    "canton": "BL"
+  },
+  {
+    "id": "1754|Rosé|FR",
+    "name": "Rosé",
+    "zipCode": "1754",
+    "canton": "FR"
+  },
+  {
+    "id": "9000|Rosenberg|SG",
+    "name": "Rosenberg",
+    "zipCode": "9000",
+    "canton": "SG"
+  },
+  {
+    "id": "8500|Rosenhuben|TG",
+    "name": "Rosenhuben",
+    "zipCode": "8500",
+    "canton": "TG"
+  },
+  {
+    "id": "3860|Rosenlaui|BE",
+    "name": "Rosenlaui",
+    "zipCode": "3860",
+    "canton": "BE"
+  },
+  {
+    "id": "4000|Rosental|BS",
+    "name": "Rosental",
+    "zipCode": "4000",
+    "canton": "BS"
+  },
+  {
+    "id": "9545|Rosental|TG",
+    "name": "Rosental",
+    "zipCode": "9545",
+    "canton": "TG"
+  },
+  {
+    "id": "6548|Rossa|GR",
+    "name": "Rossa",
+    "zipCode": "6548",
+    "canton": "GR"
+  },
+  {
+    "id": "8932|Rossau|ZH",
+    "name": "Rossau",
+    "zipCode": "8932",
+    "canton": "ZH"
+  },
+  {
+    "id": "8400|Rossberg|ZH",
+    "name": "Rossberg",
+    "zipCode": "8400",
+    "canton": "ZH"
+  },
+  {
+    "id": "2842|Rossemaison|JU",
+    "name": "Rossemaison",
+    "zipCode": "2842",
+    "canton": "JU"
+  },
+  {
+    "id": "1513|Rossenges|VD",
+    "name": "Rossenges",
+    "zipCode": "1513",
+    "canton": "VD"
+  },
+  {
+    "id": "1554|Rossens|VD",
+    "name": "Rossens",
+    "zipCode": "1554",
+    "canton": "VD"
+  },
+  {
+    "id": "1728|Rossens FR|FR",
+    "name": "Rossens FR",
+    "zipCode": "1728",
+    "canton": "FR"
+  },
+  {
+    "id": "3204|Rosshäusern|BE",
+    "name": "Rosshäusern",
+    "zipCode": "3204",
+    "canton": "BE"
+  },
+  {
+    "id": "1658|Rossinière|VD",
+    "name": "Rossinière",
+    "zipCode": "1658",
+    "canton": "VD"
+  },
+  {
+    "id": "9512|Rossrüti|SG",
+    "name": "Rossrüti",
+    "zipCode": "9512",
+    "canton": "SG"
+  },
+  {
+    "id": "6760|Rossura|TI",
+    "name": "Rossura",
+    "zipCode": "6760",
+    "canton": "TI"
+  },
+  {
+    "id": "3913|Rosswald|VS",
+    "name": "Rosswald",
+    "zipCode": "3913",
+    "canton": "VS"
+  },
+  {
+    "id": "5746|Rothacker|SO",
+    "name": "Rothacker",
+    "zipCode": "5746",
+    "canton": "SO"
+  },
+  {
+    "id": "3373|Röthenbach bei Herzogenbuchsee|BE",
+    "name": "Röthenbach bei Herzogenbuchsee",
+    "zipCode": "3373",
+    "canton": "BE"
+  },
+  {
+    "id": "3538|Röthenbach im Emmental|BE",
+    "name": "Röthenbach im Emmental",
+    "zipCode": "3538",
+    "canton": "BE"
+  },
+  {
+    "id": "7405|Rothenbrunnen|GR",
+    "name": "Rothenbrunnen",
+    "zipCode": "7405",
+    "canton": "GR"
+  },
+  {
+    "id": "6023|Rothenburg|LU",
+    "name": "Rothenburg",
+    "zipCode": "6023",
+    "canton": "LU"
+  },
+  {
+    "id": "4467|Rothenfluh|BL",
+    "name": "Rothenfluh",
+    "zipCode": "4467",
+    "canton": "BL"
+  },
+  {
+    "id": "9565|Rothenhausen|TG",
+    "name": "Rothenhausen",
+    "zipCode": "9565",
+    "canton": "TG"
+  },
+  {
+    "id": "6418|Rothenthurm|SZ",
+    "name": "Rothenthurm",
+    "zipCode": "6418",
+    "canton": "SZ"
+  },
+  {
+    "id": "3855|Rothorn Kulm|BE",
+    "name": "Rothorn Kulm",
+    "zipCode": "3855",
+    "canton": "BE"
+  },
+  {
+    "id": "4852|Rothrist|AG",
+    "name": "Rothrist",
+    "zipCode": "4852",
+    "canton": "AG"
+  },
+  {
+    "id": "3901|Rothwald|VS",
+    "name": "Rothwald",
+    "zipCode": "3901",
+    "canton": "VS"
+  },
+  {
+    "id": "6343|Rotkreuz|ZG",
+    "name": "Rotkreuz",
+    "zipCode": "6343",
+    "canton": "ZG"
+  },
+  {
+    "id": "9000|Rotmonten|SG",
+    "name": "Rotmonten",
+    "zipCode": "9000",
+    "canton": "SG"
+  },
+  {
+    "id": "8919|Rottenschwil|AG",
+    "name": "Rottenschwil",
+    "zipCode": "8919",
+    "canton": "AG"
+  },
+  {
+    "id": "6362|Rotzloch|NW",
+    "name": "Rotzloch",
+    "zipCode": "6362",
+    "canton": "NW"
+  },
+  {
+    "id": "1659|Rougemont|VD",
+    "name": "Rougemont",
+    "zipCode": "1659",
+    "canton": "VD"
+  },
+  {
+    "id": "1965|Roumaz|VS",
+    "name": "Roumaz",
+    "zipCode": "1965",
+    "canton": "VS"
+  },
+  {
+    "id": "6535|Roveredo|GR",
+    "name": "Roveredo",
+    "zipCode": "6535",
+    "canton": "GR"
+  },
+  {
+    "id": "6957|Roveredo|TI",
+    "name": "Roveredo",
+    "zipCode": "6957",
+    "canton": "TI"
+  },
+  {
+    "id": "6821|Rovio|TI",
+    "name": "Rovio",
+    "zipCode": "6821",
+    "canton": "TI"
+  },
+  {
+    "id": "1463|Rovray|VD",
+    "name": "Rovray",
+    "zipCode": "1463",
+    "canton": "VD"
+  },
+  {
+    "id": "3113|Rubigen|BE",
+    "name": "Rubigen",
+    "zipCode": "3113",
+    "canton": "BE"
+  },
+  {
+    "id": "3268|Ruchwil|BE",
+    "name": "Ruchwil",
+    "zipCode": "3268",
+    "canton": "BE"
+  },
+  {
+    "id": "6074|Rudenz|OW",
+    "name": "Rudenz",
+    "zipCode": "6074",
+    "canton": "OW"
+  },
+  {
+    "id": "3437|Rüderswil|BE",
+    "name": "Rüderswil",
+    "zipCode": "3437",
+    "canton": "BE"
+  },
+  {
+    "id": "8455|Rüdlingen|SH",
+    "name": "Rüdlingen",
+    "zipCode": "8455",
+    "canton": "SH"
+  },
+  {
+    "id": "8465|Rudolfingen|ZH",
+    "name": "Rudolfingen",
+    "zipCode": "8465",
+    "canton": "ZH"
+  },
+  {
+    "id": "8964|Rudolfstetten|AG",
+    "name": "Rudolfstetten",
+    "zipCode": "8964",
+    "canton": "AG"
+  },
+  {
+    "id": "3423|Rudswil|BE",
+    "name": "Rudswil",
+    "zipCode": "3423",
+    "canton": "BE"
+  },
+  {
+    "id": "3422|Rüdtligen|BE",
+    "name": "Rüdtligen",
+    "zipCode": "3422",
+    "canton": "BE"
+  },
+  {
+    "id": "1223|Ruè|GE",
+    "name": "Ruè",
+    "zipCode": "1223",
+    "canton": "GE"
+  },
+  {
+    "id": "1673|Rue|FR",
+    "name": "Rue",
+    "zipCode": "1673",
+    "canton": "FR"
+  },
+  {
+    "id": "3792|Rüebeldorf|BE",
+    "name": "Rüebeldorf",
+    "zipCode": "3792",
+    "canton": "BE"
+  },
+  {
+    "id": "6288|Rüediken|LU",
+    "name": "Rüediken",
+    "zipCode": "6288",
+    "canton": "LU"
+  },
+  {
+    "id": "3474|Rüedisbach|BE",
+    "name": "Rüedisbach",
+    "zipCode": "3474",
+    "canton": "BE"
+  },
+  {
+    "id": "6017|Rüediswil|LU",
+    "name": "Rüediswil",
+    "zipCode": "6017",
+    "canton": "LU"
+  },
+  {
+    "id": "3088|Rüeggisberg|BE",
+    "name": "Rüeggisberg",
+    "zipCode": "3088",
+    "canton": "BE"
+  },
+  {
+    "id": "3417|Rüegsau|BE",
+    "name": "Rüegsau",
+    "zipCode": "3417",
+    "canton": "BE"
+  },
+  {
+    "id": "3415|Rüegsauschachen|BE",
+    "name": "Rüegsauschachen",
+    "zipCode": "3415",
+    "canton": "BE"
+  },
+  {
+    "id": "3418|Rüegsbach|BE",
+    "name": "Rüegsbach",
+    "zipCode": "3418",
+    "canton": "BE"
+  },
+  {
+    "id": "7189|Rueras|GR",
+    "name": "Rueras",
+    "zipCode": "7189",
+    "canton": "GR"
+  },
+  {
+    "id": "8735|Rüeterswil|SG",
+    "name": "Rüeterswil",
+    "zipCode": "8735",
+    "canton": "SG"
+  },
+  {
+    "id": "7156|Rueun|GR",
+    "name": "Rueun",
+    "zipCode": "7156",
+    "canton": "GR"
+  },
+  {
+    "id": "1046|Rueyres|VD",
+    "name": "Rueyres",
+    "zipCode": "1046",
+    "canton": "VD"
+  },
+  {
+    "id": "1626|Rueyres|FR",
+    "name": "Rueyres",
+    "zipCode": "1626",
+    "canton": "FR"
+  },
+  {
+    "id": "1542|Rueyres-les-Prés|FR",
+    "name": "Rueyres-les-Prés",
+    "zipCode": "1542",
+    "canton": "FR"
+  },
+  {
+    "id": "1695|Rueyres-St-Laurent|FR",
+    "name": "Rueyres-St-Laurent",
+    "zipCode": "1695",
+    "canton": "FR"
+  },
+  {
+    "id": "5235|Rüfenach|AG",
+    "name": "Rüfenach",
+    "zipCode": "5235",
+    "canton": "AG"
+  },
+  {
+    "id": "3075|Rüfenacht|BE",
+    "name": "Rüfenacht",
+    "zipCode": "3075",
+    "canton": "BE"
+  },
+  {
+    "id": "8723|Rufi|SG",
+    "name": "Rufi",
+    "zipCode": "8723",
+    "canton": "SG"
+  },
+  {
+    "id": "6153|Rufswil|LU",
+    "name": "Rufswil",
+    "zipCode": "6153",
+    "canton": "LU"
+  },
+  {
+    "id": "8903|Ruggen|ZH",
+    "name": "Ruggen",
+    "zipCode": "8903",
+    "canton": "ZH"
+  },
+  {
+    "id": "3953|Rumeling|VS",
+    "name": "Rumeling",
+    "zipCode": "3953",
+    "canton": "VS"
+  },
+  {
+    "id": "3472|Rumendingen|BE",
+    "name": "Rumendingen",
+    "zipCode": "3472",
+    "canton": "BE"
+  },
+  {
+    "id": "6332|Rumentikon|ZG",
+    "name": "Rumentikon",
+    "zipCode": "6332",
+    "canton": "ZG"
+  },
+  {
+    "id": "5464|Rümikon|AG",
+    "name": "Rümikon",
+    "zipCode": "5464",
+    "canton": "AG"
+  },
+  {
+    "id": "8352|Rümikon|ZH",
+    "name": "Rümikon",
+    "zipCode": "8352",
+    "canton": "ZH"
+  },
+  {
+    "id": "4539|Rumisberg|BE",
+    "name": "Rumisberg",
+    "zipCode": "4539",
+    "canton": "BE"
+  },
+  {
+    "id": "8153|Rümlang|ZH",
+    "name": "Rümlang",
+    "zipCode": "8153",
+    "canton": "ZH"
+  },
+  {
+    "id": "3128|Rümligen|BE",
+    "name": "Rümligen",
+    "zipCode": "3128",
+    "canton": "BE"
+  },
+  {
+    "id": "8332|Rumlikon|ZH",
+    "name": "Rumlikon",
+    "zipCode": "8332",
+    "canton": "ZH"
+  },
+  {
+    "id": "4444|Rümlingen|BL",
+    "name": "Rümlingen",
+    "zipCode": "4444",
+    "canton": "BL"
+  },
+  {
+    "id": "4497|Rünenberg|BL",
+    "name": "Rünenberg",
+    "zipCode": "4497",
+    "canton": "BL"
+  },
+  {
+    "id": "3533|Rünkhofen|BE",
+    "name": "Rünkhofen",
+    "zipCode": "3533",
+    "canton": "BE"
+  },
+  {
+    "id": "3204|Rüplisried|BE",
+    "name": "Rüplisried",
+    "zipCode": "3204",
+    "canton": "BE"
+  },
+  {
+    "id": "5102|Rupperswil|AG",
+    "name": "Rupperswil",
+    "zipCode": "5102",
+    "canton": "AG"
+  },
+  {
+    "id": "4663|Ruppoldingen|SO",
+    "name": "Ruppoldingen",
+    "zipCode": "4663",
+    "canton": "SO"
+  },
+  {
+    "id": "3251|Ruppoldsried|BE",
+    "name": "Ruppoldsried",
+    "zipCode": "3251",
+    "canton": "BE"
+  },
+  {
+    "id": "3153|Rüschegg|BE",
+    "name": "Rüschegg",
+    "zipCode": "3153",
+    "canton": "BE"
+  },
+  {
+    "id": "7154|Ruschein|GR",
+    "name": "Ruschein",
+    "zipCode": "7154",
+    "canton": "GR"
+  },
+  {
+    "id": "8803|Rüschlikon|ZH",
+    "name": "Rüschlikon",
+    "zipCode": "8803",
+    "canton": "ZH"
+  },
+  {
+    "id": "8332|Russikon|ZH",
+    "name": "Russikon",
+    "zipCode": "8332",
+    "canton": "ZH"
+  },
+  {
+    "id": "1281|Russin|GE",
+    "name": "Russin",
+    "zipCode": "1281",
+    "canton": "GE"
+  },
+  {
+    "id": "6662|Russo|TI",
+    "name": "Russo",
+    "zipCode": "6662",
+    "canton": "TI"
+  },
+  {
+    "id": "1773|Russy|FR",
+    "name": "Russy",
+    "zipCode": "1773",
+    "canton": "FR"
+  },
+  {
+    "id": "5644|Rüstenschwil|AG",
+    "name": "Rüstenschwil",
+    "zipCode": "5644",
+    "canton": "AG"
+  },
+  {
+    "id": "6017|Ruswil|LU",
+    "name": "Ruswil",
+    "zipCode": "6017",
+    "canton": "LU"
+  },
+  {
+    "id": "9464|Rüthi|SG",
+    "name": "Rüthi",
+    "zipCode": "9464",
+    "canton": "SG"
+  },
+  {
+    "id": "3072|Rüti|BE",
+    "name": "Rüti",
+    "zipCode": "3072",
+    "canton": "BE"
+  },
+  {
+    "id": "8630|Rüti|ZH",
+    "name": "Rüti",
+    "zipCode": "8630",
+    "canton": "ZH"
+  },
+  {
+    "id": "8782|Rüti|GL",
+    "name": "Rüti",
+    "zipCode": "8782",
+    "canton": "GL"
+  },
+  {
+    "id": "9030|Rüti bei Abtwil|SG",
+    "name": "Rüti bei Abtwil",
+    "zipCode": "9030",
+    "canton": "SG"
+  },
+  {
+    "id": "8185|Rüti bei Bülach|ZH",
+    "name": "Rüti bei Bülach",
+    "zipCode": "8185",
+    "canton": "ZH"
+  },
+  {
+    "id": "3295|Rüti bei Büren|BE",
+    "name": "Rüti bei Büren",
+    "zipCode": "3295",
+    "canton": "BE"
+  },
+  {
+    "id": "3421|Rüti bei Lyssach|BE",
+    "name": "Rüti bei Lyssach",
+    "zipCode": "3421",
+    "canton": "BE"
+  },
+  {
+    "id": "3099|Rüti bei Riggisberg|BE",
+    "name": "Rüti bei Riggisberg",
+    "zipCode": "3099",
+    "canton": "BE"
+  },
+  {
+    "id": "5406|Rütihof|AG",
+    "name": "Rütihof",
+    "zipCode": "5406",
+    "canton": "AG"
+  },
+  {
+    "id": "5722|Rütihof|AG",
+    "name": "Rütihof",
+    "zipCode": "5722",
+    "canton": "AG"
+  },
+  {
+    "id": "6441|Rütli|UR",
+    "name": "Rütli",
+    "zipCode": "6441",
+    "canton": "UR"
+  },
+  {
+    "id": "4933|Rütschelen|BE",
+    "name": "Rütschelen",
+    "zipCode": "4933",
+    "canton": "BE"
+  },
+  {
+    "id": "8471|Rutschwil|ZH",
+    "name": "Rutschwil",
+    "zipCode": "8471",
+    "canton": "ZH"
+  },
+  {
+    "id": "4522|Rüttenen|SO",
+    "name": "Rüttenen",
+    "zipCode": "4522",
+    "canton": "SO"
+  },
+  {
+    "id": "3052|Rütti|BE",
+    "name": "Rütti",
+    "zipCode": "3052",
+    "canton": "BE"
+  },
+  {
+    "id": "6977|Ruvigliana|TI",
+    "name": "Ruvigliana",
+    "zipCode": "6977",
+    "canton": "TI"
+  },
+  {
+    "id": "7525|S-chanf|GR",
+    "name": "S-chanf",
+    "zipCode": "7525",
+    "canton": "GR"
+  },
+  {
+    "id": "7550|S-charl|GR",
+    "name": "S-charl",
+    "zipCode": "7550",
+    "canton": "GR"
+  },
+  {
+    "id": "6577|S. Abbondio|TI",
+    "name": "S. Abbondio",
+    "zipCode": "6577",
+    "canton": "TI"
+  },
+  {
+    "id": "6592|S. Antonino|TI",
+    "name": "S. Antonino",
+    "zipCode": "6592",
+    "canton": "TI"
+  },
+  {
+    "id": "7745|S. Antonio|GR",
+    "name": "S. Antonio",
+    "zipCode": "7745",
+    "canton": "GR"
+  },
+  {
+    "id": "6583|S. Antonio (Val Morobbia)|TI",
+    "name": "S. Antonio (Val Morobbia)",
+    "zipCode": "6583",
+    "canton": "TI"
+  },
+  {
+    "id": "7174|S. Benedetg|GR",
+    "name": "S. Benedetg",
+    "zipCode": "7174",
+    "canton": "GR"
+  },
+  {
+    "id": "6565|S. Bernardino-Villaggio|GR",
+    "name": "S. Bernardino-Villaggio",
+    "zipCode": "6565",
+    "canton": "GR"
+  },
+  {
+    "id": "6690|S. Carlo  (Bavona)|TI",
+    "name": "S. Carlo  (Bavona)",
+    "zipCode": "6690",
+    "canton": "TI"
+  },
+  {
+    "id": "6780|S. Gottardo|TI",
+    "name": "S. Gottardo",
+    "zipCode": "6780",
+    "canton": "TI"
+  },
+  {
+    "id": "6575|S. Nazzaro|TI",
+    "name": "S. Nazzaro",
+    "zipCode": "6575",
+    "canton": "TI"
+  },
+  {
+    "id": "6854|S. Pietro|TI",
+    "name": "S. Pietro",
+    "zipCode": "6854",
+    "canton": "TI"
+  },
+  {
+    "id": "6534|S. Vittore|GR",
+    "name": "S. Vittore",
+    "zipCode": "6534",
+    "canton": "GR"
+  },
+  {
+    "id": "3792|Saanen|BE",
+    "name": "Saanen",
+    "zipCode": "3792",
+    "canton": "BE"
+  },
+  {
+    "id": "3777|Saanenmöser|BE",
+    "name": "Saanenmöser",
+    "zipCode": "3777",
+    "canton": "BE"
+  },
+  {
+    "id": "3908|Saas Bidermatten|VS",
+    "name": "Saas Bidermatten",
+    "zipCode": "3908",
+    "canton": "VS"
+  },
+  {
+    "id": "7247|Saas im Prättigau|GR",
+    "name": "Saas im Prättigau",
+    "zipCode": "7247",
+    "canton": "GR"
+  },
+  {
+    "id": "3905|Saas-Almagell|VS",
+    "name": "Saas-Almagell",
+    "zipCode": "3905",
+    "canton": "VS"
+  },
+  {
+    "id": "3908|Saas-Balen|VS",
+    "name": "Saas-Balen",
+    "zipCode": "3908",
+    "canton": "VS"
+  },
+  {
+    "id": "3906|Saas-Fee|VS",
+    "name": "Saas-Fee",
+    "zipCode": "3906",
+    "canton": "VS"
+  },
+  {
+    "id": "3910|Saas-Grund|VS",
+    "name": "Saas-Grund",
+    "zipCode": "3910",
+    "canton": "VS"
+  },
+  {
+    "id": "6072|Sachseln|OW",
+    "name": "Sachseln",
+    "zipCode": "6072",
+    "canton": "OW"
+  },
+  {
+    "id": "1996|Saclentz|VS",
+    "name": "Saclentz",
+    "zipCode": "1996",
+    "canton": "VS"
+  },
+  {
+    "id": "1212|Saconnex-d'Arve|GE",
+    "name": "Saconnex-d'Arve",
+    "zipCode": "1212",
+    "canton": "GE"
+  },
+  {
+    "id": "5745|Safenwil|AG",
+    "name": "Safenwil",
+    "zipCode": "5745",
+    "canton": "AG"
+  },
+  {
+    "id": "7107|Safien|GR",
+    "name": "Safien",
+    "zipCode": "7107",
+    "canton": "GR"
+  },
+  {
+    "id": "7107|Safien Platz|GR",
+    "name": "Safien Platz",
+    "zipCode": "7107",
+    "canton": "GR"
+  },
+  {
+    "id": "2553|Safnern|BE",
+    "name": "Safnern",
+    "zipCode": "2553",
+    "canton": "BE"
+  },
+  {
+    "id": "6264|Sagen|LU",
+    "name": "Sagen",
+    "zipCode": "6264",
+    "canton": "LU"
+  },
+  {
+    "id": "6839|Sagno|TI",
+    "name": "Sagno",
+    "zipCode": "6839",
+    "canton": "TI"
+  },
+  {
+    "id": "7152|Sagogn|GR",
+    "name": "Sagogn",
+    "zipCode": "7152",
+    "canton": "GR"
+  },
+  {
+    "id": "2732|Saicourt|BE",
+    "name": "Saicourt",
+    "zipCode": "2732",
+    "canton": "BE"
+  },
+  {
+    "id": "2350|Saignelégier|JU",
+    "name": "Saignelégier",
+    "zipCode": "2350",
+    "canton": "JU"
+  },
+  {
+    "id": "1913|Saillon|VS",
+    "name": "Saillon",
+    "zipCode": "1913",
+    "canton": "VS"
+  },
+  {
+    "id": "6954|Sala Capriasca|TI",
+    "name": "Sala Capriasca",
+    "zipCode": "6954",
+    "canton": "TI"
+  },
+  {
+    "id": "8493|Saland|ZH",
+    "name": "Saland",
+    "zipCode": "8493",
+    "canton": "ZH"
+  },
+  {
+    "id": "1585|Salavaux|VD",
+    "name": "Salavaux",
+    "zipCode": "1585",
+    "canton": "VD"
+  },
+  {
+    "id": "1867|Salaz|VD",
+    "name": "Salaz",
+    "zipCode": "1867",
+    "canton": "VD"
+  },
+  {
+    "id": "8507|Salen|TG",
+    "name": "Salen",
+    "zipCode": "8507",
+    "canton": "TG"
+  },
+  {
+    "id": "8268|Salenstein|TG",
+    "name": "Salenstein",
+    "zipCode": "8268",
+    "canton": "TG"
+  },
+  {
+    "id": "1731|Sales|FR",
+    "name": "Sales",
+    "zipCode": "1731",
+    "canton": "FR"
+  },
+  {
+    "id": "1625|Sâles (Gruyère)|FR",
+    "name": "Sâles (Gruyère)",
+    "zipCode": "1625",
+    "canton": "FR"
+  },
+  {
+    "id": "9465|Salez|SG",
+    "name": "Salez",
+    "zipCode": "9465",
+    "canton": "SG"
+  },
+  {
+    "id": "3970|Salgesch|VS",
+    "name": "Salgesch",
+    "zipCode": "3970",
+    "canton": "VS"
+  },
+  {
+    "id": "1991|Salins|VS",
+    "name": "Salins",
+    "zipCode": "1991",
+    "canton": "VS"
+  },
+  {
+    "id": "8599|Salmsach|TG",
+    "name": "Salmsach",
+    "zipCode": "8599",
+    "canton": "TG"
+  },
+  {
+    "id": "6872|Salorino|TI",
+    "name": "Salorino",
+    "zipCode": "6872",
+    "canton": "TI"
+  },
+  {
+    "id": "7462|Salouf|GR",
+    "name": "Salouf",
+    "zipCode": "7462",
+    "canton": "GR"
+  },
+  {
+    "id": "1922|Salvan|VS",
+    "name": "Salvan",
+    "zipCode": "1922",
+    "canton": "VS"
+  },
+  {
+    "id": "1794|Salvenach|FR",
+    "name": "Salvenach",
+    "zipCode": "1794",
+    "canton": "FR"
+  },
+  {
+    "id": "3036|Salvisberg|BE",
+    "name": "Salvisberg",
+    "zipCode": "3036",
+    "canton": "BE"
+  },
+  {
+    "id": "7503|Samedan|GR",
+    "name": "Samedan",
+    "zipCode": "7503",
+    "canton": "GR"
+  },
+  {
+    "id": "7563|Samnaun|GR",
+    "name": "Samnaun",
+    "zipCode": "7563",
+    "canton": "GR"
+  },
+  {
+    "id": "8833|Samstagern|ZH",
+    "name": "Samstagern",
+    "zipCode": "8833",
+    "canton": "ZH"
+  },
+  {
+    "id": "7741|San Carlo|GR",
+    "name": "San Carlo",
+    "zipCode": "7741",
+    "canton": "GR"
+  },
+  {
+    "id": "1950|Sanetsch|VS",
+    "name": "Sanetsch",
+    "zipCode": "1950",
+    "canton": "VS"
+  },
+  {
+    "id": "1738|Sangernboden|BE",
+    "name": "Sangernboden",
+    "zipCode": "1738",
+    "canton": "BE"
+  },
+  {
+    "id": "7057|Sapün|GR",
+    "name": "Sapün",
+    "zipCode": "7057",
+    "canton": "GR"
+  },
+  {
+    "id": "7320|Sargans|SG",
+    "name": "Sargans",
+    "zipCode": "7320",
+    "canton": "SG"
+  },
+  {
+    "id": "3049|Säriswil|BE",
+    "name": "Säriswil",
+    "zipCode": "3049",
+    "canton": "BE"
+  },
+  {
+    "id": "5614|Sarmenstorf|AG",
+    "name": "Sarmenstorf",
+    "zipCode": "5614",
+    "canton": "AG"
+  },
+  {
+    "id": "7423|Sarn|GR",
+    "name": "Sarn",
+    "zipCode": "7423",
+    "canton": "GR"
+  },
+  {
+    "id": "6060|Sarnen|OW",
+    "name": "Sarnen",
+    "zipCode": "6060",
+    "canton": "OW"
+  },
+  {
+    "id": "1948|Sarreyer|VS",
+    "name": "Sarreyer",
+    "zipCode": "1948",
+    "canton": "VS"
+  },
+  {
+    "id": "1683|Sarzens|VD",
+    "name": "Sarzens",
+    "zipCode": "1683",
+    "canton": "VD"
+  },
+  {
+    "id": "1534|Sassel|VD",
+    "name": "Sassel",
+    "zipCode": "1534",
+    "canton": "VD"
+  },
+  {
+    "id": "8507|Sassenloh|TG",
+    "name": "Sassenloh",
+    "zipCode": "8507",
+    "canton": "TG"
+  },
+  {
+    "id": "1242|Satigny|GE",
+    "name": "Satigny",
+    "zipCode": "1242",
+    "canton": "GE"
+  },
+  {
+    "id": "6417|Sattel|SZ",
+    "name": "Sattel",
+    "zipCode": "6417",
+    "canton": "SZ"
+  },
+  {
+    "id": "1189|Saubraz|VD",
+    "name": "Saubraz",
+    "zipCode": "1189",
+    "canton": "VD"
+  },
+  {
+    "id": "2024|Sauges|NE",
+    "name": "Sauges",
+    "zipCode": "2024",
+    "canton": "NE"
+  },
+  {
+    "id": "2873|Saulcy|JU",
+    "name": "Saulcy",
+    "zipCode": "2873",
+    "canton": "JU"
+  },
+  {
+    "id": "2063|Saules|NE",
+    "name": "Saules",
+    "zipCode": "2063",
+    "canton": "NE"
+  },
+  {
+    "id": "2732|Saules|BE",
+    "name": "Saules",
+    "zipCode": "2732",
+    "canton": "BE"
+  },
+  {
+    "id": "3054|Saurenhorn|BE",
+    "name": "Saurenhorn",
+    "zipCode": "3054",
+    "canton": "BE"
+  },
+  {
+    "id": "1290|Sauverny|GE",
+    "name": "Sauverny",
+    "zipCode": "1290",
+    "canton": "GE"
+  },
+  {
+    "id": "2065|Savagnier|NE",
+    "name": "Savagnier",
+    "zipCode": "2065",
+    "canton": "NE"
+  },
+  {
+    "id": "1073|Savigny|VD",
+    "name": "Savigny",
+    "zipCode": "1073",
+    "canton": "VD"
+  },
+  {
+    "id": "7460|Savognin|GR",
+    "name": "Savognin",
+    "zipCode": "7460",
+    "canton": "GR"
+  },
+  {
+    "id": "6942|Savosa|TI",
+    "name": "Savosa",
+    "zipCode": "6942",
+    "canton": "TI"
+  },
+  {
+    "id": "1095|Savuit|VD",
+    "name": "Savuit",
+    "zipCode": "1095",
+    "canton": "VD"
+  },
+  {
+    "id": "9468|Sax|SG",
+    "name": "Sax",
+    "zipCode": "9468",
+    "canton": "SG"
+  },
+  {
+    "id": "1926|Saxé|VS",
+    "name": "Saxé",
+    "zipCode": "1926",
+    "canton": "VS"
+  },
+  {
+    "id": "3813|Saxeten|BE",
+    "name": "Saxeten",
+    "zipCode": "3813",
+    "canton": "BE"
+  },
+  {
+    "id": "8894|Saxli|SG",
+    "name": "Saxli",
+    "zipCode": "8894",
+    "canton": "SG"
+  },
+  {
+    "id": "1907|Saxon|VS",
+    "name": "Saxon",
+    "zipCode": "1907",
+    "canton": "VS"
+  },
+  {
+    "id": "1966|Saxonne|VS",
+    "name": "Saxonne",
+    "zipCode": "1966",
+    "canton": "VS"
+  },
+  {
+    "id": "7202|Says|GR",
+    "name": "Says",
+    "zipCode": "7202",
+    "canton": "GR"
+  },
+  {
+    "id": "6578|Scaiano|TI",
+    "name": "Scaiano",
+    "zipCode": "6578",
+    "canton": "TI"
+  },
+  {
+    "id": "6951|Scareglia|TI",
+    "name": "Scareglia",
+    "zipCode": "6951",
+    "canton": "TI"
+  },
+  {
+    "id": "2855|Sceut|JU",
+    "name": "Sceut",
+    "zipCode": "2855",
+    "canton": "JU"
+  },
+  {
+    "id": "4653|Schachen|SO",
+    "name": "Schachen",
+    "zipCode": "4653",
+    "canton": "SO"
+  },
+  {
+    "id": "6105|Schachen|LU",
+    "name": "Schachen",
+    "zipCode": "6105",
+    "canton": "LU"
+  },
+  {
+    "id": "6436|Schachen|SZ",
+    "name": "Schachen",
+    "zipCode": "6436",
+    "canton": "SZ"
+  },
+  {
+    "id": "8906|Schachen|ZH",
+    "name": "Schachen",
+    "zipCode": "8906",
+    "canton": "ZH"
+  },
+  {
+    "id": "9112|Schachen bei Herisau|AR",
+    "name": "Schachen bei Herisau",
+    "zipCode": "9112",
+    "canton": "AR"
+  },
+  {
+    "id": "9414|Schachen bei Reute|AR",
+    "name": "Schachen bei Reute",
+    "zipCode": "9414",
+    "canton": "AR"
+  },
+  {
+    "id": "8200|Schaffhausen|SH",
+    "name": "Schaffhausen",
+    "zipCode": "8200",
+    "canton": "SH"
+  },
+  {
+    "id": "3415|Schafhausen im Emmental|BE",
+    "name": "Schafhausen im Emmental",
+    "zipCode": "3415",
+    "canton": "BE"
+  },
+  {
+    "id": "2514|Schafis|BE",
+    "name": "Schafis",
+    "zipCode": "2514",
+    "canton": "BE"
+  },
+  {
+    "id": "5503|Schafisheim|AG",
+    "name": "Schafisheim",
+    "zipCode": "5503",
+    "canton": "AG"
+  },
+  {
+    "id": "8492|Schalchen|ZH",
+    "name": "Schalchen",
+    "zipCode": "8492",
+    "canton": "ZH"
+  },
+  {
+    "id": "9533|Schalkhusen|SG",
+    "name": "Schalkhusen",
+    "zipCode": "9533",
+    "canton": "SG"
+  },
+  {
+    "id": "3314|Schalunen|BE",
+    "name": "Schalunen",
+    "zipCode": "3314",
+    "canton": "BE"
+  },
+  {
+    "id": "6197|Schangnau|BE",
+    "name": "Schangnau",
+    "zipCode": "6197",
+    "canton": "BE"
+  },
+  {
+    "id": "8718|Schänis|SG",
+    "name": "Schänis",
+    "zipCode": "8718",
+    "canton": "SG"
+  },
+  {
+    "id": "7412|Scharans|GR",
+    "name": "Scharans",
+    "zipCode": "7412",
+    "canton": "GR"
+  },
+  {
+    "id": "6196|Schärlig|LU",
+    "name": "Schärlig",
+    "zipCode": "6196",
+    "canton": "LU"
+  },
+  {
+    "id": "3722|Scharnachtal|BE",
+    "name": "Scharnachtal",
+    "zipCode": "3722",
+    "canton": "BE"
+  },
+  {
+    "id": "6467|Schattdorf|UR",
+    "name": "Schattdorf",
+    "zipCode": "6467",
+    "canton": "UR"
+  },
+  {
+    "id": "3860|Schattenhalb|BE",
+    "name": "Schattenhalb",
+    "zipCode": "3860",
+    "canton": "BE"
+  },
+  {
+    "id": "7270|Schatzalp|GR",
+    "name": "Schatzalp",
+    "zipCode": "7270",
+    "canton": "GR"
+  },
+  {
+    "id": "7421|Schauenberg|GR",
+    "name": "Schauenberg",
+    "zipCode": "7421",
+    "canton": "GR"
+  },
+  {
+    "id": "7419|Scheid|GR",
+    "name": "Scheid",
+    "zipCode": "7419",
+    "canton": "GR"
+  },
+  {
+    "id": "2827|Schelten|BE",
+    "name": "Schelten",
+    "zipCode": "2827",
+    "canton": "BE"
+  },
+  {
+    "id": "6214|Schenkon|LU",
+    "name": "Schenkon",
+    "zipCode": "6214",
+    "canton": "LU"
+  },
+  {
+    "id": "2514|Schernelz|BE",
+    "name": "Schernelz",
+    "zipCode": "2514",
+    "canton": "BE"
+  },
+  {
+    "id": "5246|Scherz|AG",
+    "name": "Scherz",
+    "zipCode": "5246",
+    "canton": "AG"
+  },
+  {
+    "id": "8596|Scherzingen|TG",
+    "name": "Scherzingen",
+    "zipCode": "8596",
+    "canton": "TG"
+  },
+  {
+    "id": "3305|Scheunen|BE",
+    "name": "Scheunen",
+    "zipCode": "3305",
+    "canton": "BE"
+  },
+  {
+    "id": "3251|Scheunenberg|BE",
+    "name": "Scheunenberg",
+    "zipCode": "3251",
+    "canton": "BE"
+  },
+  {
+    "id": "2556|Scheuren|BE",
+    "name": "Scheuren",
+    "zipCode": "2556",
+    "canton": "BE"
+  },
+  {
+    "id": "7220|Schiers|GR",
+    "name": "Schiers",
+    "zipCode": "7220",
+    "canton": "GR"
+  },
+  {
+    "id": "5046|Schiltwald|AG",
+    "name": "Schiltwald",
+    "zipCode": "5046",
+    "canton": "AG"
+  },
+  {
+    "id": "8834|Schindellegi|SZ",
+    "name": "Schindellegi",
+    "zipCode": "8834",
+    "canton": "SZ"
+  },
+  {
+    "id": "5116|Schinznach-Bad|AG",
+    "name": "Schinznach-Bad",
+    "zipCode": "5116",
+    "canton": "AG"
+  },
+  {
+    "id": "5107|Schinznach-Dorf|AG",
+    "name": "Schinznach-Dorf",
+    "zipCode": "5107",
+    "canton": "AG"
+  },
+  {
+    "id": "7168|Schlans|GR",
+    "name": "Schlans",
+    "zipCode": "7168",
+    "canton": "GR"
+  },
+  {
+    "id": "9050|Schlatt|AI",
+    "name": "Schlatt",
+    "zipCode": "9050",
+    "canton": "AI"
+  },
+  {
+    "id": "8252|Schlatt (TG)|TG",
+    "name": "Schlatt (TG)",
+    "zipCode": "8252",
+    "canton": "TG"
+  },
+  {
+    "id": "5316|Schlatt bei Leuggern|AG",
+    "name": "Schlatt bei Leuggern",
+    "zipCode": "5316",
+    "canton": "AG"
+  },
+  {
+    "id": "8418|Schlatt bei Winterthur|ZH",
+    "name": "Schlatt bei Winterthur",
+    "zipCode": "8418",
+    "canton": "ZH"
+  },
+  {
+    "id": "8255|Schlattingen|TG",
+    "name": "Schlattingen",
+    "zipCode": "8255",
+    "canton": "TG"
+  },
+  {
+    "id": "8165|Schleinikon|ZH",
+    "name": "Schleinikon",
+    "zipCode": "8165",
+    "canton": "ZH"
+  },
+  {
+    "id": "8226|Schleitheim|SH",
+    "name": "Schleitheim",
+    "zipCode": "8226",
+    "canton": "SH"
+  },
+  {
+    "id": "3325|Schleumen|BE",
+    "name": "Schleumen",
+    "zipCode": "3325",
+    "canton": "BE"
+  },
+  {
+    "id": "6231|Schlierbach|LU",
+    "name": "Schlierbach",
+    "zipCode": "6231",
+    "canton": "LU"
+  },
+  {
+    "id": "8952|Schlieren|ZH",
+    "name": "Schlieren",
+    "zipCode": "8952",
+    "canton": "ZH"
+  },
+  {
+    "id": "3098|Schliern bei Köniz|BE",
+    "name": "Schliern bei Köniz",
+    "zipCode": "3098",
+    "canton": "BE"
+  },
+  {
+    "id": "5044|Schlossrued|AG",
+    "name": "Schlossrued",
+    "zipCode": "5044",
+    "canton": "AG"
+  },
+  {
+    "id": "3082|Schlosswil|BE",
+    "name": "Schlosswil",
+    "zipCode": "3082",
+    "canton": "BE"
+  },
+  {
+    "id": "7151|Schluein|GR",
+    "name": "Schluein",
+    "zipCode": "7151",
+    "canton": "GR"
+  },
+  {
+    "id": "8716|Schmerikon|SG",
+    "name": "Schmerikon",
+    "zipCode": "8716",
+    "canton": "SG"
+  },
+  {
+    "id": "3464|Schmidigen|BE",
+    "name": "Schmidigen",
+    "zipCode": "3464",
+    "canton": "BE"
+  },
+  {
+    "id": "8495|Schmidrüti|ZH",
+    "name": "Schmidrüti",
+    "zipCode": "8495",
+    "canton": "ZH"
+  },
+  {
+    "id": "9565|Schmidshof|TG",
+    "name": "Schmidshof",
+    "zipCode": "9565",
+    "canton": "TG"
+  },
+  {
+    "id": "5046|Schmiedrued|AG",
+    "name": "Schmiedrued",
+    "zipCode": "5046",
+    "canton": "AG"
+  },
+  {
+    "id": "3185|Schmitten|FR",
+    "name": "Schmitten",
+    "zipCode": "3185",
+    "canton": "FR"
+  },
+  {
+    "id": "7212|Schmitten|GR",
+    "name": "Schmitten",
+    "zipCode": "7212",
+    "canton": "GR"
+  },
+  {
+    "id": "7493|Schmitten|GR",
+    "name": "Schmitten",
+    "zipCode": "7493",
+    "canton": "GR"
+  },
+  {
+    "id": "9444|Schmitter|SG",
+    "name": "Schmitter",
+    "zipCode": "9444",
+    "canton": "SG"
+  },
+  {
+    "id": "8352|Schnasberg|ZH",
+    "name": "Schnasberg",
+    "zipCode": "8352",
+    "canton": "ZH"
+  },
+  {
+    "id": "7130|Schnaus|GR",
+    "name": "Schnaus",
+    "zipCode": "7130",
+    "canton": "GR"
+  },
+  {
+    "id": "5425|Schneisingen|AG",
+    "name": "Schneisingen",
+    "zipCode": "5425",
+    "canton": "AG"
+  },
+  {
+    "id": "3253|Schnottwil|SO",
+    "name": "Schnottwil",
+    "zipCode": "3253",
+    "canton": "SO"
+  },
+  {
+    "id": "8581|Schocherswil|TG",
+    "name": "Schocherswil",
+    "zipCode": "8581",
+    "canton": "TG"
+  },
+  {
+    "id": "8165|Schöfflisdorf|ZH",
+    "name": "Schöfflisdorf",
+    "zipCode": "8165",
+    "canton": "ZH"
+  },
+  {
+    "id": "5040|Schöftland|AG",
+    "name": "Schöftland",
+    "zipCode": "5040",
+    "canton": "AG"
+  },
+  {
+    "id": "3322|Schönbühl|BE",
+    "name": "Schönbühl",
+    "zipCode": "3322",
+    "canton": "BE"
+  },
+  {
+    "id": "8585|Schönenbaumgarten|TG",
+    "name": "Schönenbaumgarten",
+    "zipCode": "8585",
+    "canton": "TG"
+  },
+  {
+    "id": "8824|Schönenberg|ZH",
+    "name": "Schönenberg",
+    "zipCode": "8824",
+    "canton": "ZH"
+  },
+  {
+    "id": "9215|Schönenberg an der Thur|TG",
+    "name": "Schönenberg an der Thur",
+    "zipCode": "9215",
+    "canton": "TG"
+  },
+  {
+    "id": "4124|Schönenbuch|BL",
+    "name": "Schönenbuch",
+    "zipCode": "4124",
+    "canton": "BL"
+  },
+  {
+    "id": "9105|Schönengrund|AR",
+    "name": "Schönengrund",
+    "zipCode": "9105",
+    "canton": "AR"
+  },
+  {
+    "id": "5012|Schönenwerd|SO",
+    "name": "Schönenwerd",
+    "zipCode": "5012",
+    "canton": "SO"
+  },
+  {
+    "id": "6288|Schongau|LU",
+    "name": "Schongau",
+    "zipCode": "6288",
+    "canton": "LU"
+  },
+  {
+    "id": "8577|Schönholzerswilen|TG",
+    "name": "Schönholzerswilen",
+    "zipCode": "8577",
+    "canton": "TG"
+  },
+  {
+    "id": "3778|Schönried|BE",
+    "name": "Schönried",
+    "zipCode": "3778",
+    "canton": "BE"
+  },
+  {
+    "id": "4414|Schöntal|BL",
+    "name": "Schöntal",
+    "zipCode": "4414",
+    "canton": "BL"
+  },
+  {
+    "id": "8802|Schooren|ZH",
+    "name": "Schooren",
+    "zipCode": "8802",
+    "canton": "ZH"
+  },
+  {
+    "id": "3600|Schoren|BE",
+    "name": "Schoren",
+    "zipCode": "3600",
+    "canton": "BE"
+  },
+  {
+    "id": "4900|Schoren|BE",
+    "name": "Schoren",
+    "zipCode": "4900",
+    "canton": "BE"
+  },
+  {
+    "id": "5642|Schoren|AG",
+    "name": "Schoren",
+    "zipCode": "5642",
+    "canton": "AG"
+  },
+  {
+    "id": "6055|Schoried|OW",
+    "name": "Schoried",
+    "zipCode": "6055",
+    "canton": "OW"
+  },
+  {
+    "id": "3000|Schosshalde|BE",
+    "name": "Schosshalde",
+    "zipCode": "3000",
+    "canton": "BE"
+  },
+  {
+    "id": "8352|Schottikon|ZH",
+    "name": "Schottikon",
+    "zipCode": "8352",
+    "canton": "ZH"
+  },
+  {
+    "id": "6247|Schötz|LU",
+    "name": "Schötz",
+    "zipCode": "6247",
+    "canton": "LU"
+  },
+  {
+    "id": "8580|Schrofen|TG",
+    "name": "Schrofen",
+    "zipCode": "8580",
+    "canton": "TG"
+  },
+  {
+    "id": "8862|Schübelbach|SZ",
+    "name": "Schübelbach",
+    "zipCode": "8862",
+    "canton": "SZ"
+  },
+  {
+    "id": "7228|Schuders|GR",
+    "name": "Schuders",
+    "zipCode": "7228",
+    "canton": "GR"
+  },
+  {
+    "id": "3535|Schüpbach|BE",
+    "name": "Schüpbach",
+    "zipCode": "3535",
+    "canton": "BE"
+  },
+  {
+    "id": "3054|Schüpberg|BE",
+    "name": "Schüpberg",
+    "zipCode": "3054",
+    "canton": "BE"
+  },
+  {
+    "id": "4325|Schupfart|AG",
+    "name": "Schupfart",
+    "zipCode": "4325",
+    "canton": "AG"
+  },
+  {
+    "id": "3054|Schüpfen|BE",
+    "name": "Schüpfen",
+    "zipCode": "3054",
+    "canton": "BE"
+  },
+  {
+    "id": "6170|Schüpfheim|LU",
+    "name": "Schüpfheim",
+    "zipCode": "6170",
+    "canton": "LU"
+  },
+  {
+    "id": "8374|Schurten|TG",
+    "name": "Schurten",
+    "zipCode": "8374",
+    "canton": "TG"
+  },
+  {
+    "id": "3613|Schwäbis|BE",
+    "name": "Schwäbis",
+    "zipCode": "3613",
+    "canton": "BE"
+  },
+  {
+    "id": "5326|Schwaderloch|AG",
+    "name": "Schwaderloch",
+    "zipCode": "5326",
+    "canton": "AG"
+  },
+  {
+    "id": "8566|Schwaderloh|TG",
+    "name": "Schwaderloh",
+    "zipCode": "8566",
+    "canton": "TG"
+  },
+  {
+    "id": "2556|Schwadernau|BE",
+    "name": "Schwadernau",
+    "zipCode": "2556",
+    "canton": "BE"
+  },
+  {
+    "id": "9107|Schwägalp (Säntis)|AR",
+    "name": "Schwägalp (Säntis)",
+    "zipCode": "9107",
+    "canton": "AR"
+  },
+  {
+    "id": "8051|Schwamendingen|ZH",
+    "name": "Schwamendingen",
+    "zipCode": "8051",
+    "canton": "ZH"
+  },
+  {
+    "id": "3634|Schwand|BE",
+    "name": "Schwand",
+    "zipCode": "3634",
+    "canton": "BE"
+  },
+  {
+    "id": "8762|Schwanden|GL",
+    "name": "Schwanden",
+    "zipCode": "8762",
+    "canton": "GL"
+  },
+  {
+    "id": "3855|Schwanden bei Brienz|BE",
+    "name": "Schwanden bei Brienz",
+    "zipCode": "3855",
+    "canton": "BE"
+  },
+  {
+    "id": "3054|Schwanden bei Schüpfen|BE",
+    "name": "Schwanden bei Schüpfen",
+    "zipCode": "3054",
+    "canton": "BE"
+  },
+  {
+    "id": "3657|Schwanden bei Sigriswil|BE",
+    "name": "Schwanden bei Sigriswil",
+    "zipCode": "3657",
+    "canton": "BE"
+  },
+  {
+    "id": "3433|Schwanden im Emmental|BE",
+    "name": "Schwanden im Emmental",
+    "zipCode": "3433",
+    "canton": "BE"
+  },
+  {
+    "id": "8762|Schwändi bei Schwanden|GL",
+    "name": "Schwändi bei Schwanden",
+    "zipCode": "8762",
+    "canton": "GL"
+  },
+  {
+    "id": "4953|Schwarzenbach|BE",
+    "name": "Schwarzenbach",
+    "zipCode": "4953",
+    "canton": "BE"
+  },
+  {
+    "id": "6215|Schwarzenbach|LU",
+    "name": "Schwarzenbach",
+    "zipCode": "6215",
+    "canton": "LU"
+  },
+  {
+    "id": "9536|Schwarzenbach|SG",
+    "name": "Schwarzenbach",
+    "zipCode": "9536",
+    "canton": "SG"
+  },
+  {
+    "id": "6103|Schwarzenberg|LU",
+    "name": "Schwarzenberg",
+    "zipCode": "6103",
+    "canton": "LU"
+  },
+  {
+    "id": "3156|Schwarzenbühl|BE",
+    "name": "Schwarzenbühl",
+    "zipCode": "3156",
+    "canton": "BE"
+  },
+  {
+    "id": "3150|Schwarzenburg|BE",
+    "name": "Schwarzenburg",
+    "zipCode": "3150",
+    "canton": "BE"
+  },
+  {
+    "id": "3616|Schwarzenegg|BE",
+    "name": "Schwarzenegg",
+    "zipCode": "3616",
+    "canton": "BE"
+  },
+  {
+    "id": "3766|Schwarzenmatt|BE",
+    "name": "Schwarzenmatt",
+    "zipCode": "3766",
+    "canton": "BE"
+  },
+  {
+    "id": "4911|Schwarzhäusern|BE",
+    "name": "Schwarzhäusern",
+    "zipCode": "4911",
+    "canton": "BE"
+  },
+  {
+    "id": "1716|Schwarzsee|FR",
+    "name": "Schwarzsee",
+    "zipCode": "1716",
+    "canton": "FR"
+  },
+  {
+    "id": "1738|Schwefelberg Bad|BE",
+    "name": "Schwefelberg Bad",
+    "zipCode": "1738",
+    "canton": "BE"
+  },
+  {
+    "id": "8506|Schweikhof|TG",
+    "name": "Schweikhof",
+    "zipCode": "8506",
+    "canton": "TG"
+  },
+  {
+    "id": "8925|Schweikhof|ZH",
+    "name": "Schweikhof",
+    "zipCode": "8925",
+    "canton": "ZH"
+  },
+  {
+    "id": "4953|Schweinbrunnen|BE",
+    "name": "Schweinbrunnen",
+    "zipCode": "4953",
+    "canton": "BE"
+  },
+  {
+    "id": "4133|Schweizerhalle|BL",
+    "name": "Schweizerhalle",
+    "zipCode": "4133",
+    "canton": "BL"
+  },
+  {
+    "id": "9223|Schweizersholz|TG",
+    "name": "Schweizersholz",
+    "zipCode": "9223",
+    "canton": "TG"
+  },
+  {
+    "id": "9103|Schwellbrunn|AR",
+    "name": "Schwellbrunn",
+    "zipCode": "9103",
+    "canton": "AR"
+  },
+  {
+    "id": "9057|Schwende|AI",
+    "name": "Schwende",
+    "zipCode": "9057",
+    "canton": "AI"
+  },
+  {
+    "id": "3757|Schwenden|BE",
+    "name": "Schwenden",
+    "zipCode": "3757",
+    "canton": "BE"
+  },
+  {
+    "id": "8486|Schwendi|ZH",
+    "name": "Schwendi",
+    "zipCode": "8486",
+    "canton": "ZH"
+  },
+  {
+    "id": "9658|Schwendi|SG",
+    "name": "Schwendi",
+    "zipCode": "9658",
+    "canton": "SG"
+  },
+  {
+    "id": "9405|Schwendi bei Heiden|AR",
+    "name": "Schwendi bei Heiden",
+    "zipCode": "9405",
+    "canton": "AR"
+  },
+  {
+    "id": "3625|Schwendi bei Thun|BE",
+    "name": "Schwendi bei Thun",
+    "zipCode": "3625",
+    "canton": "BE"
+  },
+  {
+    "id": "7325|Schwendi im Weisstannental|SG",
+    "name": "Schwendi im Weisstannental",
+    "zipCode": "7325",
+    "canton": "SG"
+  },
+  {
+    "id": "3624|Schwendibach|BE",
+    "name": "Schwendibach",
+    "zipCode": "3624",
+    "canton": "BE"
+  },
+  {
+    "id": "8603|Schwerzenbach|ZH",
+    "name": "Schwerzenbach",
+    "zipCode": "8603",
+    "canton": "ZH"
+  },
+  {
+    "id": "6430|Schwyz|SZ",
+    "name": "Schwyz",
+    "zipCode": "6430",
+    "canton": "SZ"
+  },
+  {
+    "id": "3800|Schynige Platte|BE",
+    "name": "Schynige Platte",
+    "zipCode": "3800",
+    "canton": "BE"
+  },
+  {
+    "id": "6702|Scubiago|TI",
+    "name": "Scubiago",
+    "zipCode": "6702",
+    "canton": "TI"
+  },
+  {
+    "id": "6838|Scudellate|TI",
+    "name": "Scudellate",
+    "zipCode": "6838",
+    "canton": "TI"
+  },
+  {
+    "id": "7402|Sculms|GR",
+    "name": "Sculms",
+    "zipCode": "7402",
+    "canton": "GR"
+  },
+  {
+    "id": "7550|Scuol|GR",
+    "name": "Scuol",
+    "zipCode": "7550",
+    "canton": "GR"
+  },
+  {
+    "id": "1200|Sécheron|GE",
+    "name": "Sécheron",
+    "zipCode": "1200",
+    "canton": "GE"
+  },
+  {
+    "id": "1554|Sédeilles|VD",
+    "name": "Sédeilles",
+    "zipCode": "1554",
+    "canton": "VD"
+  },
+  {
+    "id": "6020|Sedel|LU",
+    "name": "Sedel",
+    "zipCode": "6020",
+    "canton": "LU"
+  },
+  {
+    "id": "7188|Sedrun|GR",
+    "name": "Sedrun",
+    "zipCode": "7188",
+    "canton": "GR"
+  },
+  {
+    "id": "8185|Seeb|ZH",
+    "name": "Seeb",
+    "zipCode": "8185",
+    "canton": "ZH"
+  },
+  {
+    "id": "8052|Seebach|ZH",
+    "name": "Seebach",
+    "zipCode": "8052",
+    "canton": "ZH"
+  },
+  {
+    "id": "3365|Seeberg|BE",
+    "name": "Seeberg",
+    "zipCode": "3365",
+    "canton": "BE"
+  },
+  {
+    "id": "3267|Seedorf|BE",
+    "name": "Seedorf",
+    "zipCode": "3267",
+    "canton": "BE"
+  },
+  {
+    "id": "6462|Seedorf|UR",
+    "name": "Seedorf",
+    "zipCode": "6462",
+    "canton": "UR"
+  },
+  {
+    "id": "8607|Seegräben|ZH",
+    "name": "Seegräben",
+    "zipCode": "8607",
+    "canton": "ZH"
+  },
+  {
+    "id": "2747|Seehof|BE",
+    "name": "Seehof",
+    "zipCode": "2747",
+    "canton": "BE"
+  },
+  {
+    "id": "6377|Seelisberg|UR",
+    "name": "Seelisberg",
+    "zipCode": "6377",
+    "canton": "UR"
+  },
+  {
+    "id": "8488|Seelmatte|ZH",
+    "name": "Seelmatte",
+    "zipCode": "8488",
+    "canton": "ZH"
+  },
+  {
+    "id": "8400|Seen|ZH",
+    "name": "Seen",
+    "zipCode": "8400",
+    "canton": "ZH"
+  },
+  {
+    "id": "5707|Seengen|AG",
+    "name": "Seengen",
+    "zipCode": "5707",
+    "canton": "AG"
+  },
+  {
+    "id": "6203|Seesatz|LU",
+    "name": "Seesatz",
+    "zipCode": "6203",
+    "canton": "LU"
+  },
+  {
+    "id": "4206|Seewen|SO",
+    "name": "Seewen",
+    "zipCode": "4206",
+    "canton": "SO"
+  },
+  {
+    "id": "6423|Seewen|SZ",
+    "name": "Seewen",
+    "zipCode": "6423",
+    "canton": "SZ"
+  },
+  {
+    "id": "3256|Seewil|BE",
+    "name": "Seewil",
+    "zipCode": "3256",
+    "canton": "BE"
+  },
+  {
+    "id": "7212|Seewis Dorf|GR",
+    "name": "Seewis Dorf",
+    "zipCode": "7212",
+    "canton": "GR"
+  },
+  {
+    "id": "7212|Seewis im Prättigau|GR",
+    "name": "Seewis im Prättigau",
+    "zipCode": "7212",
+    "canton": "GR"
+  },
+  {
+    "id": "3047|Seftau|BE",
+    "name": "Seftau",
+    "zipCode": "3047",
+    "canton": "BE"
+  },
+  {
+    "id": "3662|Seftigen|BE",
+    "name": "Seftigen",
+    "zipCode": "3662",
+    "canton": "BE"
+  },
+  {
+    "id": "8193|Seglingen|ZH",
+    "name": "Seglingen",
+    "zipCode": "8193",
+    "canton": "ZH"
+  },
+  {
+    "id": "7186|Segnas|GR",
+    "name": "Segnas",
+    "zipCode": "7186",
+    "canton": "GR"
+  },
+  {
+    "id": "2883|Seigne|JU",
+    "name": "Seigne",
+    "zipCode": "2883",
+    "canton": "JU"
+  },
+  {
+    "id": "1525|Seigneux|VD",
+    "name": "Seigneux",
+    "zipCode": "1525",
+    "canton": "VD"
+  },
+  {
+    "id": "1470|Seiry|FR",
+    "name": "Seiry",
+    "zipCode": "1470",
+    "canton": "FR"
+  },
+  {
+    "id": "2888|Seleute|JU",
+    "name": "Seleute",
+    "zipCode": "2888",
+    "canton": "JU"
+  },
+  {
+    "id": "7250|Selfranga|GR",
+    "name": "Selfranga",
+    "zipCode": "7250",
+    "canton": "GR"
+  },
+  {
+    "id": "3989|Selkingen|VS",
+    "name": "Selkingen",
+    "zipCode": "3989",
+    "canton": "VS"
+  },
+  {
+    "id": "8143|Sellenbüren|ZH",
+    "name": "Sellenbüren",
+    "zipCode": "8143",
+    "canton": "ZH"
+  },
+  {
+    "id": "6545|Selma|GR",
+    "name": "Selma",
+    "zipCode": "6545",
+    "canton": "GR"
+  },
+  {
+    "id": "4411|Seltisberg|BL",
+    "name": "Seltisberg",
+    "zipCode": "4411",
+    "canton": "BL"
+  },
+  {
+    "id": "7189|Selva|GR",
+    "name": "Selva",
+    "zipCode": "7189",
+    "canton": "GR"
+  },
+  {
+    "id": "2545|Selzach|SO",
+    "name": "Selzach",
+    "zipCode": "2545",
+    "canton": "SO"
+  },
+  {
+    "id": "1933|Sembrancher|VS",
+    "name": "Sembrancher",
+    "zipCode": "1933",
+    "canton": "VS"
+  },
+  {
+    "id": "6514|Sementina|TI",
+    "name": "Sementina",
+    "zipCode": "6514",
+    "canton": "TI"
+  },
+  {
+    "id": "6714|Semione|TI",
+    "name": "Semione",
+    "zipCode": "6714",
+    "canton": "TI"
+  },
+  {
+    "id": "6204|Sempach|LU",
+    "name": "Sempach",
+    "zipCode": "6204",
+    "canton": "LU"
+  },
+  {
+    "id": "6203|Sempach Station|LU",
+    "name": "Sempach Station",
+    "zipCode": "6203",
+    "canton": "LU"
+  },
+  {
+    "id": "1623|Semsales|FR",
+    "name": "Semsales",
+    "zipCode": "1623",
+    "canton": "FR"
+  },
+  {
+    "id": "1304|Senarclens|VD",
+    "name": "Senarclens",
+    "zipCode": "1304",
+    "canton": "VD"
+  },
+  {
+    "id": "1724|Senèdes|FR",
+    "name": "Senèdes",
+    "zipCode": "1724",
+    "canton": "FR"
+  },
+  {
+    "id": "4852|Sennhof|AG",
+    "name": "Sennhof",
+    "zipCode": "4852",
+    "canton": "AG"
+  },
+  {
+    "id": "8482|Sennhof|ZH",
+    "name": "Sennhof",
+    "zipCode": "8482",
+    "canton": "ZH"
+  },
+  {
+    "id": "8332|Sennhof bei Russikon|ZH",
+    "name": "Sennhof bei Russikon",
+    "zipCode": "8332",
+    "canton": "ZH"
+  },
+  {
+    "id": "9466|Sennwald|SG",
+    "name": "Sennwald",
+    "zipCode": "9466",
+    "canton": "SG"
+  },
+  {
+    "id": "1975|Sensine|VS",
+    "name": "Sensine",
+    "zipCode": "1975",
+    "canton": "VS"
+  },
+  {
+    "id": "7554|Sent|GR",
+    "name": "Sent",
+    "zipCode": "7554",
+    "canton": "GR"
+  },
+  {
+    "id": "5630|Sentenhof|AG",
+    "name": "Sentenhof",
+    "zipCode": "5630",
+    "canton": "AG"
+  },
+  {
+    "id": "5703|Seon|AG",
+    "name": "Seon",
+    "zipCode": "5703",
+    "canton": "AG"
+  },
+  {
+    "id": "2857|Séprais|JU",
+    "name": "Séprais",
+    "zipCode": "2857",
+    "canton": "JU"
+  },
+  {
+    "id": "7558|Seraplana|GR",
+    "name": "Seraplana",
+    "zipCode": "7558",
+    "canton": "GR"
+  },
+  {
+    "id": "6834|Serfontana|TI",
+    "name": "Serfontana",
+    "zipCode": "6834",
+    "canton": "TI"
+  },
+  {
+    "id": "1355|Sergey|VD",
+    "name": "Sergey",
+    "zipCode": "1355",
+    "canton": "VD"
+  },
+  {
+    "id": "1607|Serix|VD",
+    "name": "Serix",
+    "zipCode": "1607",
+    "canton": "VD"
+  },
+  {
+    "id": "1412|Sermuz|VD",
+    "name": "Sermuz",
+    "zipCode": "1412",
+    "canton": "VD"
+  },
+  {
+    "id": "7249|Serneus|GR",
+    "name": "Serneus",
+    "zipCode": "7249",
+    "canton": "GR"
+  },
+  {
+    "id": "7249|Serneus Station|GR",
+    "name": "Serneus Station",
+    "zipCode": "7249",
+    "canton": "GR"
+  },
+  {
+    "id": "6982|Serocca|TI",
+    "name": "Serocca",
+    "zipCode": "6982",
+    "canton": "TI"
+  },
+  {
+    "id": "6867|Serpiano|TI",
+    "name": "Serpiano",
+    "zipCode": "6867",
+    "canton": "TI"
+  },
+  {
+    "id": "2000|Serrières|NE",
+    "name": "Serrières",
+    "zipCode": "2000",
+    "canton": "NE"
+  },
+  {
+    "id": "2037|Serroue|NE",
+    "name": "Serroue",
+    "zipCode": "2037",
+    "canton": "NE"
+  },
+  {
+    "id": "7272|Sertig Dörfli|GR",
+    "name": "Sertig Dörfli",
+    "zipCode": "7272",
+    "canton": "GR"
+  },
+  {
+    "id": "1077|Servion|VD",
+    "name": "Servion",
+    "zipCode": "1077",
+    "canton": "VD"
+  },
+  {
+    "id": "6832|Seseglio|TI",
+    "name": "Seseglio",
+    "zipCode": "6832",
+    "canton": "TI"
+  },
+  {
+    "id": "6997|Sessa|TI",
+    "name": "Sessa",
+    "zipCode": "6997",
+    "canton": "TI"
+  },
+  {
+    "id": "8472|Seuzach|ZH",
+    "name": "Seuzach",
+    "zipCode": "8472",
+    "canton": "ZH"
+  },
+  {
+    "id": "1541|Sévaz|FR",
+    "name": "Sévaz",
+    "zipCode": "1541",
+    "canton": "FR"
+  },
+  {
+    "id": "9475|Sevelen|SG",
+    "name": "Sevelen",
+    "zipCode": "9475",
+    "canton": "SG"
+  },
+  {
+    "id": "1141|Sévery|VD",
+    "name": "Sévery",
+    "zipCode": "1141",
+    "canton": "VD"
+  },
+  {
+    "id": "7127|Sevgein|GR",
+    "name": "Sevgein",
+    "zipCode": "7127",
+    "canton": "GR"
+  },
+  {
+    "id": "1285|Sézegnin|GE",
+    "name": "Sézegnin",
+    "zipCode": "1285",
+    "canton": "GE"
+  },
+  {
+    "id": "1233|Sézenove|GE",
+    "name": "Sézenove",
+    "zipCode": "1233",
+    "canton": "GE"
+  },
+  {
+    "id": "7742|Sfazù|GR",
+    "name": "Sfazù",
+    "zipCode": "7742",
+    "canton": "GR"
+  },
+  {
+    "id": "7157|Siat|GR",
+    "name": "Siat",
+    "zipCode": "7157",
+    "canton": "GR"
+  },
+  {
+    "id": "8225|Siblingen|SH",
+    "name": "Siblingen",
+    "zipCode": "8225",
+    "canton": "SH"
+  },
+  {
+    "id": "8854|Siebnen|SZ",
+    "name": "Siebnen",
+    "zipCode": "8854",
+    "canton": "SZ"
+  },
+  {
+    "id": "8573|Siegershausen|TG",
+    "name": "Siegershausen",
+    "zipCode": "8573",
+    "canton": "TG"
+  },
+  {
+    "id": "1255|Sierne|GE",
+    "name": "Sierne",
+    "zipCode": "1255",
+    "canton": "GE"
+  },
+  {
+    "id": "3960|Sierre|VS",
+    "name": "Sierre",
+    "zipCode": "3960",
+    "canton": "VS"
+  },
+  {
+    "id": "5301|Siggenthal Station|AG",
+    "name": "Siggenthal Station",
+    "zipCode": "5301",
+    "canton": "AG"
+  },
+  {
+    "id": "6019|Sigigen|LU",
+    "name": "Sigigen",
+    "zipCode": "6019",
+    "canton": "LU"
+  },
+  {
+    "id": "6806|Sigirino|TI",
+    "name": "Sigirino",
+    "zipCode": "6806",
+    "canton": "TI"
+  },
+  {
+    "id": "5462|Siglistorf|AG",
+    "name": "Siglistorf",
+    "zipCode": "5462",
+    "canton": "AG"
+  },
+  {
+    "id": "1172|Signal-de-Bougy|VD",
+    "name": "Signal-de-Bougy",
+    "zipCode": "1172",
+    "canton": "VD"
+  },
+  {
+    "id": "3534|Signau|BE",
+    "name": "Signau",
+    "zipCode": "3534",
+    "canton": "BE"
+  },
+  {
+    "id": "1966|Signèse|VS",
+    "name": "Signèse",
+    "zipCode": "1966",
+    "canton": "VS"
+  },
+  {
+    "id": "6951|Signôra|TI",
+    "name": "Signôra",
+    "zipCode": "6951",
+    "canton": "TI"
+  },
+  {
+    "id": "1274|Signy|VD",
+    "name": "Signy",
+    "zipCode": "1274",
+    "canton": "VD"
+  },
+  {
+    "id": "3655|Sigriswil|BE",
+    "name": "Sigriswil",
+    "zipCode": "3655",
+    "canton": "BE"
+  },
+  {
+    "id": "6340|Sihlbrugg|ZH",
+    "name": "Sihlbrugg",
+    "zipCode": "6340",
+    "canton": "ZH"
+  },
+  {
+    "id": "6340|Sihlbrugg|ZG",
+    "name": "Sihlbrugg",
+    "zipCode": "6340",
+    "canton": "ZG"
+  },
+  {
+    "id": "8135|Sihlbrugg Station|ZH",
+    "name": "Sihlbrugg Station",
+    "zipCode": "8135",
+    "canton": "ZH"
+  },
+  {
+    "id": "8135|Sihlwald|ZH",
+    "name": "Sihlwald",
+    "zipCode": "8135",
+    "canton": "ZH"
+  },
+  {
+    "id": "6473|Silenen|UR",
+    "name": "Silenen",
+    "zipCode": "6473",
+    "canton": "UR"
+  },
+  {
+    "id": "7411|Sils im Domleschg|GR",
+    "name": "Sils im Domleschg",
+    "zipCode": "7411",
+    "canton": "GR"
+  },
+  {
+    "id": "7515|Sils im Engadin|GR",
+    "name": "Sils im Engadin",
+    "zipCode": "7515",
+    "canton": "GR"
+  },
+  {
+    "id": "7515|Sils/Segl Baselgia|GR",
+    "name": "Sils/Segl Baselgia",
+    "zipCode": "7515",
+    "canton": "GR"
+  },
+  {
+    "id": "7514|Sils/Segl Maria|GR",
+    "name": "Sils/Segl Maria",
+    "zipCode": "7514",
+    "canton": "GR"
+  },
+  {
+    "id": "7513|Silvaplana|GR",
+    "name": "Silvaplana",
+    "zipCode": "7513",
+    "canton": "GR"
+  },
+  {
+    "id": "7513|Silvaplana-Surlej|GR",
+    "name": "Silvaplana-Surlej",
+    "zipCode": "7513",
+    "canton": "GR"
+  },
+  {
+    "id": "3907|Simplon Hospiz|VS",
+    "name": "Simplon Hospiz",
+    "zipCode": "3907",
+    "canton": "VS"
+  },
+  {
+    "id": "3907|Simplon-Dorf|VS",
+    "name": "Simplon-Dorf",
+    "zipCode": "3907",
+    "canton": "VS"
+  },
+  {
+    "id": "3067|Sinneringen|BE",
+    "name": "Sinneringen",
+    "zipCode": "3067",
+    "canton": "BE"
+  },
+  {
+    "id": "5643|Sins|AG",
+    "name": "Sins",
+    "zipCode": "5643",
+    "canton": "AG"
+  },
+  {
+    "id": "1950|Sion|VS",
+    "name": "Sion",
+    "zipCode": "1950",
+    "canton": "VS"
+  },
+  {
+    "id": "8370|Sirnach|TG",
+    "name": "Sirnach",
+    "zipCode": "8370",
+    "canton": "TG"
+  },
+  {
+    "id": "2577|Siselen|BE",
+    "name": "Siselen",
+    "zipCode": "2577",
+    "canton": "BE"
+  },
+  {
+    "id": "6452|Sisikon|UR",
+    "name": "Sisikon",
+    "zipCode": "6452",
+    "canton": "UR"
+  },
+  {
+    "id": "4450|Sissach|BL",
+    "name": "Sissach",
+    "zipCode": "4450",
+    "canton": "BL"
+  },
+  {
+    "id": "4334|Sisseln|AG",
+    "name": "Sisseln",
+    "zipCode": "4334",
+    "canton": "AG"
+  },
+  {
+    "id": "8589|Sitterdorf|TG",
+    "name": "Sitterdorf",
+    "zipCode": "8589",
+    "canton": "TG"
+  },
+  {
+    "id": "9220|Sittertal|TG",
+    "name": "Sittertal",
+    "zipCode": "9220",
+    "canton": "TG"
+  },
+  {
+    "id": "8495|Sitzberg|ZH",
+    "name": "Sitzberg",
+    "zipCode": "8495",
+    "canton": "ZH"
+  },
+  {
+    "id": "1997|Siviez|VS",
+    "name": "Siviez",
+    "zipCode": "1997",
+    "canton": "VS"
+  },
+  {
+    "id": "1678|Siviriez|FR",
+    "name": "Siviriez",
+    "zipCode": "1678",
+    "canton": "FR"
+  },
+  {
+    "id": "6562|Soazza|GR",
+    "name": "Soazza",
+    "zipCode": "6562",
+    "canton": "GR"
+  },
+  {
+    "id": "6749|Sobrio|TI",
+    "name": "Sobrio",
+    "zipCode": "6749",
+    "canton": "TI"
+  },
+  {
+    "id": "7610|Soglio|GR",
+    "name": "Soglio",
+    "zipCode": "7610",
+    "canton": "GR"
+  },
+  {
+    "id": "1882|Solalex|VD",
+    "name": "Solalex",
+    "zipCode": "1882",
+    "canton": "VD"
+  },
+  {
+    "id": "6600|Solduno|TI",
+    "name": "Solduno",
+    "zipCode": "6600",
+    "canton": "TI"
+  },
+  {
+    "id": "8197|Solgen|ZH",
+    "name": "Solgen",
+    "zipCode": "8197",
+    "canton": "ZH"
+  },
+  {
+    "id": "7450|Solis|GR",
+    "name": "Solis",
+    "zipCode": "7450",
+    "canton": "GR"
+  },
+  {
+    "id": "4500|Solothurn|SO",
+    "name": "Solothurn",
+    "zipCode": "4500",
+    "canton": "SO"
+  },
+  {
+    "id": "6872|Somazzo|TI",
+    "name": "Somazzo",
+    "zipCode": "6872",
+    "canton": "TI"
+  },
+  {
+    "id": "2605|Sombeval|BE",
+    "name": "Sombeval",
+    "zipCode": "2605",
+    "canton": "BE"
+  },
+  {
+    "id": "6674|Someo|TI",
+    "name": "Someo",
+    "zipCode": "6674",
+    "canton": "TI"
+  },
+  {
+    "id": "1937|Somlaproz|VS",
+    "name": "Somlaproz",
+    "zipCode": "1937",
+    "canton": "VS"
+  },
+  {
+    "id": "1688|Sommentier|FR",
+    "name": "Sommentier",
+    "zipCode": "1688",
+    "canton": "FR"
+  },
+  {
+    "id": "4444|Sommerau|BL",
+    "name": "Sommerau",
+    "zipCode": "4444",
+    "canton": "BL"
+  },
+  {
+    "id": "8580|Sommeri|TG",
+    "name": "Sommeri",
+    "zipCode": "8580",
+    "canton": "TG"
+  },
+  {
+    "id": "2605|Sonceboz|BE",
+    "name": "Sonceboz",
+    "zipCode": "2605",
+    "canton": "BE"
+  },
+  {
+    "id": "9507|Sonnenberg|TG",
+    "name": "Sonnenberg",
+    "zipCode": "9507",
+    "canton": "TG"
+  },
+  {
+    "id": "8311|Sonnenbühl|ZH",
+    "name": "Sonnenbühl",
+    "zipCode": "8311",
+    "canton": "ZH"
+  },
+  {
+    "id": "9245|Sonnental|SG",
+    "name": "Sonnental",
+    "zipCode": "9245",
+    "canton": "SG"
+  },
+  {
+    "id": "6637|Sonogno|TI",
+    "name": "Sonogno",
+    "zipCode": "6637",
+    "canton": "TI"
+  },
+  {
+    "id": "8564|Sonterswil|TG",
+    "name": "Sonterswil",
+    "zipCode": "8564",
+    "canton": "TG"
+  },
+  {
+    "id": "7130|Sontga Clau|GR",
+    "name": "Sontga Clau",
+    "zipCode": "7130",
+    "canton": "GR"
+  },
+  {
+    "id": "6968|Sonvico|TI",
+    "name": "Sonvico",
+    "zipCode": "6968",
+    "canton": "TI"
+  },
+  {
+    "id": "2615|Sonvilier|BE",
+    "name": "Sonvilier",
+    "zipCode": "2615",
+    "canton": "BE"
+  },
+  {
+    "id": "1822|Sonzier|VD",
+    "name": "Sonzier",
+    "zipCode": "1822",
+    "canton": "VD"
+  },
+  {
+    "id": "8134|Sood|ZH",
+    "name": "Sood",
+    "zipCode": "8134",
+    "canton": "ZH"
+  },
+  {
+    "id": "8762|Sool|GL",
+    "name": "Sool",
+    "zipCode": "8762",
+    "canton": "GL"
+  },
+  {
+    "id": "6964|Soragno|TI",
+    "name": "Soragno",
+    "zipCode": "6964",
+    "canton": "TI"
+  },
+  {
+    "id": "1286|Soral|GE",
+    "name": "Soral",
+    "zipCode": "1286",
+    "canton": "GE"
+  },
+  {
+    "id": "6174|Sörenberg|LU",
+    "name": "Sörenberg",
+    "zipCode": "6174",
+    "canton": "LU"
+  },
+  {
+    "id": "6802|Sorencino|TI",
+    "name": "Sorencino",
+    "zipCode": "6802",
+    "canton": "TI"
+  },
+  {
+    "id": "6924|Sorengo|TI",
+    "name": "Sorengo",
+    "zipCode": "6924",
+    "canton": "TI"
+  },
+  {
+    "id": "1642|Sorens|FR",
+    "name": "Sorens",
+    "zipCode": "1642",
+    "canton": "FR"
+  },
+  {
+    "id": "9213|Sorental bei Hauptwil|SG",
+    "name": "Sorental bei Hauptwil",
+    "zipCode": "9213",
+    "canton": "SG"
+  },
+  {
+    "id": "6802|Soresina|TI",
+    "name": "Soresina",
+    "zipCode": "6802",
+    "canton": "TI"
+  },
+  {
+    "id": "1997|Sornard|VS",
+    "name": "Sornard",
+    "zipCode": "1997",
+    "canton": "VS"
+  },
+  {
+    "id": "2716|Sornetan|BE",
+    "name": "Sornetan",
+    "zipCode": "2716",
+    "canton": "BE"
+  },
+  {
+    "id": "6694|Sornico|TI",
+    "name": "Sornico",
+    "zipCode": "6694",
+    "canton": "TI"
+  },
+  {
+    "id": "2736|Sorvilier|BE",
+    "name": "Sorvilier",
+    "zipCode": "2736",
+    "canton": "BE"
+  },
+  {
+    "id": "1062|Sottens|VD",
+    "name": "Sottens",
+    "zipCode": "1062",
+    "canton": "VD"
+  },
+  {
+    "id": "2887|Soubey|JU",
+    "name": "Soubey",
+    "zipCode": "2887",
+    "canton": "JU"
+  },
+  {
+    "id": "1937|Soulalex|VS",
+    "name": "Soulalex",
+    "zipCode": "1937",
+    "canton": "VS"
+  },
+  {
+    "id": "2864|Soulce|JU",
+    "name": "Soulce",
+    "zipCode": "2864",
+    "canton": "JU"
+  },
+  {
+    "id": "3961|Soussillon|VS",
+    "name": "Soussillon",
+    "zipCode": "3961",
+    "canton": "VS"
+  },
+  {
+    "id": "2805|Soyhières|JU",
+    "name": "Soyhières",
+    "zipCode": "2805",
+    "canton": "JU"
+  },
+  {
+    "id": "7553|Sparsels|GR",
+    "name": "Sparsels",
+    "zipCode": "7553",
+    "canton": "GR"
+  },
+  {
+    "id": "9042|Speicher|AR",
+    "name": "Speicher",
+    "zipCode": "9042",
+    "canton": "AR"
+  },
+  {
+    "id": "9037|Speicherschwendi|AR",
+    "name": "Speicherschwendi",
+    "zipCode": "9037",
+    "canton": "AR"
+  },
+  {
+    "id": "3204|Spengelried|BE",
+    "name": "Spengelried",
+    "zipCode": "3204",
+    "canton": "BE"
+  },
+  {
+    "id": "3095|Spiegel bei Bern|BE",
+    "name": "Spiegel bei Bern",
+    "zipCode": "3095",
+    "canton": "BE"
+  },
+  {
+    "id": "3700|Spiez|BE",
+    "name": "Spiez",
+    "zipCode": "3700",
+    "canton": "BE"
+  },
+  {
+    "id": "3700|Spiezmoos|BE",
+    "name": "Spiezmoos",
+    "zipCode": "3700",
+    "canton": "BE"
+  },
+  {
+    "id": "3700|Spiezwiler|BE",
+    "name": "Spiezwiler",
+    "zipCode": "3700",
+    "canton": "BE"
+  },
+  {
+    "id": "7502|Spinas|GR",
+    "name": "Spinas",
+    "zipCode": "7502",
+    "canton": "GR"
+  },
+  {
+    "id": "3270|Spins|BE",
+    "name": "Spins",
+    "zipCode": "3270",
+    "canton": "BE"
+  },
+  {
+    "id": "3803|Spirenwald|BE",
+    "name": "Spirenwald",
+    "zipCode": "3803",
+    "canton": "BE"
+  },
+  {
+    "id": "6464|Spiringen|UR",
+    "name": "Spiringen",
+    "zipCode": "6464",
+    "canton": "UR"
+  },
+  {
+    "id": "8590|Spitz|TG",
+    "name": "Spitz",
+    "zipCode": "8590",
+    "canton": "TG"
+  },
+  {
+    "id": "2516|Spitzberg|BE",
+    "name": "Spitzberg",
+    "zipCode": "2516",
+    "canton": "BE"
+  },
+  {
+    "id": "8816|Spitzen|ZH",
+    "name": "Spitzen",
+    "zipCode": "8816",
+    "canton": "ZH"
+  },
+  {
+    "id": "7435|Splügen|GR",
+    "name": "Splügen",
+    "zipCode": "7435",
+    "canton": "GR"
+  },
+  {
+    "id": "7078|Sporz|GR",
+    "name": "Sporz",
+    "zipCode": "7078",
+    "canton": "GR"
+  },
+  {
+    "id": "8957|Spreitenbach|AG",
+    "name": "Spreitenbach",
+    "zipCode": "8957",
+    "canton": "AG"
+  },
+  {
+    "id": "6663|Spruga|TI",
+    "name": "Spruga",
+    "zipCode": "6663",
+    "canton": "TI"
+  },
+  {
+    "id": "1566|St-Aubin|FR",
+    "name": "St-Aubin",
+    "zipCode": "1566",
+    "canton": "FR"
+  },
+  {
+    "id": "2024|St-Aubin|NE",
+    "name": "St-Aubin",
+    "zipCode": "2024",
+    "canton": "NE"
+  },
+  {
+    "id": "1040|St-Barthélemy|VD",
+    "name": "St-Barthélemy",
+    "zipCode": "1040",
+    "canton": "VD"
+  },
+  {
+    "id": "2072|St-Blaise|NE",
+    "name": "St-Blaise",
+    "zipCode": "2072",
+    "canton": "NE"
+  },
+  {
+    "id": "2364|St-Brais|JU",
+    "name": "St-Brais",
+    "zipCode": "2364",
+    "canton": "JU"
+  },
+  {
+    "id": "1264|St-Cergue|VD",
+    "name": "St-Cergue",
+    "zipCode": "1264",
+    "canton": "VD"
+  },
+  {
+    "id": "1410|St-Cierges|VD",
+    "name": "St-Cierges",
+    "zipCode": "1410",
+    "canton": "VD"
+  },
+  {
+    "id": "1117|St-Denis|VD",
+    "name": "St-Denis",
+    "zipCode": "1117",
+    "canton": "VD"
+  },
+  {
+    "id": "1188|St-George|VD",
+    "name": "St-George",
+    "zipCode": "1188",
+    "canton": "VD"
+  },
+  {
+    "id": "1213|St-Georges|GE",
+    "name": "St-Georges",
+    "zipCode": "1213",
+    "canton": "GE"
+  },
+  {
+    "id": "1898|St-Gingolph|VS",
+    "name": "St-Gingolph",
+    "zipCode": "1898",
+    "canton": "VS"
+  },
+  {
+    "id": "2610|St-Imier|BE",
+    "name": "St-Imier",
+    "zipCode": "2610",
+    "canton": "BE"
+  },
+  {
+    "id": "3961|St-Jean|VS",
+    "name": "St-Jean",
+    "zipCode": "3961",
+    "canton": "VS"
+  },
+  {
+    "id": "1806|St-Légier|VD",
+    "name": "St-Légier",
+    "zipCode": "1806",
+    "canton": "VD"
+  },
+  {
+    "id": "1958|St-Léonard|VS",
+    "name": "St-Léonard",
+    "zipCode": "1958",
+    "canton": "VS"
+  },
+  {
+    "id": "1176|St-Livres|VD",
+    "name": "St-Livres",
+    "zipCode": "1176",
+    "canton": "VD"
+  },
+  {
+    "id": "1318|St-Loup|VD",
+    "name": "St-Loup",
+    "zipCode": "1318",
+    "canton": "VD"
+  },
+  {
+    "id": "3961|St-Luc|VS",
+    "name": "St-Luc",
+    "zipCode": "3961",
+    "canton": "VS"
+  },
+  {
+    "id": "1609|St-Martin|FR",
+    "name": "St-Martin",
+    "zipCode": "1609",
+    "canton": "FR"
+  },
+  {
+    "id": "1969|St-Martin|VS",
+    "name": "St-Martin",
+    "zipCode": "1969",
+    "canton": "VS"
+  },
+  {
+    "id": "2054|St-Martin|NE",
+    "name": "St-Martin",
+    "zipCode": "2054",
+    "canton": "NE"
+  },
+  {
+    "id": "1222|St-Maurice|GE",
+    "name": "St-Maurice",
+    "zipCode": "1222",
+    "canton": "GE"
+  },
+  {
+    "id": "1424|St-Maurice|VD",
+    "name": "St-Maurice",
+    "zipCode": "1424",
+    "canton": "VD"
+  },
+  {
+    "id": "1890|St-Maurice|VS",
+    "name": "St-Maurice",
+    "zipCode": "1890",
+    "canton": "VS"
+  },
+  {
+    "id": "1187|St-Oyens|VD",
+    "name": "St-Oyens",
+    "zipCode": "1187",
+    "canton": "VD"
+  },
+  {
+    "id": "1955|St-Pierre-de-Clages|VS",
+    "name": "St-Pierre-de-Clages",
+    "zipCode": "1955",
+    "canton": "VS"
+  },
+  {
+    "id": "1162|St-Prex|VD",
+    "name": "St-Prex",
+    "zipCode": "1162",
+    "canton": "VD"
+  },
+  {
+    "id": "1966|St-Romain|VS",
+    "name": "St-Romain",
+    "zipCode": "1966",
+    "canton": "VS"
+  },
+  {
+    "id": "1071|St-Saphorin (Lavaux)|VD",
+    "name": "St-Saphorin (Lavaux)",
+    "zipCode": "1071",
+    "canton": "VD"
+  },
+  {
+    "id": "1113|St-Saphorin-sur-Morges|VD",
+    "name": "St-Saphorin-sur-Morges",
+    "zipCode": "1113",
+    "canton": "VD"
+  },
+  {
+    "id": "1975|St-Séverin|VS",
+    "name": "St-Séverin",
+    "zipCode": "1975",
+    "canton": "VS"
+  },
+  {
+    "id": "1025|St-Sulpice|VD",
+    "name": "St-Sulpice",
+    "zipCode": "1025",
+    "canton": "VD"
+  },
+  {
+    "id": "2123|St-Sulpice|NE",
+    "name": "St-Sulpice",
+    "zipCode": "2123",
+    "canton": "NE"
+  },
+  {
+    "id": "1867|St-Triphon|VD",
+    "name": "St-Triphon",
+    "zipCode": "1867",
+    "canton": "VD"
+  },
+  {
+    "id": "2882|St-Ursanne|JU",
+    "name": "St-Ursanne",
+    "zipCode": "2882",
+    "canton": "JU"
+  },
+  {
+    "id": "4000|St. Alban|BS",
+    "name": "St. Alban",
+    "zipCode": "4000",
+    "canton": "BS"
+  },
+  {
+    "id": "1713|St. Antoni|FR",
+    "name": "St. Antoni",
+    "zipCode": "1713",
+    "canton": "FR"
+  },
+  {
+    "id": "7246|St. Antönien|GR",
+    "name": "St. Antönien",
+    "zipCode": "7246",
+    "canton": "GR"
+  },
+  {
+    "id": "4126|St. Chrischona|BS",
+    "name": "St. Chrischona",
+    "zipCode": "4126",
+    "canton": "BS"
+  },
+  {
+    "id": "6212|St. Erhard|LU",
+    "name": "St. Erhard",
+    "zipCode": "6212",
+    "canton": "LU"
+  },
+  {
+    "id": "9000|St. Fiden|SG",
+    "name": "St. Fiden",
+    "zipCode": "9000",
+    "canton": "SG"
+  },
+  {
+    "id": "9000|St. Gallen|SG",
+    "name": "St. Gallen",
+    "zipCode": "9000",
+    "canton": "SG"
+  },
+  {
+    "id": "8735|St. Gallenkappel|SG",
+    "name": "St. Gallenkappel",
+    "zipCode": "8735",
+    "canton": "SG"
+  },
+  {
+    "id": "9000|St. Georgen|SG",
+    "name": "St. Georgen",
+    "zipCode": "9000",
+    "canton": "SG"
+  },
+  {
+    "id": "1965|St. Germain|VS",
+    "name": "St. Germain",
+    "zipCode": "1965",
+    "canton": "VS"
+  },
+  {
+    "id": "3942|St. German|VS",
+    "name": "St. German",
+    "zipCode": "3942",
+    "canton": "VS"
+  },
+  {
+    "id": "6372|St. Jakob|NW",
+    "name": "St. Jakob",
+    "zipCode": "6372",
+    "canton": "NW"
+  },
+  {
+    "id": "4000|St. Johann|BS",
+    "name": "St. Johann",
+    "zipCode": "4000",
+    "canton": "BS"
+  },
+  {
+    "id": "2525|St. Johannsen|BE",
+    "name": "St. Johannsen",
+    "zipCode": "2525",
+    "canton": "BE"
+  },
+  {
+    "id": "9030|St. Josefen|SG",
+    "name": "St. Josefen",
+    "zipCode": "9030",
+    "canton": "SG"
+  },
+  {
+    "id": "8253|St. Katharinental|TG",
+    "name": "St. Katharinental",
+    "zipCode": "8253",
+    "canton": "TG"
+  },
+  {
+    "id": "9620|St. Loretto|SG",
+    "name": "St. Loretto",
+    "zipCode": "9620",
+    "canton": "SG"
+  },
+  {
+    "id": "7304|St. Luzisteig|GR",
+    "name": "St. Luzisteig",
+    "zipCode": "7304",
+    "canton": "GR"
+  },
+  {
+    "id": "9543|St. Margarethen|TG",
+    "name": "St. Margarethen",
+    "zipCode": "9543",
+    "canton": "TG"
+  },
+  {
+    "id": "9430|St. Margrethen|SG",
+    "name": "St. Margrethen",
+    "zipCode": "9430",
+    "canton": "SG"
+  },
+  {
+    "id": "7313|St. Margrethenberg|SG",
+    "name": "St. Margrethenberg",
+    "zipCode": "7313",
+    "canton": "SG"
+  },
+  {
+    "id": "7116|St. Martin|GR",
+    "name": "St. Martin",
+    "zipCode": "7116",
+    "canton": "GR"
+  },
+  {
+    "id": "7500|St. Moritz|GR",
+    "name": "St. Moritz",
+    "zipCode": "7500",
+    "canton": "GR"
+  },
+  {
+    "id": "7500|St. Moritz Bad|GR",
+    "name": "St. Moritz Bad",
+    "zipCode": "7500",
+    "canton": "GR"
+  },
+  {
+    "id": "3924|St. Niklaus|VS",
+    "name": "St. Niklaus",
+    "zipCode": "3924",
+    "canton": "VS"
+  },
+  {
+    "id": "4532|St. Niklaus|SO",
+    "name": "St. Niklaus",
+    "zipCode": "4532",
+    "canton": "SO"
+  },
+  {
+    "id": "3425|St. Niklaus bei Koppigen|BE",
+    "name": "St. Niklaus bei Koppigen",
+    "zipCode": "3425",
+    "canton": "BE"
+  },
+  {
+    "id": "3274|St. Niklaus bei Merzligen|BE",
+    "name": "St. Niklaus bei Merzligen",
+    "zipCode": "3274",
+    "canton": "BE"
+  },
+  {
+    "id": "6005|St. Niklausen|LU",
+    "name": "St. Niklausen",
+    "zipCode": "6005",
+    "canton": "LU"
+  },
+  {
+    "id": "6066|St. Niklausen|OW",
+    "name": "St. Niklausen",
+    "zipCode": "6066",
+    "canton": "OW"
+  },
+  {
+    "id": "4421|St. Pantaleon|SO",
+    "name": "St. Pantaleon",
+    "zipCode": "4421",
+    "canton": "SO"
+  },
+  {
+    "id": "9225|St. Pelagiberg|TG",
+    "name": "St. Pelagiberg",
+    "zipCode": "9225",
+    "canton": "TG"
+  },
+  {
+    "id": "7028|St. Peter|GR",
+    "name": "St. Peter",
+    "zipCode": "7028",
+    "canton": "GR"
+  },
+  {
+    "id": "3235|St. Petersinsel|BE",
+    "name": "St. Petersinsel",
+    "zipCode": "3235",
+    "canton": "BE"
+  },
+  {
+    "id": "9127|St. Peterzell|SG",
+    "name": "St. Peterzell",
+    "zipCode": "9127",
+    "canton": "SG"
+  },
+  {
+    "id": "1736|St. Silvester|FR",
+    "name": "St. Silvester",
+    "zipCode": "1736",
+    "canton": "FR"
+  },
+  {
+    "id": "3772|St. Stephan|BE",
+    "name": "St. Stephan",
+    "zipCode": "3772",
+    "canton": "BE"
+  },
+  {
+    "id": "4915|St. Urban|LU",
+    "name": "St. Urban",
+    "zipCode": "4915",
+    "canton": "LU"
+  },
+  {
+    "id": "1717|St. Ursen|FR",
+    "name": "St. Ursen",
+    "zipCode": "1717",
+    "canton": "FR"
+  },
+  {
+    "id": "3186|St. Wolfgang|FR",
+    "name": "St. Wolfgang",
+    "zipCode": "3186",
+    "canton": "FR"
+  },
+  {
+    "id": "6546|Sta Domenica|GR",
+    "name": "Sta Domenica",
+    "zipCode": "6546",
+    "canton": "GR"
+  },
+  {
+    "id": "6541|Sta Maria in Calanca|GR",
+    "name": "Sta Maria in Calanca",
+    "zipCode": "6541",
+    "canton": "GR"
+  },
+  {
+    "id": "7536|Sta. Maria Val Müstair|GR",
+    "name": "Sta. Maria Val Müstair",
+    "zipCode": "7536",
+    "canton": "GR"
+  },
+  {
+    "id": "2540|Staad|SO",
+    "name": "Staad",
+    "zipCode": "2540",
+    "canton": "SO"
+  },
+  {
+    "id": "9422|Staad|SG",
+    "name": "Staad",
+    "zipCode": "9422",
+    "canton": "SG"
+  },
+  {
+    "id": "6855|Stabio|TI",
+    "name": "Stabio",
+    "zipCode": "6855",
+    "canton": "TI"
+  },
+  {
+    "id": "9320|Stachen|TG",
+    "name": "Stachen",
+    "zipCode": "9320",
+    "canton": "TG"
+  },
+  {
+    "id": "8272|Stad|TG",
+    "name": "Stad",
+    "zipCode": "8272",
+    "canton": "TG"
+  },
+  {
+    "id": "8404|Stadel|ZH",
+    "name": "Stadel",
+    "zipCode": "8404",
+    "canton": "ZH"
+  },
+  {
+    "id": "8174|Stadel bei Niederglatt|ZH",
+    "name": "Stadel bei Niederglatt",
+    "zipCode": "8174",
+    "canton": "ZH"
+  },
+  {
+    "id": "6383|Städtli|NW",
+    "name": "Städtli",
+    "zipCode": "6383",
+    "canton": "NW"
+  },
+  {
+    "id": "8712|Stäfa|ZH",
+    "name": "Stäfa",
+    "zipCode": "8712",
+    "canton": "ZH"
+  },
+  {
+    "id": "5053|Staffelbach|AG",
+    "name": "Staffelbach",
+    "zipCode": "5053",
+    "canton": "AG"
+  },
+  {
+    "id": "3922|Stalden|VS",
+    "name": "Stalden",
+    "zipCode": "3922",
+    "canton": "VS"
+  },
+  {
+    "id": "3932|Stalden|VS",
+    "name": "Stalden",
+    "zipCode": "3932",
+    "canton": "VS"
+  },
+  {
+    "id": "6063|Stalden|OW",
+    "name": "Stalden",
+    "zipCode": "6063",
+    "canton": "OW"
+  },
+  {
+    "id": "3510|Stalden im Emmental|BE",
+    "name": "Stalden im Emmental",
+    "zipCode": "3510",
+    "canton": "BE"
+  },
+  {
+    "id": "3933|Staldenried|VS",
+    "name": "Staldenried",
+    "zipCode": "3933",
+    "canton": "VS"
+  },
+  {
+    "id": "8143|Stallikon|ZH",
+    "name": "Stallikon",
+    "zipCode": "8143",
+    "canton": "ZH"
+  },
+  {
+    "id": "7605|Stampa|GR",
+    "name": "Stampa",
+    "zipCode": "7605",
+    "canton": "GR"
+  },
+  {
+    "id": "6370|Stans|NW",
+    "name": "Stans",
+    "zipCode": "6370",
+    "canton": "NW"
+  },
+  {
+    "id": "6362|Stansstad|NW",
+    "name": "Stansstad",
+    "zipCode": "6362",
+    "canton": "NW"
+  },
+  {
+    "id": "5452|Staretschwil|AG",
+    "name": "Staretschwil",
+    "zipCode": "5452",
+    "canton": "AG"
+  },
+  {
+    "id": "9656|Starkenbach|SG",
+    "name": "Starkenbach",
+    "zipCode": "9656",
+    "canton": "SG"
+  },
+  {
+    "id": "8717|Starrberg|SG",
+    "name": "Starrberg",
+    "zipCode": "8717",
+    "canton": "SG"
+  },
+  {
+    "id": "4656|Starrkirch|SO",
+    "name": "Starrkirch",
+    "zipCode": "4656",
+    "canton": "SO"
+  },
+  {
+    "id": "5603|Staufen|AG",
+    "name": "Staufen",
+    "zipCode": "5603",
+    "canton": "AG"
+  },
+  {
+    "id": "1450|Ste-Croix|VD",
+    "name": "Ste-Croix",
+    "zipCode": "1450",
+    "canton": "VD"
+  },
+  {
+    "id": "3824|Stechelberg|BE",
+    "name": "Stechelberg",
+    "zipCode": "3824",
+    "canton": "BE"
+  },
+  {
+    "id": "8266|Steckborn|TG",
+    "name": "Steckborn",
+    "zipCode": "8266",
+    "canton": "TG"
+  },
+  {
+    "id": "3612|Steffisburg|BE",
+    "name": "Steffisburg",
+    "zipCode": "3612",
+    "canton": "BE"
+  },
+  {
+    "id": "3613|Steffisburg|BE",
+    "name": "Steffisburg",
+    "zipCode": "3613",
+    "canton": "BE"
+  },
+  {
+    "id": "3940|Steg|VS",
+    "name": "Steg",
+    "zipCode": "3940",
+    "canton": "VS"
+  },
+  {
+    "id": "8496|Steg im Tösstal|ZH",
+    "name": "Steg im Tösstal",
+    "zipCode": "8496",
+    "canton": "ZH"
+  },
+  {
+    "id": "8543|Stegen bei Gachnang|ZH",
+    "name": "Stegen bei Gachnang",
+    "zipCode": "8543",
+    "canton": "ZH"
+  },
+  {
+    "id": "9503|Stehrenberg|TG",
+    "name": "Stehrenberg",
+    "zipCode": "9503",
+    "canton": "TG"
+  },
+  {
+    "id": "8354|Steig|ZH",
+    "name": "Steig",
+    "zipCode": "8354",
+    "canton": "ZH"
+  },
+  {
+    "id": "4332|Stein|AG",
+    "name": "Stein",
+    "zipCode": "4332",
+    "canton": "AG"
+  },
+  {
+    "id": "9063|Stein|AR",
+    "name": "Stein",
+    "zipCode": "9063",
+    "canton": "AR"
+  },
+  {
+    "id": "9655|Stein|SG",
+    "name": "Stein",
+    "zipCode": "9655",
+    "canton": "SG"
+  },
+  {
+    "id": "8260|Stein am Rhein|SH",
+    "name": "Stein am Rhein",
+    "zipCode": "8260",
+    "canton": "SH"
+  },
+  {
+    "id": "9323|Steinach|SG",
+    "name": "Steinach",
+    "zipCode": "9323",
+    "canton": "SG"
+  },
+  {
+    "id": "9314|Steinebrunn|TG",
+    "name": "Steinebrunn",
+    "zipCode": "9314",
+    "canton": "TG"
+  },
+  {
+    "id": "8536|Steinegg|TG",
+    "name": "Steinegg",
+    "zipCode": "8536",
+    "canton": "TG"
+  },
+  {
+    "id": "9050|Steinegg|AI",
+    "name": "Steinegg",
+    "zipCode": "9050",
+    "canton": "AI"
+  },
+  {
+    "id": "9320|Steineloh|TG",
+    "name": "Steineloh",
+    "zipCode": "9320",
+    "canton": "TG"
+  },
+  {
+    "id": "6422|Steinen|SZ",
+    "name": "Steinen",
+    "zipCode": "6422",
+    "canton": "SZ"
+  },
+  {
+    "id": "3534|Steinen bei Signau|BE",
+    "name": "Steinen bei Signau",
+    "zipCode": "3534",
+    "canton": "BE"
+  },
+  {
+    "id": "8499|Steinenbach hinteres Tal|ZH",
+    "name": "Steinenbach hinteres Tal",
+    "zipCode": "8499",
+    "canton": "ZH"
+  },
+  {
+    "id": "8492|Steinenbach vorderes Tal|ZH",
+    "name": "Steinenbach vorderes Tal",
+    "zipCode": "8492",
+    "canton": "ZH"
+  },
+  {
+    "id": "6416|Steinerberg|SZ",
+    "name": "Steinerberg",
+    "zipCode": "6416",
+    "canton": "SZ"
+  },
+  {
+    "id": "3860|Steingletscher|BE",
+    "name": "Steingletscher",
+    "zipCode": "3860",
+    "canton": "BE"
+  },
+  {
+    "id": "3995|Steinhaus|VS",
+    "name": "Steinhaus",
+    "zipCode": "3995",
+    "canton": "VS"
+  },
+  {
+    "id": "6312|Steinhausen|ZG",
+    "name": "Steinhausen",
+    "zipCode": "6312",
+    "canton": "ZG"
+  },
+  {
+    "id": "4556|Steinhof|SO",
+    "name": "Steinhof",
+    "zipCode": "4556",
+    "canton": "SO"
+  },
+  {
+    "id": "6114|Steinhuserberg|LU",
+    "name": "Steinhuserberg",
+    "zipCode": "6114",
+    "canton": "LU"
+  },
+  {
+    "id": "8162|Steinmaur|ZH",
+    "name": "Steinmaur",
+    "zipCode": "8162",
+    "canton": "ZH"
+  },
+  {
+    "id": "7226|Stels|GR",
+    "name": "Stels",
+    "zipCode": "7226",
+    "canton": "GR"
+  },
+  {
+    "id": "8499|Sternenberg|ZH",
+    "name": "Sternenberg",
+    "zipCode": "8499",
+    "canton": "ZH"
+  },
+  {
+    "id": "8600|Stettbach|ZH",
+    "name": "Stettbach",
+    "zipCode": "8600",
+    "canton": "ZH"
+  },
+  {
+    "id": "5608|Stetten|AG",
+    "name": "Stetten",
+    "zipCode": "5608",
+    "canton": "AG"
+  },
+  {
+    "id": "8234|Stetten|SH",
+    "name": "Stetten",
+    "zipCode": "8234",
+    "canton": "SH"
+  },
+  {
+    "id": "9507|Stettfurt|TG",
+    "name": "Stettfurt",
+    "zipCode": "9507",
+    "canton": "TG"
+  },
+  {
+    "id": "3066|Stettlen|BE",
+    "name": "Stettlen",
+    "zipCode": "3066",
+    "canton": "BE"
+  },
+  {
+    "id": "7459|Stierva|GR",
+    "name": "Stierva",
+    "zipCode": "7459",
+    "canton": "GR"
+  },
+  {
+    "id": "5233|Stilli|AG",
+    "name": "Stilli",
+    "zipCode": "5233",
+    "canton": "AG"
+  },
+  {
+    "id": "3632|Stocken|BE",
+    "name": "Stocken",
+    "zipCode": "3632",
+    "canton": "BE"
+  },
+  {
+    "id": "8842|Stöcken|SZ",
+    "name": "Stöcken",
+    "zipCode": "8842",
+    "canton": "SZ"
+  },
+  {
+    "id": "6433|Stoos|SZ",
+    "name": "Stoos",
+    "zipCode": "6433",
+    "canton": "SZ"
+  },
+  {
+    "id": "7558|Strada im Engadin|GR",
+    "name": "Strada im Engadin",
+    "zipCode": "7558",
+    "canton": "GR"
+  },
+  {
+    "id": "8500|Strass|TG",
+    "name": "Strass",
+    "zipCode": "8500",
+    "canton": "TG"
+  },
+  {
+    "id": "3600|Strättligen|BE",
+    "name": "Strättligen",
+    "zipCode": "3600",
+    "canton": "BE"
+  },
+  {
+    "id": "4802|Strengelbach|AG",
+    "name": "Strengelbach",
+    "zipCode": "4802",
+    "canton": "AG"
+  },
+  {
+    "id": "8514|Strohwilen|TG",
+    "name": "Strohwilen",
+    "zipCode": "8514",
+    "canton": "TG"
+  },
+  {
+    "id": "3037|Stuckishaus|BE",
+    "name": "Stuckishaus",
+    "zipCode": "3037",
+    "canton": "BE"
+  },
+  {
+    "id": "8845|Studen|SZ",
+    "name": "Studen",
+    "zipCode": "8845",
+    "canton": "SZ"
+  },
+  {
+    "id": "9472|Studen|SG",
+    "name": "Studen",
+    "zipCode": "9472",
+    "canton": "SG"
+  },
+  {
+    "id": "2557|Studen (BE)|BE",
+    "name": "Studen (BE)",
+    "zipCode": "2557",
+    "canton": "BE"
+  },
+  {
+    "id": "7482|Stugl/Stuls|GR",
+    "name": "Stugl/Stuls",
+    "zipCode": "7482",
+    "canton": "GR"
+  },
+  {
+    "id": "4655|Stüsslingen|SO",
+    "name": "Stüsslingen",
+    "zipCode": "4655",
+    "canton": "SO"
+  },
+  {
+    "id": "3262|Suberg|BE",
+    "name": "Suberg",
+    "zipCode": "3262",
+    "canton": "BE"
+  },
+  {
+    "id": "4553|Subingen|SO",
+    "name": "Subingen",
+    "zipCode": "4553",
+    "canton": "SO"
+  },
+  {
+    "id": "1433|Suchy|VD",
+    "name": "Suchy",
+    "zipCode": "1433",
+    "canton": "VD"
+  },
+  {
+    "id": "3618|Süderen|BE",
+    "name": "Süderen",
+    "zipCode": "3618",
+    "canton": "BE"
+  },
+  {
+    "id": "1969|Suen|VS",
+    "name": "Suen",
+    "zipCode": "1969",
+    "canton": "VS"
+  },
+  {
+    "id": "7434|Sufers|GR",
+    "name": "Sufers",
+    "zipCode": "7434",
+    "canton": "GR"
+  },
+  {
+    "id": "1786|Sugiez|FR",
+    "name": "Sugiez",
+    "zipCode": "1786",
+    "canton": "FR"
+  },
+  {
+    "id": "1043|Sugnens|VD",
+    "name": "Sugnens",
+    "zipCode": "1043",
+    "canton": "VD"
+  },
+  {
+    "id": "5034|Suhr|AG",
+    "name": "Suhr",
+    "zipCode": "5034",
+    "canton": "AG"
+  },
+  {
+    "id": "6997|Suino|TI",
+    "name": "Suino",
+    "zipCode": "6997",
+    "canton": "TI"
+  },
+  {
+    "id": "8583|Sulgen|TG",
+    "name": "Sulgen",
+    "zipCode": "8583",
+    "canton": "TG"
+  },
+  {
+    "id": "1036|Sullens|VD",
+    "name": "Sullens",
+    "zipCode": "1036",
+    "canton": "VD"
+  },
+  {
+    "id": "5085|Sulz|AG",
+    "name": "Sulz",
+    "zipCode": "5085",
+    "canton": "AG"
+  },
+  {
+    "id": "6284|Sulz|LU",
+    "name": "Sulz",
+    "zipCode": "6284",
+    "canton": "LU"
+  },
+  {
+    "id": "8545|Sulz|ZH",
+    "name": "Sulz",
+    "zipCode": "8545",
+    "canton": "ZH"
+  },
+  {
+    "id": "5444|Sulz bei Künten|AG",
+    "name": "Sulz bei Künten",
+    "zipCode": "5444",
+    "canton": "AG"
+  },
+  {
+    "id": "8614|Sulzbach|ZH",
+    "name": "Sulzbach",
+    "zipCode": "8614",
+    "canton": "ZH"
+  },
+  {
+    "id": "3454|Sumiswald|BE",
+    "name": "Sumiswald",
+    "zipCode": "3454",
+    "canton": "BE"
+  },
+  {
+    "id": "7421|Summaprada|GR",
+    "name": "Summaprada",
+    "zipCode": "7421",
+    "canton": "GR"
+  },
+  {
+    "id": "7175|Sumvitg|GR",
+    "name": "Sumvitg",
+    "zipCode": "7175",
+    "canton": "GR"
+  },
+  {
+    "id": "3800|Sundlauenen|BE",
+    "name": "Sundlauenen",
+    "zipCode": "3800",
+    "canton": "BE"
+  },
+  {
+    "id": "8162|Sünikon|ZH",
+    "name": "Sünikon",
+    "zipCode": "8162",
+    "canton": "ZH"
+  },
+  {
+    "id": "7456|Sur|GR",
+    "name": "Sur",
+    "zipCode": "7456",
+    "canton": "GR"
+  },
+  {
+    "id": "7554|Sur En|GR",
+    "name": "Sur En",
+    "zipCode": "7554",
+    "canton": "GR"
+  },
+  {
+    "id": "7472|Surava|GR",
+    "name": "Surava",
+    "zipCode": "7472",
+    "canton": "GR"
+  },
+  {
+    "id": "7115|Surcasti|GR",
+    "name": "Surcasti",
+    "zipCode": "7115",
+    "canton": "GR"
+  },
+  {
+    "id": "7138|Surcuolm|GR",
+    "name": "Surcuolm",
+    "zipCode": "7138",
+    "canton": "GR"
+  },
+  {
+    "id": "6953|Sureggio|TI",
+    "name": "Sureggio",
+    "zipCode": "6953",
+    "canton": "TI"
+  },
+  {
+    "id": "3204|Süri|BE",
+    "name": "Süri",
+    "zipCode": "3204",
+    "canton": "BE"
+  },
+  {
+    "id": "7148|Surin|GR",
+    "name": "Surin",
+    "zipCode": "7148",
+    "canton": "GR"
+  },
+  {
+    "id": "1528|Surpierre|FR",
+    "name": "Surpierre",
+    "zipCode": "1528",
+    "canton": "FR"
+  },
+  {
+    "id": "7173|Surrein|GR",
+    "name": "Surrein",
+    "zipCode": "7173",
+    "canton": "GR"
+  },
+  {
+    "id": "6210|Sursee|LU",
+    "name": "Sursee",
+    "zipCode": "6210",
+    "canton": "LU"
+  },
+  {
+    "id": "7526|Susauna|GR",
+    "name": "Susauna",
+    "zipCode": "7526",
+    "canton": "GR"
+  },
+  {
+    "id": "1437|Suscévaz|VD",
+    "name": "Suscévaz",
+    "zipCode": "1437",
+    "canton": "VD"
+  },
+  {
+    "id": "7542|Susch|GR",
+    "name": "Susch",
+    "zipCode": "7542",
+    "canton": "GR"
+  },
+  {
+    "id": "3952|Susten|VS",
+    "name": "Susten",
+    "zipCode": "3952",
+    "canton": "VS"
+  },
+  {
+    "id": "2572|Sutz|BE",
+    "name": "Sutz",
+    "zipCode": "2572",
+    "canton": "BE"
+  },
+  {
+    "id": "1510|Syens|VD",
+    "name": "Syens",
+    "zipCode": "1510",
+    "canton": "VD"
+  },
+  {
+    "id": "8492|Tablat|ZH",
+    "name": "Tablat",
+    "zipCode": "8492",
+    "canton": "ZH"
+  },
+  {
+    "id": "1712|Tafers|FR",
+    "name": "Tafers",
+    "zipCode": "1712",
+    "canton": "FR"
+  },
+  {
+    "id": "8317|Tagelswangen|ZH",
+    "name": "Tagelswangen",
+    "zipCode": "8317",
+    "canton": "ZH"
+  },
+  {
+    "id": "5522|Tägerig|AG",
+    "name": "Tägerig",
+    "zipCode": "5522",
+    "canton": "AG"
+  },
+  {
+    "id": "6473|Tägerlohn|UR",
+    "name": "Tägerlohn",
+    "zipCode": "6473",
+    "canton": "UR"
+  },
+  {
+    "id": "9554|Tägerschen|TG",
+    "name": "Tägerschen",
+    "zipCode": "9554",
+    "canton": "TG"
+  },
+  {
+    "id": "3111|Tägertschi|BE",
+    "name": "Tägertschi",
+    "zipCode": "3111",
+    "canton": "BE"
+  },
+  {
+    "id": "8274|Tägerwilen|TG",
+    "name": "Tägerwilen",
+    "zipCode": "8274",
+    "canton": "TG"
+  },
+  {
+    "id": "7015|Tamins|GR",
+    "name": "Tamins",
+    "zipCode": "7015",
+    "canton": "GR"
+  },
+  {
+    "id": "1896|Tanay|VS",
+    "name": "Tanay",
+    "zipCode": "1896",
+    "canton": "VS"
+  },
+  {
+    "id": "8356|Tänikon|TG",
+    "name": "Tänikon",
+    "zipCode": "8356",
+    "canton": "TG"
+  },
+  {
+    "id": "6214|Tann|LU",
+    "name": "Tann",
+    "zipCode": "6214",
+    "canton": "LU"
+  },
+  {
+    "id": "8632|Tann|ZH",
+    "name": "Tann",
+    "zipCode": "8632",
+    "canton": "ZH"
+  },
+  {
+    "id": "1295|Tannay|VD",
+    "name": "Tannay",
+    "zipCode": "1295",
+    "canton": "VD"
+  },
+  {
+    "id": "8820|Tanne bei Wädenswil|ZH",
+    "name": "Tanne bei Wädenswil",
+    "zipCode": "8820",
+    "canton": "ZH"
+  },
+  {
+    "id": "8374|Tannegg|TG",
+    "name": "Tannegg",
+    "zipCode": "8374",
+    "canton": "TG"
+  },
+  {
+    "id": "3068|Tannen|BE",
+    "name": "Tannen",
+    "zipCode": "3068",
+    "canton": "BE"
+  },
+  {
+    "id": "8603|Tannenboden|ZH",
+    "name": "Tannenboden",
+    "zipCode": "8603",
+    "canton": "ZH"
+  },
+  {
+    "id": "8898|Tannenbodenalp|SG",
+    "name": "Tannenbodenalp",
+    "zipCode": "8898",
+    "canton": "SG"
+  },
+  {
+    "id": "8897|Tannenheim|SG",
+    "name": "Tannenheim",
+    "zipCode": "8897",
+    "canton": "SG"
+  },
+  {
+    "id": "7553|Tarasp|GR",
+    "name": "Tarasp",
+    "zipCode": "7553",
+    "canton": "GR"
+  },
+  {
+    "id": "7422|Tartar|GR",
+    "name": "Tartar",
+    "zipCode": "7422",
+    "canton": "GR"
+  },
+  {
+    "id": "1180|Tartegnin|VD",
+    "name": "Tartegnin",
+    "zipCode": "1180",
+    "canton": "VD"
+  },
+  {
+    "id": "3929|Täsch|VS",
+    "name": "Täsch",
+    "zipCode": "3929",
+    "canton": "VS"
+  },
+  {
+    "id": "1617|Tatroz|FR",
+    "name": "Tatroz",
+    "zipCode": "1617",
+    "canton": "FR"
+  },
+  {
+    "id": "2575|Täuffelen|BE",
+    "name": "Täuffelen",
+    "zipCode": "2575",
+    "canton": "BE"
+  },
+  {
+    "id": "7162|Tavanasa|GR",
+    "name": "Tavanasa",
+    "zipCode": "7162",
+    "canton": "GR"
+  },
+  {
+    "id": "2710|Tavannes|BE",
+    "name": "Tavannes",
+    "zipCode": "2710",
+    "canton": "BE"
+  },
+  {
+    "id": "6807|Taverne|TI",
+    "name": "Taverne",
+    "zipCode": "6807",
+    "canton": "TI"
+  },
+  {
+    "id": "4492|Tecknau|BL",
+    "name": "Tecknau",
+    "zipCode": "4492",
+    "canton": "BL"
+  },
+  {
+    "id": "5306|Tegerfelden|AG",
+    "name": "Tegerfelden",
+    "zipCode": "5306",
+    "canton": "AG"
+  },
+  {
+    "id": "6652|Tegna|TI",
+    "name": "Tegna",
+    "zipCode": "6652",
+    "canton": "TI"
+  },
+  {
+    "id": "3714|Tellenfeld|BE",
+    "name": "Tellenfeld",
+    "zipCode": "3714",
+    "canton": "BE"
+  },
+  {
+    "id": "6598|Tenero|TI",
+    "name": "Tenero",
+    "zipCode": "6598",
+    "canton": "TI"
+  },
+  {
+    "id": "6760|Tengia|TI",
+    "name": "Tengia",
+    "zipCode": "6760",
+    "canton": "TI"
+  },
+  {
+    "id": "7173|Tenigerbad|GR",
+    "name": "Tenigerbad",
+    "zipCode": "7173",
+    "canton": "GR"
+  },
+  {
+    "id": "7106|Tenna|GR",
+    "name": "Tenna",
+    "zipCode": "7106",
+    "canton": "GR"
+  },
+  {
+    "id": "4456|Tenniken|BL",
+    "name": "Tenniken",
+    "zipCode": "4456",
+    "canton": "BL"
+  },
+  {
+    "id": "5617|Tennwil|AG",
+    "name": "Tennwil",
+    "zipCode": "5617",
+    "canton": "AG"
+  },
+  {
+    "id": "1734|Tentlingen|FR",
+    "name": "Tentlingen",
+    "zipCode": "1734",
+    "canton": "FR"
+  },
+  {
+    "id": "3912|Termen|VS",
+    "name": "Termen",
+    "zipCode": "3912",
+    "canton": "VS"
+  },
+  {
+    "id": "6998|Termine|TI",
+    "name": "Termine",
+    "zipCode": "6998",
+    "canton": "TI"
+  },
+  {
+    "id": "1820|Territet|VD",
+    "name": "Territet",
+    "zipCode": "1820",
+    "canton": "VD"
+  },
+  {
+    "id": "7116|Tersnaus|GR",
+    "name": "Tersnaus",
+    "zipCode": "7116",
+    "canton": "GR"
+  },
+  {
+    "id": "6950|Tesserete|TI",
+    "name": "Tesserete",
+    "zipCode": "6950",
+    "canton": "TI"
+  },
+  {
+    "id": "2052|Tête-de-Ran|NE",
+    "name": "Tête-de-Ran",
+    "zipCode": "2052",
+    "canton": "NE"
+  },
+  {
+    "id": "8428|Teufen|ZH",
+    "name": "Teufen",
+    "zipCode": "8428",
+    "canton": "ZH"
+  },
+  {
+    "id": "9053|Teufen|AR",
+    "name": "Teufen",
+    "zipCode": "9053",
+    "canton": "AR"
+  },
+  {
+    "id": "5723|Teufenthal|AG",
+    "name": "Teufenthal",
+    "zipCode": "5723",
+    "canton": "AG"
+  },
+  {
+    "id": "3623|Teuffenthal|BE",
+    "name": "Teuffenthal",
+    "zipCode": "3623",
+    "canton": "BE"
+  },
+  {
+    "id": "9425|Thal|SG",
+    "name": "Thal",
+    "zipCode": "9425",
+    "canton": "SG"
+  },
+  {
+    "id": "3432|Thalgraben|BE",
+    "name": "Thalgraben",
+    "zipCode": "3432",
+    "canton": "BE"
+  },
+  {
+    "id": "5112|Thalheim|AG",
+    "name": "Thalheim",
+    "zipCode": "5112",
+    "canton": "AG"
+  },
+  {
+    "id": "8478|Thalheim an der Thur|ZH",
+    "name": "Thalheim an der Thur",
+    "zipCode": "8478",
+    "canton": "ZH"
+  },
+  {
+    "id": "7109|Thalkirch|GR",
+    "name": "Thalkirch",
+    "zipCode": "7109",
+    "canton": "GR"
+  },
+  {
+    "id": "8800|Thalwil|ZH",
+    "name": "Thalwil",
+    "zipCode": "8800",
+    "canton": "ZH"
+  },
+  {
+    "id": "8240|Thayngen|SH",
+    "name": "Thayngen",
+    "zipCode": "8240",
+    "canton": "SH"
+  },
+  {
+    "id": "8484|Theilingen|ZH",
+    "name": "Theilingen",
+    "zipCode": "8484",
+    "canton": "ZH"
+  },
+  {
+    "id": "4106|Therwil|BL",
+    "name": "Therwil",
+    "zipCode": "4106",
+    "canton": "BL"
+  },
+  {
+    "id": "2075|Thielle|NE",
+    "name": "Thielle",
+    "zipCode": "2075",
+    "canton": "NE"
+  },
+  {
+    "id": "3634|Thierachern|BE",
+    "name": "Thierachern",
+    "zipCode": "3634",
+    "canton": "BE"
+  },
+  {
+    "id": "1410|Thierrens|VD",
+    "name": "Thierrens",
+    "zipCode": "1410",
+    "canton": "VD"
+  },
+  {
+    "id": "8762|Thon|GL",
+    "name": "Thon",
+    "zipCode": "8762",
+    "canton": "GL"
+  },
+  {
+    "id": "1226|Thônex|GE",
+    "name": "Thônex",
+    "zipCode": "1226",
+    "canton": "GE"
+  },
+  {
+    "id": "3326|Thorberg|BE",
+    "name": "Thorberg",
+    "zipCode": "3326",
+    "canton": "BE"
+  },
+  {
+    "id": "3367|Thörigen|BE",
+    "name": "Thörigen",
+    "zipCode": "3367",
+    "canton": "BE"
+  },
+  {
+    "id": "3174|Thörishaus|BE",
+    "name": "Thörishaus",
+    "zipCode": "3174",
+    "canton": "BE"
+  },
+  {
+    "id": "3600|Thun|BE",
+    "name": "Thun",
+    "zipCode": "3600",
+    "canton": "BE"
+  },
+  {
+    "id": "8512|Thundorf|TG",
+    "name": "Thundorf",
+    "zipCode": "8512",
+    "canton": "TG"
+  },
+  {
+    "id": "4922|Thunstetten|BE",
+    "name": "Thunstetten",
+    "zipCode": "4922",
+    "canton": "BE"
+  },
+  {
+    "id": "4441|Thürnen|BL",
+    "name": "Thürnen",
+    "zipCode": "4441",
+    "canton": "BL"
+  },
+  {
+    "id": "7430|Thusis|GR",
+    "name": "Thusis",
+    "zipCode": "7430",
+    "canton": "GR"
+  },
+  {
+    "id": "1988|Thyon|VS",
+    "name": "Thyon",
+    "zipCode": "1988",
+    "canton": "VS"
+  },
+  {
+    "id": "3000|Tiefenau|BE",
+    "name": "Tiefenau",
+    "zipCode": "3000",
+    "canton": "BE"
+  },
+  {
+    "id": "7450|Tiefencastel|GR",
+    "name": "Tiefencastel",
+    "zipCode": "7450",
+    "canton": "GR"
+  },
+  {
+    "id": "7453|Tinizong|GR",
+    "name": "Tinizong",
+    "zipCode": "7453",
+    "canton": "GR"
+  },
+  {
+    "id": "4425|Titterten|BL",
+    "name": "Titterten",
+    "zipCode": "4425",
+    "canton": "BL"
+  },
+  {
+    "id": "8634|Tobel|ZH",
+    "name": "Tobel",
+    "zipCode": "8634",
+    "canton": "ZH"
+  },
+  {
+    "id": "9405|Tobel|AR",
+    "name": "Tobel",
+    "zipCode": "9405",
+    "canton": "AR"
+  },
+  {
+    "id": "9555|Tobel|TG",
+    "name": "Tobel",
+    "zipCode": "9555",
+    "canton": "TG"
+  },
+  {
+    "id": "3125|Toffen|BE",
+    "name": "Toffen",
+    "zipCode": "3125",
+    "canton": "BE"
+  },
+  {
+    "id": "8352|Tollhausen|ZH",
+    "name": "Tollhausen",
+    "zipCode": "8352",
+    "canton": "ZH"
+  },
+  {
+    "id": "1131|Tolochenaz|VD",
+    "name": "Tolochenaz",
+    "zipCode": "1131",
+    "canton": "VD"
+  },
+  {
+    "id": "8577|Toos|TG",
+    "name": "Toos",
+    "zipCode": "8577",
+    "canton": "TG"
+  },
+  {
+    "id": "3923|Törbel|VS",
+    "name": "Törbel",
+    "zipCode": "3923",
+    "canton": "VS"
+  },
+  {
+    "id": "1899|Torgon|VS",
+    "name": "Torgon",
+    "zipCode": "1899",
+    "canton": "VS"
+  },
+  {
+    "id": "1748|Torny-le-Grand|FR",
+    "name": "Torny-le-Grand",
+    "zipCode": "1748",
+    "canton": "FR"
+  },
+  {
+    "id": "1749|Torny-le-Petit|FR",
+    "name": "Torny-le-Petit",
+    "zipCode": "1749",
+    "canton": "FR"
+  },
+  {
+    "id": "6717|Torre|TI",
+    "name": "Torre",
+    "zipCode": "6717",
+    "canton": "TI"
+  },
+  {
+    "id": "3954|Torrentalp|VS",
+    "name": "Torrentalp",
+    "zipCode": "3954",
+    "canton": "VS"
+  },
+  {
+    "id": "6808|Torricella|TI",
+    "name": "Torricella",
+    "zipCode": "6808",
+    "canton": "TI"
+  },
+  {
+    "id": "8400|Töss|ZH",
+    "name": "Töss",
+    "zipCode": "8400",
+    "canton": "ZH"
+  },
+  {
+    "id": "8193|Tössriederen|ZH",
+    "name": "Tössriederen",
+    "zipCode": "8193",
+    "canton": "ZH"
+  },
+  {
+    "id": "8912|Toussen|ZH",
+    "name": "Toussen",
+    "zipCode": "8912",
+    "canton": "ZH"
+  },
+  {
+    "id": "3456|Trachselwald|BE",
+    "name": "Trachselwald",
+    "zipCode": "3456",
+    "canton": "BE"
+  },
+  {
+    "id": "8840|Trachslau|SZ",
+    "name": "Trachslau",
+    "zipCode": "8840",
+    "canton": "SZ"
+  },
+  {
+    "id": "2720|Tramelan|BE",
+    "name": "Tramelan",
+    "zipCode": "2720",
+    "canton": "BE"
+  },
+  {
+    "id": "8766|Trämligen|GL",
+    "name": "Trämligen",
+    "zipCode": "8766",
+    "canton": "GL"
+  },
+  {
+    "id": "7407|Trans|GR",
+    "name": "Trans",
+    "zipCode": "7407",
+    "canton": "GR"
+  },
+  {
+    "id": "8219|Trasadingen|SH",
+    "name": "Trasadingen",
+    "zipCode": "8219",
+    "canton": "SH"
+  },
+  {
+    "id": "2105|Travers|NE",
+    "name": "Travers",
+    "zipCode": "2105",
+    "canton": "NE"
+  },
+  {
+    "id": "6957|Treggia|TI",
+    "name": "Treggia",
+    "zipCode": "6957",
+    "canton": "TI"
+  },
+  {
+    "id": "6377|Treib|UR",
+    "name": "Treib",
+    "zipCode": "6377",
+    "canton": "UR"
+  },
+  {
+    "id": "3226|Treiten|BE",
+    "name": "Treiten",
+    "zipCode": "3226",
+    "canton": "BE"
+  },
+  {
+    "id": "1525|Treize-Cantons|VD",
+    "name": "Treize-Cantons",
+    "zipCode": "1525",
+    "canton": "VD"
+  },
+  {
+    "id": "1270|Trélex|VD",
+    "name": "Trélex",
+    "zipCode": "1270",
+    "canton": "VD"
+  },
+  {
+    "id": "6865|Tremona|TI",
+    "name": "Tremona",
+    "zipCode": "6865",
+    "canton": "TI"
+  },
+  {
+    "id": "1552|Trey|VD",
+    "name": "Trey",
+    "zipCode": "1552",
+    "canton": "VD"
+  },
+  {
+    "id": "1436|Treycovagnes|VD",
+    "name": "Treycovagnes",
+    "zipCode": "1436",
+    "canton": "VD"
+  },
+  {
+    "id": "1626|Treyfayes|FR",
+    "name": "Treyfayes",
+    "zipCode": "1626",
+    "canton": "FR"
+  },
+  {
+    "id": "1096|Treytorrens (Lavaux)|VD",
+    "name": "Treytorrens (Lavaux)",
+    "zipCode": "1096",
+    "canton": "VD"
+  },
+  {
+    "id": "1538|Treytorrens (Payerne)|VD",
+    "name": "Treytorrens (Payerne)",
+    "zipCode": "1538",
+    "canton": "VD"
+  },
+  {
+    "id": "1733|Treyvaux|FR",
+    "name": "Treyvaux",
+    "zipCode": "1733",
+    "canton": "FR"
+  },
+  {
+    "id": "8273|Triboltingen|TG",
+    "name": "Triboltingen",
+    "zipCode": "8273",
+    "canton": "TG"
+  },
+  {
+    "id": "8000|Triemli|ZH",
+    "name": "Triemli",
+    "zipCode": "8000",
+    "canton": "ZH"
+  },
+  {
+    "id": "6234|Triengen|LU",
+    "name": "Triengen",
+    "zipCode": "6234",
+    "canton": "LU"
+  },
+  {
+    "id": "1929|Trient|VS",
+    "name": "Trient",
+    "zipCode": "1929",
+    "canton": "VS"
+  },
+  {
+    "id": "4632|Trimbach|SO",
+    "name": "Trimbach",
+    "zipCode": "4632",
+    "canton": "SO"
+  },
+  {
+    "id": "7203|Trimmis|GR",
+    "name": "Trimmis",
+    "zipCode": "7203",
+    "canton": "GR"
+  },
+  {
+    "id": "3083|Trimstein|BE",
+    "name": "Trimstein",
+    "zipCode": "3083",
+    "canton": "BE"
+  },
+  {
+    "id": "7014|Trin|GR",
+    "name": "Trin",
+    "zipCode": "7014",
+    "canton": "GR"
+  },
+  {
+    "id": "7014|Trin Statiun|GR",
+    "name": "Trin Statiun",
+    "zipCode": "7014",
+    "canton": "GR"
+  },
+  {
+    "id": "9043|Trogen|AR",
+    "name": "Trogen",
+    "zipCode": "9043",
+    "canton": "AR"
+  },
+  {
+    "id": "1969|Trogne|VS",
+    "name": "Trogne",
+    "zipCode": "1969",
+    "canton": "VS"
+  },
+  {
+    "id": "1256|Troinex|GE",
+    "name": "Troinex",
+    "zipCode": "1256",
+    "canton": "GE"
+  },
+  {
+    "id": "1068|Trois Chasseurs|VD",
+    "name": "Trois Chasseurs",
+    "zipCode": "1068",
+    "canton": "VD"
+  },
+  {
+    "id": "1872|Troistorrents|VS",
+    "name": "Troistorrents",
+    "zipCode": "1872",
+    "canton": "VS"
+  },
+  {
+    "id": "3556|Trub|BE",
+    "name": "Trub",
+    "zipCode": "3556",
+    "canton": "BE"
+  },
+  {
+    "id": "9477|Trübbach|SG",
+    "name": "Trübbach",
+    "zipCode": "9477",
+    "canton": "SG"
+  },
+  {
+    "id": "3555|Trubschachen|BE",
+    "name": "Trubschachen",
+    "zipCode": "3555",
+    "canton": "BE"
+  },
+  {
+    "id": "8466|Trüllikon|ZH",
+    "name": "Trüllikon",
+    "zipCode": "8466",
+    "canton": "ZH"
+  },
+  {
+    "id": "7166|Trun|GR",
+    "name": "Trun",
+    "zipCode": "7166",
+    "canton": "GR"
+  },
+  {
+    "id": "8467|Truttikon|ZH",
+    "name": "Truttikon",
+    "zipCode": "8467",
+    "canton": "ZH"
+  },
+  {
+    "id": "8524|Trüttlikon|TG",
+    "name": "Trüttlikon",
+    "zipCode": "8524",
+    "canton": "TG"
+  },
+  {
+    "id": "8843|Tschalun|SZ",
+    "name": "Tschalun",
+    "zipCode": "8843",
+    "canton": "SZ"
+  },
+  {
+    "id": "7189|Tschamut|GR",
+    "name": "Tschamut",
+    "zipCode": "7189",
+    "canton": "GR"
+  },
+  {
+    "id": "7134|Tschappina|GR",
+    "name": "Tschappina",
+    "zipCode": "7134",
+    "canton": "GR"
+  },
+  {
+    "id": "7428|Tschappina|GR",
+    "name": "Tschappina",
+    "zipCode": "7428",
+    "canton": "GR"
+  },
+  {
+    "id": "4576|Tscheppach|SO",
+    "name": "Tscheppach",
+    "zipCode": "4576",
+    "canton": "SO"
+  },
+  {
+    "id": "8881|Tscherlach|SG",
+    "name": "Tscherlach",
+    "zipCode": "8881",
+    "canton": "SG"
+  },
+  {
+    "id": "7064|Tschiertschen|GR",
+    "name": "Tschiertschen",
+    "zipCode": "7064",
+    "canton": "GR"
+  },
+  {
+    "id": "7532|Tschierv|GR",
+    "name": "Tschierv",
+    "zipCode": "7532",
+    "canton": "GR"
+  },
+  {
+    "id": "3656|Tschingel bei Sigriswil|BE",
+    "name": "Tschingel bei Sigriswil",
+    "zipCode": "3656",
+    "canton": "BE"
+  },
+  {
+    "id": "7559|Tschlin|GR",
+    "name": "Tschlin",
+    "zipCode": "7559",
+    "canton": "GR"
+  },
+  {
+    "id": "3233|Tschugg|BE",
+    "name": "Tschugg",
+    "zipCode": "3233",
+    "canton": "BE"
+  },
+  {
+    "id": "9327|Tübach|SG",
+    "name": "Tübach",
+    "zipCode": "9327",
+    "canton": "SG"
+  },
+  {
+    "id": "9604|Tufertswil|SG",
+    "name": "Tufertswil",
+    "zipCode": "9604",
+    "canton": "SG"
+  },
+  {
+    "id": "3178|Tuftera|FR",
+    "name": "Tuftera",
+    "zipCode": "3178",
+    "canton": "FR"
+  },
+  {
+    "id": "8856|Tuggen|SZ",
+    "name": "Tuggen",
+    "zipCode": "8856",
+    "canton": "SZ"
+  },
+  {
+    "id": "7188|Tujetsch|GR",
+    "name": "Tujetsch",
+    "zipCode": "7188",
+    "canton": "GR"
+  },
+  {
+    "id": "7418|Tumegl/Tomils|GR",
+    "name": "Tumegl/Tomils",
+    "zipCode": "7418",
+    "canton": "GR"
+  },
+  {
+    "id": "3781|Turbach|BE",
+    "name": "Turbach",
+    "zipCode": "3781",
+    "canton": "BE"
+  },
+  {
+    "id": "8488|Turbenthal|ZH",
+    "name": "Turbenthal",
+    "zipCode": "8488",
+    "canton": "ZH"
+  },
+  {
+    "id": "5300|Turgi|AG",
+    "name": "Turgi",
+    "zipCode": "5300",
+    "canton": "AG"
+  },
+  {
+    "id": "1991|Turin|VS",
+    "name": "Turin",
+    "zipCode": "1991",
+    "canton": "VS"
+  },
+  {
+    "id": "8915|Türlen|ZH",
+    "name": "Türlen",
+    "zipCode": "8915",
+    "canton": "ZH"
+  },
+  {
+    "id": "3942|Turtig|VS",
+    "name": "Turtig",
+    "zipCode": "3942",
+    "canton": "VS"
+  },
+  {
+    "id": "3946|Turtmann|VS",
+    "name": "Turtmann",
+    "zipCode": "3946",
+    "canton": "VS"
+  },
+  {
+    "id": "2512|Tüscherz|BE",
+    "name": "Tüscherz",
+    "zipCode": "2512",
+    "canton": "BE"
+  },
+  {
+    "id": "7134|Tusen|GR",
+    "name": "Tusen",
+    "zipCode": "7134",
+    "canton": "GR"
+  },
+  {
+    "id": "9546|Tuttwil|TG",
+    "name": "Tuttwil",
+    "zipCode": "9546",
+    "canton": "TG"
+  },
+  {
+    "id": "2513|Twann|BE",
+    "name": "Twann",
+    "zipCode": "2513",
+    "canton": "BE"
+  },
+  {
+    "id": "2516|Twannberg|BE",
+    "name": "Twannberg",
+    "zipCode": "2516",
+    "canton": "BE"
+  },
+  {
+    "id": "6122|Twerenegg|LU",
+    "name": "Twerenegg",
+    "zipCode": "6122",
+    "canton": "LU"
+  },
+  {
+    "id": "6044|Udligenswil|LU",
+    "name": "Udligenswil",
+    "zipCode": "6044",
+    "canton": "LU"
+  },
+  {
+    "id": "3182|Ueberstorf|FR",
+    "name": "Ueberstorf",
+    "zipCode": "3182",
+    "canton": "FR"
+  },
+  {
+    "id": "5237|Ueberthal|AG",
+    "name": "Ueberthal",
+    "zipCode": "5237",
+    "canton": "AG"
+  },
+  {
+    "id": "3635|Uebeschi|BE",
+    "name": "Uebeschi",
+    "zipCode": "3635",
+    "canton": "BE"
+  },
+  {
+    "id": "1700|Uebewil|FR",
+    "name": "Uebewil",
+    "zipCode": "1700",
+    "canton": "FR"
+  },
+  {
+    "id": "5028|Ueken|AG",
+    "name": "Ueken",
+    "zipCode": "5028",
+    "canton": "AG"
+  },
+  {
+    "id": "8712|Uelikon|ZH",
+    "name": "Uelikon",
+    "zipCode": "8712",
+    "canton": "ZH"
+  },
+  {
+    "id": "8713|Uerikon|ZH",
+    "name": "Uerikon",
+    "zipCode": "8713",
+    "canton": "ZH"
+  },
+  {
+    "id": "4813|Uerkheim|AG",
+    "name": "Uerkheim",
+    "zipCode": "4813",
+    "canton": "AG"
+  },
+  {
+    "id": "8537|Uerschhausen|TG",
+    "name": "Uerschhausen",
+    "zipCode": "8537",
+    "canton": "TG"
+  },
+  {
+    "id": "8926|Uerzlikon|ZH",
+    "name": "Uerzlikon",
+    "zipCode": "8926",
+    "canton": "ZH"
+  },
+  {
+    "id": "8124|Uessikon|ZH",
+    "name": "Uessikon",
+    "zipCode": "8124",
+    "canton": "ZH"
+  },
+  {
+    "id": "8524|Uesslingen|TG",
+    "name": "Uesslingen",
+    "zipCode": "8524",
+    "canton": "TG"
+  },
+  {
+    "id": "3661|Uetendorf|BE",
+    "name": "Uetendorf",
+    "zipCode": "3661",
+    "canton": "BE"
+  },
+  {
+    "id": "3661|Uetendorf Allmend|BE",
+    "name": "Uetendorf Allmend",
+    "zipCode": "3661",
+    "canton": "BE"
+  },
+  {
+    "id": "8707|Uetikon am See|ZH",
+    "name": "Uetikon am See",
+    "zipCode": "8707",
+    "canton": "ZH"
+  },
+  {
+    "id": "8143|Uetliberg|ZH",
+    "name": "Uetliberg",
+    "zipCode": "8143",
+    "canton": "ZH"
+  },
+  {
+    "id": "8738|Uetliburg|SG",
+    "name": "Uetliburg",
+    "zipCode": "8738",
+    "canton": "SG"
+  },
+  {
+    "id": "3043|Uettligen|BE",
+    "name": "Uettligen",
+    "zipCode": "3043",
+    "canton": "BE"
+  },
+  {
+    "id": "5619|Uezwil|AG",
+    "name": "Uezwil",
+    "zipCode": "5619",
+    "canton": "AG"
+  },
+  {
+    "id": "8808|Ufenau|SZ",
+    "name": "Ufenau",
+    "zipCode": "8808",
+    "canton": "SZ"
+  },
+  {
+    "id": "6253|Uffikon|LU",
+    "name": "Uffikon",
+    "zipCode": "6253",
+    "canton": "LU"
+  },
+  {
+    "id": "6153|Ufhusen|LU",
+    "name": "Ufhusen",
+    "zipCode": "6153",
+    "canton": "LU"
+  },
+  {
+    "id": "8142|Uitikon|ZH",
+    "name": "Uitikon",
+    "zipCode": "8142",
+    "canton": "ZH"
+  },
+  {
+    "id": "9631|Ulisbach|SG",
+    "name": "Ulisbach",
+    "zipCode": "9631",
+    "canton": "SG"
+  },
+  {
+    "id": "3214|Ulmiz|FR",
+    "name": "Ulmiz",
+    "zipCode": "3214",
+    "canton": "FR"
+  },
+  {
+    "id": "3988|Ulrichen|VS",
+    "name": "Ulrichen",
+    "zipCode": "3988",
+    "canton": "VS"
+  },
+  {
+    "id": "7536|Umbrail|GR",
+    "name": "Umbrail",
+    "zipCode": "7536",
+    "canton": "GR"
+  },
+  {
+    "id": "5222|Umiken|AG",
+    "name": "Umiken",
+    "zipCode": "5222",
+    "canton": "AG"
+  },
+  {
+    "id": "3792|Underbort|BE",
+    "name": "Underbort",
+    "zipCode": "3792",
+    "canton": "BE"
+  },
+  {
+    "id": "2863|Undervelier|JU",
+    "name": "Undervelier",
+    "zipCode": "2863",
+    "canton": "JU"
+  },
+  {
+    "id": "6314|Unterägeri|ZG",
+    "name": "Unterägeri",
+    "zipCode": "6314",
+    "canton": "ZG"
+  },
+  {
+    "id": "3857|Unterbach|BE",
+    "name": "Unterbach",
+    "zipCode": "3857",
+    "canton": "BE"
+  },
+  {
+    "id": "3944|Unterbäch|VS",
+    "name": "Unterbäch",
+    "zipCode": "3944",
+    "canton": "VS"
+  },
+  {
+    "id": "9404|Unterbilchen|SG",
+    "name": "Unterbilchen",
+    "zipCode": "9404",
+    "canton": "SG"
+  },
+  {
+    "id": "5225|Unterbözberg|AG",
+    "name": "Unterbözberg",
+    "zipCode": "5225",
+    "canton": "AG"
+  },
+  {
+    "id": "8589|Unteregg|SG",
+    "name": "Unteregg",
+    "zipCode": "8589",
+    "canton": "SG"
+  },
+  {
+    "id": "9033|Untereggen|SG",
+    "name": "Untereggen",
+    "zipCode": "9033",
+    "canton": "SG"
+  },
+  {
+    "id": "5420|Unterehrendingen|AG",
+    "name": "Unterehrendingen",
+    "zipCode": "5420",
+    "canton": "AG"
+  },
+  {
+    "id": "3948|Unterems|VS",
+    "name": "Unterems",
+    "zipCode": "3948",
+    "canton": "VS"
+  },
+  {
+    "id": "5305|Unterendingen|AG",
+    "name": "Unterendingen",
+    "zipCode": "5305",
+    "canton": "AG"
+  },
+  {
+    "id": "8103|Unterengstringen|ZH",
+    "name": "Unterengstringen",
+    "zipCode": "8103",
+    "canton": "ZH"
+  },
+  {
+    "id": "5035|Unterentfelden|AG",
+    "name": "Unterentfelden",
+    "zipCode": "5035",
+    "canton": "AG"
+  },
+  {
+    "id": "8570|Unterhard|TG",
+    "name": "Unterhard",
+    "zipCode": "8570",
+    "canton": "TG"
+  },
+  {
+    "id": "3857|Unterheid|BE",
+    "name": "Unterheid",
+    "zipCode": "3857",
+    "canton": "BE"
+  },
+  {
+    "id": "8508|Unterhörstetten|TG",
+    "name": "Unterhörstetten",
+    "zipCode": "8508",
+    "canton": "TG"
+  },
+  {
+    "id": "8842|Unteriberg|SZ",
+    "name": "Unteriberg",
+    "zipCode": "8842",
+    "canton": "SZ"
+  },
+  {
+    "id": "5726|Unterkulm|AG",
+    "name": "Unterkulm",
+    "zipCode": "5726",
+    "canton": "AG"
+  },
+  {
+    "id": "3614|Unterlangenegg|BE",
+    "name": "Unterlangenegg",
+    "zipCode": "3614",
+    "canton": "BE"
+  },
+  {
+    "id": "9300|Unterlören|SG",
+    "name": "Unterlören",
+    "zipCode": "9300",
+    "canton": "SG"
+  },
+  {
+    "id": "8918|Unterlunkhofen|AG",
+    "name": "Unterlunkhofen",
+    "zipCode": "8918",
+    "canton": "AG"
+  },
+  {
+    "id": "8912|Unterlunnern|ZH",
+    "name": "Unterlunnern",
+    "zipCode": "8912",
+    "canton": "ZH"
+  },
+  {
+    "id": "8472|Unterohringen|ZH",
+    "name": "Unterohringen",
+    "zipCode": "8472",
+    "canton": "ZH"
+  },
+  {
+    "id": "4588|Unterramsern|SO",
+    "name": "Unterramsern",
+    "zipCode": "4588",
+    "canton": "SO"
+  },
+  {
+    "id": "7408|Unterrealta|GR",
+    "name": "Unterrealta",
+    "zipCode": "7408",
+    "canton": "GR"
+  },
+  {
+    "id": "9604|Unterrindal|SG",
+    "name": "Unterrindal",
+    "zipCode": "9604",
+    "canton": "SG"
+  },
+  {
+    "id": "5634|Unterrüti|AG",
+    "name": "Unterrüti",
+    "zipCode": "5634",
+    "canton": "AG"
+  },
+  {
+    "id": "6465|Unterschächen|UR",
+    "name": "Unterschächen",
+    "zipCode": "6465",
+    "canton": "UR"
+  },
+  {
+    "id": "8418|Unterschlatt|ZH",
+    "name": "Unterschlatt",
+    "zipCode": "8418",
+    "canton": "ZH"
+  },
+  {
+    "id": "6440|Unterschönenbuch|SZ",
+    "name": "Unterschönenbuch",
+    "zipCode": "6440",
+    "canton": "SZ"
+  },
+  {
+    "id": "3800|Unterseen|BE",
+    "name": "Unterseen",
+    "zipCode": "3800",
+    "canton": "BE"
+  },
+  {
+    "id": "5417|Untersiggenthal|AG",
+    "name": "Untersiggenthal",
+    "zipCode": "5417",
+    "canton": "AG"
+  },
+  {
+    "id": "5417|Untersiggingen|AG",
+    "name": "Untersiggingen",
+    "zipCode": "5417",
+    "canton": "AG"
+  },
+  {
+    "id": "8476|Unterstammheim|ZH",
+    "name": "Unterstammheim",
+    "zipCode": "8476",
+    "canton": "ZH"
+  },
+  {
+    "id": "4916|Untersteckholz|BE",
+    "name": "Untersteckholz",
+    "zipCode": "4916",
+    "canton": "BE"
+  },
+  {
+    "id": "8000|Unterstrass|ZH",
+    "name": "Unterstrass",
+    "zipCode": "8000",
+    "canton": "ZH"
+  },
+  {
+    "id": "8882|Unterterzen|SG",
+    "name": "Unterterzen",
+    "zipCode": "8882",
+    "canton": "SG"
+  },
+  {
+    "id": "7204|Untervaz|GR",
+    "name": "Untervaz",
+    "zipCode": "7204",
+    "canton": "GR"
+  },
+  {
+    "id": "7201|Untervaz Bahnhof|GR",
+    "name": "Untervaz Bahnhof",
+    "zipCode": "7201",
+    "canton": "GR"
+  },
+  {
+    "id": "9657|Unterwasser|SG",
+    "name": "Unterwasser",
+    "zipCode": "9657",
+    "canton": "SG"
+  },
+  {
+    "id": "3999|Unterwassern|VS",
+    "name": "Unterwassern",
+    "zipCode": "3999",
+    "canton": "VS"
+  },
+  {
+    "id": "3052|Unterzollikofen|BE",
+    "name": "Unterzollikofen",
+    "zipCode": "3052",
+    "canton": "BE"
+  },
+  {
+    "id": "7114|Uors|GR",
+    "name": "Uors",
+    "zipCode": "7114",
+    "canton": "GR"
+  },
+  {
+    "id": "8902|Urdorf|ZH",
+    "name": "Urdorf",
+    "zipCode": "8902",
+    "canton": "ZH"
+  },
+  {
+    "id": "6465|Urigen|UR",
+    "name": "Urigen",
+    "zipCode": "6465",
+    "canton": "UR"
+  },
+  {
+    "id": "7427|Urmein|GR",
+    "name": "Urmein",
+    "zipCode": "7427",
+    "canton": "GR"
+  },
+  {
+    "id": "9107|Urnäsch|AR",
+    "name": "Urnäsch",
+    "zipCode": "9107",
+    "canton": "AR"
+  },
+  {
+    "id": "8751|Urnerboden|UR",
+    "name": "Urnerboden",
+    "zipCode": "8751",
+    "canton": "UR"
+  },
+  {
+    "id": "3510|Ursellen|BE",
+    "name": "Ursellen",
+    "zipCode": "3510",
+    "canton": "BE"
+  },
+  {
+    "id": "4937|Ursenbach|BE",
+    "name": "Ursenbach",
+    "zipCode": "4937",
+    "canton": "BE"
+  },
+  {
+    "id": "1412|Ursins|VD",
+    "name": "Ursins",
+    "zipCode": "1412",
+    "canton": "VD"
+  },
+  {
+    "id": "5225|Ursprung|AG",
+    "name": "Ursprung",
+    "zipCode": "5225",
+    "canton": "AG"
+  },
+  {
+    "id": "6280|Urswil|LU",
+    "name": "Urswil",
+    "zipCode": "6280",
+    "canton": "LU"
+  },
+  {
+    "id": "1670|Ursy|FR",
+    "name": "Ursy",
+    "zipCode": "1670",
+    "canton": "FR"
+  },
+  {
+    "id": "3322|Urtenen|BE",
+    "name": "Urtenen",
+    "zipCode": "3322",
+    "canton": "BE"
+  },
+  {
+    "id": "8864|Ussbühl|SZ",
+    "name": "Ussbühl",
+    "zipCode": "8864",
+    "canton": "SZ"
+  },
+  {
+    "id": "8864|Ussbühl|GL",
+    "name": "Ussbühl",
+    "zipCode": "8864",
+    "canton": "GL"
+  },
+  {
+    "id": "8610|Uster|ZH",
+    "name": "Uster",
+    "zipCode": "8610",
+    "canton": "ZH"
+  },
+  {
+    "id": "8934|Uttenberg|ZH",
+    "name": "Uttenberg",
+    "zipCode": "8934",
+    "canton": "ZH"
+  },
+  {
+    "id": "3628|Uttigen|BE",
+    "name": "Uttigen",
+    "zipCode": "3628",
+    "canton": "BE"
+  },
+  {
+    "id": "8592|Uttwil|TG",
+    "name": "Uttwil",
+    "zipCode": "8592",
+    "canton": "TG"
+  },
+  {
+    "id": "3427|Utzenstorf|BE",
+    "name": "Utzenstorf",
+    "zipCode": "3427",
+    "canton": "BE"
+  },
+  {
+    "id": "3068|Utzigen|BE",
+    "name": "Utzigen",
+    "zipCode": "3068",
+    "canton": "BE"
+  },
+  {
+    "id": "1958|Uvrier|VS",
+    "name": "Uvrier",
+    "zipCode": "1958",
+    "canton": "VS"
+  },
+  {
+    "id": "8730|Uznaberg|SG",
+    "name": "Uznaberg",
+    "zipCode": "8730",
+    "canton": "SG"
+  },
+  {
+    "id": "8730|Uznach|SG",
+    "name": "Uznach",
+    "zipCode": "8730",
+    "canton": "SG"
+  },
+  {
+    "id": "9240|Uzwil|SG",
+    "name": "Uzwil",
+    "zipCode": "9240",
+    "canton": "SG"
+  },
+  {
+    "id": "3978|Vaas|VS",
+    "name": "Vaas",
+    "zipCode": "3978",
+    "canton": "VS"
+  },
+  {
+    "id": "6833|Vacallo|TI",
+    "name": "Vacallo",
+    "zipCode": "6833",
+    "canton": "TI"
+  },
+  {
+    "id": "7314|Vadura|SG",
+    "name": "Vadura",
+    "zipCode": "7314",
+    "canton": "SG"
+  },
+  {
+    "id": "6947|Vaglio|TI",
+    "name": "Vaglio",
+    "zipCode": "6947",
+    "canton": "TI"
+  },
+  {
+    "id": "6575|Vairano|TI",
+    "name": "Vairano",
+    "zipCode": "6575",
+    "canton": "TI"
+  },
+  {
+    "id": "7741|Val di Campo|GR",
+    "name": "Val di Campo",
+    "zipCode": "7741",
+    "canton": "GR"
+  },
+  {
+    "id": "7554|Val Sinestra|GR",
+    "name": "Val Sinestra",
+    "zipCode": "7554",
+    "canton": "GR"
+  },
+  {
+    "id": "1873|Val-d'Illiez|VS",
+    "name": "Val-d'Illiez",
+    "zipCode": "1873",
+    "canton": "VS"
+  },
+  {
+    "id": "2042|Valangin|NE",
+    "name": "Valangin",
+    "zipCode": "2042",
+    "canton": "NE"
+  },
+  {
+    "id": "7138|Valata|GR",
+    "name": "Valata",
+    "zipCode": "7138",
+    "canton": "GR"
+  },
+  {
+    "id": "1293|Valavran|GE",
+    "name": "Valavran",
+    "zipCode": "1293",
+    "canton": "GE"
+  },
+  {
+    "id": "7077|Valbella|GR",
+    "name": "Valbella",
+    "zipCode": "7077",
+    "canton": "GR"
+  },
+  {
+    "id": "7535|Valchava|GR",
+    "name": "Valchava",
+    "zipCode": "7535",
+    "canton": "GR"
+  },
+  {
+    "id": "6951|Valcolla|TI",
+    "name": "Valcolla",
+    "zipCode": "6951",
+    "canton": "TI"
+  },
+  {
+    "id": "7132|Valé|GR",
+    "name": "Valé",
+    "zipCode": "7132",
+    "canton": "GR"
+  },
+  {
+    "id": "3978|Valençon|VS",
+    "name": "Valençon",
+    "zipCode": "3978",
+    "canton": "VS"
+  },
+  {
+    "id": "7122|Valendas|GR",
+    "name": "Valendas",
+    "zipCode": "7122",
+    "canton": "GR"
+  },
+  {
+    "id": "7317|Valens|SG",
+    "name": "Valens",
+    "zipCode": "7317",
+    "canton": "SG"
+  },
+  {
+    "id": "1441|Valeyres-sous-Montagny|VD",
+    "name": "Valeyres-sous-Montagny",
+    "zipCode": "1441",
+    "canton": "VD"
+  },
+  {
+    "id": "1358|Valeyres-sous-Rances|VD",
+    "name": "Valeyres-sous-Rances",
+    "zipCode": "1358",
+    "canton": "VD"
+  },
+  {
+    "id": "1412|Valeyres-sous-Ursins|VD",
+    "name": "Valeyres-sous-Ursins",
+    "zipCode": "1412",
+    "canton": "VD"
+  },
+  {
+    "id": "1586|Vallamand-Dessous|VD",
+    "name": "Vallamand-Dessous",
+    "zipCode": "1586",
+    "canton": "VD"
+  },
+  {
+    "id": "1586|Vallamand-Dessus|VD",
+    "name": "Vallamand-Dessus",
+    "zipCode": "1586",
+    "canton": "VD"
+  },
+  {
+    "id": "7553|Vallatscha|GR",
+    "name": "Vallatscha",
+    "zipCode": "7553",
+    "canton": "GR"
+  },
+  {
+    "id": "6780|Valle|TI",
+    "name": "Valle",
+    "zipCode": "6780",
+    "canton": "TI"
+  },
+  {
+    "id": "1565|Vallon|FR",
+    "name": "Vallon",
+    "zipCode": "1565",
+    "canton": "FR"
+  },
+  {
+    "id": "1337|Vallorbe|VD",
+    "name": "Vallorbe",
+    "zipCode": "1337",
+    "canton": "VD"
+  },
+  {
+    "id": "7132|Vals|GR",
+    "name": "Vals",
+    "zipCode": "7132",
+    "canton": "GR"
+  },
+  {
+    "id": "7213|Valzeina|GR",
+    "name": "Valzeina",
+    "zipCode": "7213",
+    "canton": "GR"
+  },
+  {
+    "id": "1922|Van-d'en-Bas|VS",
+    "name": "Van-d'en-Bas",
+    "zipCode": "1922",
+    "canton": "VS"
+  },
+  {
+    "id": "1922|Van-d'en-Haut|VS",
+    "name": "Van-d'en-Haut",
+    "zipCode": "1922",
+    "canton": "VS"
+  },
+  {
+    "id": "1253|Vandoeuvres|GE",
+    "name": "Vandoeuvres",
+    "zipCode": "1253",
+    "canton": "GE"
+  },
+  {
+    "id": "3953|Varen|VS",
+    "name": "Varen",
+    "zipCode": "3953",
+    "canton": "VS"
+  },
+  {
+    "id": "6777|Varenzo|TI",
+    "name": "Varenzo",
+    "zipCode": "6777",
+    "canton": "TI"
+  },
+  {
+    "id": "7317|Vasön|SG",
+    "name": "Vasön",
+    "zipCode": "7317",
+    "canton": "SG"
+  },
+  {
+    "id": "7315|Vättis|SG",
+    "name": "Vättis",
+    "zipCode": "7315",
+    "canton": "SG"
+  },
+  {
+    "id": "7146|Vattiz|GR",
+    "name": "Vattiz",
+    "zipCode": "7146",
+    "canton": "GR"
+  },
+  {
+    "id": "1675|Vauderens|FR",
+    "name": "Vauderens",
+    "zipCode": "1675",
+    "canton": "FR"
+  },
+  {
+    "id": "2537|Vauffelin|BE",
+    "name": "Vauffelin",
+    "zipCode": "2537",
+    "canton": "BE"
+  },
+  {
+    "id": "1423|Vaugondry|VD",
+    "name": "Vaugondry",
+    "zipCode": "1423",
+    "canton": "VD"
+  },
+  {
+    "id": "1325|Vaulion|VD",
+    "name": "Vaulion",
+    "zipCode": "1325",
+    "canton": "VD"
+  },
+  {
+    "id": "1627|Vaulruz|FR",
+    "name": "Vaulruz",
+    "zipCode": "1627",
+    "canton": "FR"
+  },
+  {
+    "id": "2028|Vaumarcus|NE",
+    "name": "Vaumarcus",
+    "zipCode": "2028",
+    "canton": "NE"
+  },
+  {
+    "id": "2354|Vautenaivre|JU",
+    "name": "Vautenaivre",
+    "zipCode": "2354",
+    "canton": "JU"
+  },
+  {
+    "id": "1126|Vaux-sur-Morges|VD",
+    "name": "Vaux-sur-Morges",
+    "zipCode": "1126",
+    "canton": "VD"
+  },
+  {
+    "id": "7082|Vaz/Obervaz|GR",
+    "name": "Vaz/Obervaz",
+    "zipCode": "7082",
+    "canton": "GR"
+  },
+  {
+    "id": "7084|Vazerol|GR",
+    "name": "Vazerol",
+    "zipCode": "7084",
+    "canton": "GR"
+  },
+  {
+    "id": "3067|Vechigen|BE",
+    "name": "Vechigen",
+    "zipCode": "3067",
+    "canton": "BE"
+  },
+  {
+    "id": "1251|Veigy (Suisse)|GE",
+    "name": "Veigy (Suisse)",
+    "zipCode": "1251",
+    "canton": "GE"
+  },
+  {
+    "id": "7144|Vella|GR",
+    "name": "Vella",
+    "zipCode": "7144",
+    "canton": "GR"
+  },
+  {
+    "id": "6583|Vellano|TI",
+    "name": "Vellano",
+    "zipCode": "6583",
+    "canton": "TI"
+  },
+  {
+    "id": "2830|Vellerat|JU",
+    "name": "Vellerat",
+    "zipCode": "2830",
+    "canton": "JU"
+  },
+  {
+    "id": "5106|Veltheim|AG",
+    "name": "Veltheim",
+    "zipCode": "5106",
+    "canton": "AG"
+  },
+  {
+    "id": "8400|Veltheim|ZH",
+    "name": "Veltheim",
+    "zipCode": "8400",
+    "canton": "ZH"
+  },
+  {
+    "id": "2943|Vendlincourt|JU",
+    "name": "Vendlincourt",
+    "zipCode": "2943",
+    "canton": "JU"
+  },
+  {
+    "id": "1000|Vennes|VD",
+    "name": "Vennes",
+    "zipCode": "1000",
+    "canton": "VD"
+  },
+  {
+    "id": "1933|Vens|VS",
+    "name": "Vens",
+    "zipCode": "1933",
+    "canton": "VS"
+  },
+  {
+    "id": "3973|Venthône|VS",
+    "name": "Venthône",
+    "zipCode": "3973",
+    "canton": "VS"
+  },
+  {
+    "id": "1936|Verbier|VS",
+    "name": "Verbier",
+    "zipCode": "1936",
+    "canton": "VS"
+  },
+  {
+    "id": "3967|Vercorin|VS",
+    "name": "Vercorin",
+    "zipCode": "3967",
+    "canton": "VS"
+  },
+  {
+    "id": "6538|Verdabbio|GR",
+    "name": "Verdabbio",
+    "zipCode": "6538",
+    "canton": "GR"
+  },
+  {
+    "id": "6655|Verdasio|TI",
+    "name": "Verdasio",
+    "zipCode": "6655",
+    "canton": "TI"
+  },
+  {
+    "id": "6664|Vergeletto|TI",
+    "name": "Vergeletto",
+    "zipCode": "6664",
+    "canton": "TI"
+  },
+  {
+    "id": "1937|Verlonnaz|VS",
+    "name": "Verlonnaz",
+    "zipCode": "1937",
+    "canton": "VS"
+  },
+  {
+    "id": "3963|Vermala|VS",
+    "name": "Vermala",
+    "zipCode": "3963",
+    "canton": "VS"
+  },
+  {
+    "id": "2829|Vermes|JU",
+    "name": "Vermes",
+    "zipCode": "2829",
+    "canton": "JU"
+  },
+  {
+    "id": "8886|Vermol|SG",
+    "name": "Vermol",
+    "zipCode": "8886",
+    "canton": "SG"
+  },
+  {
+    "id": "1961|Vernamiège|VS",
+    "name": "Vernamiège",
+    "zipCode": "1961",
+    "canton": "VS"
+  },
+  {
+    "id": "1033|Vernand-Dessous|VD",
+    "name": "Vernand-Dessous",
+    "zipCode": "1033",
+    "canton": "VD"
+  },
+  {
+    "id": "1032|Vernand-Dessus|VD",
+    "name": "Vernand-Dessus",
+    "zipCode": "1032",
+    "canton": "VD"
+  },
+  {
+    "id": "6992|Vernate|TI",
+    "name": "Vernate",
+    "zipCode": "6992",
+    "canton": "TI"
+  },
+  {
+    "id": "1904|Vernayaz|VS",
+    "name": "Vernayaz",
+    "zipCode": "1904",
+    "canton": "VS"
+  },
+  {
+    "id": "2028|Vernéaz|NE",
+    "name": "Vernéaz",
+    "zipCode": "2028",
+    "canton": "NE"
+  },
+  {
+    "id": "1820|Vernex|VD",
+    "name": "Vernex",
+    "zipCode": "1820",
+    "canton": "VD"
+  },
+  {
+    "id": "1214|Vernier|GE",
+    "name": "Vernier",
+    "zipCode": "1214",
+    "canton": "GE"
+  },
+  {
+    "id": "1891|Vérossaz|VS",
+    "name": "Vérossaz",
+    "zipCode": "1891",
+    "canton": "VS"
+  },
+  {
+    "id": "1420|Vers chez Patthey|VD",
+    "name": "Vers chez Patthey",
+    "zipCode": "1420",
+    "canton": "VD"
+  },
+  {
+    "id": "1926|Vers l'Eglise|VS",
+    "name": "Vers l'Eglise",
+    "zipCode": "1926",
+    "canton": "VS"
+  },
+  {
+    "id": "1450|Vers-chez-Jaccard|VD",
+    "name": "Vers-chez-Jaccard",
+    "zipCode": "1450",
+    "canton": "VD"
+  },
+  {
+    "id": "1000|Vers-chez-les-Blancs|VD",
+    "name": "Vers-chez-les-Blancs",
+    "zipCode": "1000",
+    "canton": "VD"
+  },
+  {
+    "id": "1551|Vers-chez-Perrin|VD",
+    "name": "Vers-chez-Perrin",
+    "zipCode": "1551",
+    "canton": "VD"
+  },
+  {
+    "id": "1864|Vers-l'Eglise|VD",
+    "name": "Vers-l'Eglise",
+    "zipCode": "1864",
+    "canton": "VD"
+  },
+  {
+    "id": "1853|Vers-Morey|VD",
+    "name": "Vers-Morey",
+    "zipCode": "1853",
+    "canton": "VD"
+  },
+  {
+    "id": "7104|Versam|GR",
+    "name": "Versam",
+    "zipCode": "7104",
+    "canton": "GR"
+  },
+  {
+    "id": "7104|Versam Statiun|GR",
+    "name": "Versam Statiun",
+    "zipCode": "7104",
+    "canton": "GR"
+  },
+  {
+    "id": "6653|Verscio|TI",
+    "name": "Verscio",
+    "zipCode": "6653",
+    "canton": "TI"
+  },
+  {
+    "id": "1947|Versegères|VS",
+    "name": "Versegères",
+    "zipCode": "1947",
+    "canton": "VS"
+  },
+  {
+    "id": "1290|Versoix|GE",
+    "name": "Versoix",
+    "zipCode": "1290",
+    "canton": "GE"
+  },
+  {
+    "id": "1290|Versoix la Ville|GE",
+    "name": "Versoix la Ville",
+    "zipCode": "1290",
+    "canton": "GE"
+  },
+  {
+    "id": "1290|Versoix le Bourg|GE",
+    "name": "Versoix le Bourg",
+    "zipCode": "1290",
+    "canton": "GE"
+  },
+  {
+    "id": "1852|Versvey|VD",
+    "name": "Versvey",
+    "zipCode": "1852",
+    "canton": "VD"
+  },
+  {
+    "id": "1222|Vésenaz|GE",
+    "name": "Vésenaz",
+    "zipCode": "1222",
+    "canton": "GE"
+  },
+  {
+    "id": "1483|Vesin|FR",
+    "name": "Vesin",
+    "zipCode": "1483",
+    "canton": "FR"
+  },
+  {
+    "id": "1234|Vessy|GE",
+    "name": "Vessy",
+    "zipCode": "1234",
+    "canton": "GE"
+  },
+  {
+    "id": "1963|Vétroz|VS",
+    "name": "Vétroz",
+    "zipCode": "1963",
+    "canton": "VS"
+  },
+  {
+    "id": "1800|Vevey|VD",
+    "name": "Vevey",
+    "zipCode": "1800",
+    "canton": "VD"
+  },
+  {
+    "id": "1981|Vex|VS",
+    "name": "Vex",
+    "zipCode": "1981",
+    "canton": "VS"
+  },
+  {
+    "id": "3968|Veyras|VS",
+    "name": "Veyras",
+    "zipCode": "3968",
+    "canton": "VS"
+  },
+  {
+    "id": "1255|Veyrier|GE",
+    "name": "Veyrier",
+    "zipCode": "1255",
+    "canton": "GE"
+  },
+  {
+    "id": "1993|Veysonnaz|VS",
+    "name": "Veysonnaz",
+    "zipCode": "1993",
+    "canton": "VS"
+  },
+  {
+    "id": "1820|Veytaux|VD",
+    "name": "Veytaux",
+    "zipCode": "1820",
+    "canton": "VD"
+  },
+  {
+    "id": "6943|Vezia|TI",
+    "name": "Vezia",
+    "zipCode": "6943",
+    "canton": "TI"
+  },
+  {
+    "id": "6938|Vezio|TI",
+    "name": "Vezio",
+    "zipCode": "6938",
+    "canton": "TI"
+  },
+  {
+    "id": "7747|Viano|GR",
+    "name": "Viano",
+    "zipCode": "7747",
+    "canton": "GR"
+  },
+  {
+    "id": "1267|Vich|VD",
+    "name": "Vich",
+    "zipCode": "1267",
+    "canton": "VD"
+  },
+  {
+    "id": "1945|Vichères|VS",
+    "name": "Vichères",
+    "zipCode": "1945",
+    "canton": "VS"
+  },
+  {
+    "id": "6921|Vico Morcote|TI",
+    "name": "Vico Morcote",
+    "zipCode": "6921",
+    "canton": "TI"
+  },
+  {
+    "id": "7603|Vicosoprano|GR",
+    "name": "Vicosoprano",
+    "zipCode": "7603",
+    "canton": "GR"
+  },
+  {
+    "id": "2824|Vicques|JU",
+    "name": "Vicques",
+    "zipCode": "2824",
+    "canton": "JU"
+  },
+  {
+    "id": "3075|Vielbringen bei Worb|BE",
+    "name": "Vielbringen bei Worb",
+    "zipCode": "3075",
+    "canton": "BE"
+  },
+  {
+    "id": "6962|Viganello|TI",
+    "name": "Viganello",
+    "zipCode": "6962",
+    "canton": "TI"
+  },
+  {
+    "id": "6763|Vigera|TI",
+    "name": "Vigera",
+    "zipCode": "6763",
+    "canton": "TI"
+  },
+  {
+    "id": "7147|Vignogn|GR",
+    "name": "Vignogn",
+    "zipCode": "7147",
+    "canton": "GR"
+  },
+  {
+    "id": "2063|Vilars|NE",
+    "name": "Vilars",
+    "zipCode": "2063",
+    "canton": "NE"
+  },
+  {
+    "id": "1966|Villa|VS",
+    "name": "Villa",
+    "zipCode": "1966",
+    "canton": "VS"
+  },
+  {
+    "id": "6781|Villa|TI",
+    "name": "Villa",
+    "zipCode": "6781",
+    "canton": "TI"
+  },
+  {
+    "id": "6877|Villa|TI",
+    "name": "Villa",
+    "zipCode": "6877",
+    "canton": "TI"
+  },
+  {
+    "id": "6966|Villa Luganese|TI",
+    "name": "Villa Luganese",
+    "zipCode": "6966",
+    "canton": "TI"
+  },
+  {
+    "id": "1673|Villangeaux|FR",
+    "name": "Villangeaux",
+    "zipCode": "1673",
+    "canton": "FR"
+  },
+  {
+    "id": "1148|Villar-Bozon|VD",
+    "name": "Villar-Bozon",
+    "zipCode": "1148",
+    "canton": "VD"
+  },
+  {
+    "id": "1679|Villaraboud|FR",
+    "name": "Villaraboud",
+    "zipCode": "1679",
+    "canton": "FR"
+  },
+  {
+    "id": "1678|Villaranon|FR",
+    "name": "Villaranon",
+    "zipCode": "1678",
+    "canton": "FR"
+  },
+  {
+    "id": "1652|Villarbeney|FR",
+    "name": "Villarbeney",
+    "zipCode": "1652",
+    "canton": "FR"
+  },
+  {
+    "id": "1832|Villard-sur-Chamby|VD",
+    "name": "Villard-sur-Chamby",
+    "zipCode": "1832",
+    "canton": "VD"
+  },
+  {
+    "id": "1583|Villarepos|FR",
+    "name": "Villarepos",
+    "zipCode": "1583",
+    "canton": "FR"
+  },
+  {
+    "id": "1432|Villaret|VD",
+    "name": "Villaret",
+    "zipCode": "1432",
+    "canton": "VD"
+  },
+  {
+    "id": "1774|Villarey|FR",
+    "name": "Villarey",
+    "zipCode": "1774",
+    "canton": "FR"
+  },
+  {
+    "id": "1694|Villargiroud|FR",
+    "name": "Villargiroud",
+    "zipCode": "1694",
+    "canton": "FR"
+  },
+  {
+    "id": "1685|Villariaz|FR",
+    "name": "Villariaz",
+    "zipCode": "1685",
+    "canton": "FR"
+  },
+  {
+    "id": "1691|Villarimboud|FR",
+    "name": "Villarimboud",
+    "zipCode": "1691",
+    "canton": "FR"
+  },
+  {
+    "id": "1695|Villarlod|FR",
+    "name": "Villarlod",
+    "zipCode": "1695",
+    "canton": "FR"
+  },
+  {
+    "id": "1682|Villars-Bramard|VD",
+    "name": "Villars-Bramard",
+    "zipCode": "1682",
+    "canton": "VD"
+  },
+  {
+    "id": "1423|Villars-Burquin|VD",
+    "name": "Villars-Burquin",
+    "zipCode": "1423",
+    "canton": "VD"
+  },
+  {
+    "id": "1404|Villars-Epeney|VD",
+    "name": "Villars-Epeney",
+    "zipCode": "1404",
+    "canton": "VD"
+  },
+  {
+    "id": "1515|Villars-le-Comte|VD",
+    "name": "Villars-le-Comte",
+    "zipCode": "1515",
+    "canton": "VD"
+  },
+  {
+    "id": "1584|Villars-le-Grand|VD",
+    "name": "Villars-le-Grand",
+    "zipCode": "1584",
+    "canton": "VD"
+  },
+  {
+    "id": "1040|Villars-le-Terroir|VD",
+    "name": "Villars-le-Terroir",
+    "zipCode": "1040",
+    "canton": "VD"
+  },
+  {
+    "id": "1700|Villars-les-Joncs|FR",
+    "name": "Villars-les-Joncs",
+    "zipCode": "1700",
+    "canton": "FR"
+  },
+  {
+    "id": "1307|Villars-Lussery|VD",
+    "name": "Villars-Lussery",
+    "zipCode": "1307",
+    "canton": "VD"
+  },
+  {
+    "id": "1061|Villars-Mendraz|VD",
+    "name": "Villars-Mendraz",
+    "zipCode": "1061",
+    "canton": "VD"
+  },
+  {
+    "id": "1443|Villars-sous-Champvent|VD",
+    "name": "Villars-sous-Champvent",
+    "zipCode": "1443",
+    "canton": "VD"
+  },
+  {
+    "id": "1666|Villars-sous-Mont|FR",
+    "name": "Villars-sous-Mont",
+    "zipCode": "1666",
+    "canton": "FR"
+  },
+  {
+    "id": "1168|Villars-sous-Yens|VD",
+    "name": "Villars-sous-Yens",
+    "zipCode": "1168",
+    "canton": "VD"
+  },
+  {
+    "id": "1029|Villars-Ste-Croix|VD",
+    "name": "Villars-Ste-Croix",
+    "zipCode": "1029",
+    "canton": "VD"
+  },
+  {
+    "id": "2903|Villars-sur-Fontenais|JU",
+    "name": "Villars-sur-Fontenais",
+    "zipCode": "2903",
+    "canton": "JU"
+  },
+  {
+    "id": "1752|Villars-sur-Glâne|FR",
+    "name": "Villars-sur-Glâne",
+    "zipCode": "1752",
+    "canton": "FR"
+  },
+  {
+    "id": "1884|Villars-sur-Ollon|VD",
+    "name": "Villars-sur-Ollon",
+    "zipCode": "1884",
+    "canton": "VD"
+  },
+  {
+    "id": "1058|Villars-Tiercelin|VD",
+    "name": "Villars-Tiercelin",
+    "zipCode": "1058",
+    "canton": "VD"
+  },
+  {
+    "id": "1695|Villarsel-le-Gibloux|FR",
+    "name": "Villarsel-le-Gibloux",
+    "zipCode": "1695",
+    "canton": "FR"
+  },
+  {
+    "id": "1723|Villarsel-sur-Marly|FR",
+    "name": "Villarsel-sur-Marly",
+    "zipCode": "1723",
+    "canton": "FR"
+  },
+  {
+    "id": "1694|Villarsiviriaux|FR",
+    "name": "Villarsiviriaux",
+    "zipCode": "1694",
+    "canton": "FR"
+  },
+  {
+    "id": "1651|Villarvolard|FR",
+    "name": "Villarvolard",
+    "zipCode": "1651",
+    "canton": "FR"
+  },
+  {
+    "id": "1555|Villarzel|VD",
+    "name": "Villarzel",
+    "zipCode": "1555",
+    "canton": "VD"
+  },
+  {
+    "id": "1985|Villaz|VS",
+    "name": "Villaz",
+    "zipCode": "1985",
+    "canton": "VS"
+  },
+  {
+    "id": "1690|Villaz-St-Pierre|FR",
+    "name": "Villaz-St-Pierre",
+    "zipCode": "1690",
+    "canton": "FR"
+  },
+  {
+    "id": "1527|Villeneuve|FR",
+    "name": "Villeneuve",
+    "zipCode": "1527",
+    "canton": "FR"
+  },
+  {
+    "id": "1844|Villeneuve|VD",
+    "name": "Villeneuve",
+    "zipCode": "1844",
+    "canton": "VD"
+  },
+  {
+    "id": "2613|Villeret|BE",
+    "name": "Villeret",
+    "zipCode": "2613",
+    "canton": "BE"
+  },
+  {
+    "id": "1225|Villette|GE",
+    "name": "Villette",
+    "zipCode": "1225",
+    "canton": "GE"
+  },
+  {
+    "id": "1934|Villette|VS",
+    "name": "Villette",
+    "zipCode": "1934",
+    "canton": "VS"
+  },
+  {
+    "id": "1096|Villette (Lavaux)|VD",
+    "name": "Villette (Lavaux)",
+    "zipCode": "1096",
+    "canton": "VD"
+  },
+  {
+    "id": "2057|Villiers|NE",
+    "name": "Villiers",
+    "zipCode": "2057",
+    "canton": "NE"
+  },
+  {
+    "id": "5234|Villigen|AG",
+    "name": "Villigen",
+    "zipCode": "5234",
+    "canton": "AG"
+  },
+  {
+    "id": "5612|Villmergen|AG",
+    "name": "Villmergen",
+    "zipCode": "5612",
+    "canton": "AG"
+  },
+  {
+    "id": "5213|Villnachern|AG",
+    "name": "Villnachern",
+    "zipCode": "5213",
+    "canton": "AG"
+  },
+  {
+    "id": "1867|Villy|VD",
+    "name": "Villy",
+    "zipCode": "1867",
+    "canton": "VD"
+  },
+  {
+    "id": "7324|Vilters|SG",
+    "name": "Vilters",
+    "zipCode": "7324",
+    "canton": "SG"
+  },
+  {
+    "id": "1182|Vincy|VD",
+    "name": "Vincy",
+    "zipCode": "1182",
+    "canton": "VD"
+  },
+  {
+    "id": "3234|Vinelz|BE",
+    "name": "Vinelz",
+    "zipCode": "3234",
+    "canton": "BE"
+  },
+  {
+    "id": "2500|Vingelz|BE",
+    "name": "Vingelz",
+    "zipCode": "2500",
+    "canton": "BE"
+  },
+  {
+    "id": "1184|Vinzel|VD",
+    "name": "Vinzel",
+    "zipCode": "1184",
+    "canton": "VD"
+  },
+  {
+    "id": "1895|Vionnaz|VS",
+    "name": "Vionnaz",
+    "zipCode": "1895",
+    "canton": "VS"
+  },
+  {
+    "id": "6805|Vira|TI",
+    "name": "Vira",
+    "zipCode": "6805",
+    "canton": "TI"
+  },
+  {
+    "id": "6574|Vira (Gambarogno)|TI",
+    "name": "Vira (Gambarogno)",
+    "zipCode": "6574",
+    "canton": "TI"
+  },
+  {
+    "id": "1239|Vireloup|GE",
+    "name": "Vireloup",
+    "zipCode": "1239",
+    "canton": "GE"
+  },
+  {
+    "id": "1906|Vison|VS",
+    "name": "Vison",
+    "zipCode": "1906",
+    "canton": "VS"
+  },
+  {
+    "id": "3930|Visp|VS",
+    "name": "Visp",
+    "zipCode": "3930",
+    "canton": "VS"
+  },
+  {
+    "id": "3932|Visperterminen|VS",
+    "name": "Visperterminen",
+    "zipCode": "3932",
+    "canton": "VS"
+  },
+  {
+    "id": "3961|Vissoie|VS",
+    "name": "Vissoie",
+    "zipCode": "3961",
+    "canton": "VS"
+  },
+  {
+    "id": "6354|Vitznau|LU",
+    "name": "Vitznau",
+    "zipCode": "6354",
+    "canton": "LU"
+  },
+  {
+    "id": "7557|Vnà|GR",
+    "name": "Vnà",
+    "zipCode": "7557",
+    "canton": "GR"
+  },
+  {
+    "id": "6663|Vocaglia|TI",
+    "name": "Vocaglia",
+    "zipCode": "6663",
+    "canton": "TI"
+  },
+  {
+    "id": "3255|Vogelsang|BE",
+    "name": "Vogelsang",
+    "zipCode": "3255",
+    "canton": "BE"
+  },
+  {
+    "id": "5426|Vogelsang|AG",
+    "name": "Vogelsang",
+    "zipCode": "5426",
+    "canton": "AG"
+  },
+  {
+    "id": "5412|Vogelsang bei Turgi|AG",
+    "name": "Vogelsang bei Turgi",
+    "zipCode": "5412",
+    "canton": "AG"
+  },
+  {
+    "id": "6632|Vogorno|TI",
+    "name": "Vogorno",
+    "zipCode": "6632",
+    "canton": "TI"
+  },
+  {
+    "id": "8459|Volken|ZH",
+    "name": "Volken",
+    "zipCode": "8459",
+    "canton": "ZH"
+  },
+  {
+    "id": "8604|Volketswil|ZH",
+    "name": "Volketswil",
+    "zipCode": "8604",
+    "canton": "ZH"
+  },
+  {
+    "id": "1941|Vollèges|VS",
+    "name": "Vollèges",
+    "zipCode": "1941",
+    "canton": "VS"
+  },
+  {
+    "id": "8915|Vollenweid|ZH",
+    "name": "Vollenweid",
+    "zipCode": "8915",
+    "canton": "ZH"
+  },
+  {
+    "id": "4803|Vordemwald|AG",
+    "name": "Vordemwald",
+    "zipCode": "4803",
+    "canton": "AG"
+  },
+  {
+    "id": "3089|Vorderfultigen|BE",
+    "name": "Vorderfultigen",
+    "zipCode": "3089",
+    "canton": "BE"
+  },
+  {
+    "id": "9033|Vorderhof|SG",
+    "name": "Vorderhof",
+    "zipCode": "9033",
+    "canton": "SG"
+  },
+  {
+    "id": "3412|Vorderrinderbach|BE",
+    "name": "Vorderrinderbach",
+    "zipCode": "3412",
+    "canton": "BE"
+  },
+  {
+    "id": "3418|Vorderrinderbach|BE",
+    "name": "Vorderrinderbach",
+    "zipCode": "3418",
+    "canton": "BE"
+  },
+  {
+    "id": "8857|Vorderthal|SZ",
+    "name": "Vorderthal",
+    "zipCode": "8857",
+    "canton": "SZ"
+  },
+  {
+    "id": "3257|Vorimholz|BE",
+    "name": "Vorimholz",
+    "zipCode": "3257",
+    "canton": "BE"
+  },
+  {
+    "id": "1896|Vouvry|VS",
+    "name": "Vouvry",
+    "zipCode": "1896",
+    "canton": "VS"
+  },
+  {
+    "id": "7149|Vrin|GR",
+    "name": "Vrin",
+    "zipCode": "7149",
+    "canton": "GR"
+  },
+  {
+    "id": "1628|Vuadens|FR",
+    "name": "Vuadens",
+    "zipCode": "1628",
+    "canton": "FR"
+  },
+  {
+    "id": "1616|Vuarat|FR",
+    "name": "Vuarat",
+    "zipCode": "1616",
+    "canton": "FR"
+  },
+  {
+    "id": "1820|Vuarennes|VD",
+    "name": "Vuarennes",
+    "zipCode": "1820",
+    "canton": "VD"
+  },
+  {
+    "id": "1674|Vuarmarens|FR",
+    "name": "Vuarmarens",
+    "zipCode": "1674",
+    "canton": "FR"
+  },
+  {
+    "id": "1418|Vuarrengel|VD",
+    "name": "Vuarrengel",
+    "zipCode": "1418",
+    "canton": "VD"
+  },
+  {
+    "id": "1418|Vuarrens|VD",
+    "name": "Vuarrens",
+    "zipCode": "1418",
+    "canton": "VD"
+  },
+  {
+    "id": "1509|Vucherens|VD",
+    "name": "Vucherens",
+    "zipCode": "1509",
+    "canton": "VD"
+  },
+  {
+    "id": "1302|Vufflens-la-Ville|VD",
+    "name": "Vufflens-la-Ville",
+    "zipCode": "1302",
+    "canton": "VD"
+  },
+  {
+    "id": "1134|Vufflens-le-Château|VD",
+    "name": "Vufflens-le-Château",
+    "zipCode": "1134",
+    "canton": "VD"
+  },
+  {
+    "id": "1431|Vugelles|VD",
+    "name": "Vugelles",
+    "zipCode": "1431",
+    "canton": "VD"
+  },
+  {
+    "id": "1610|Vuibroye|VD",
+    "name": "Vuibroye",
+    "zipCode": "1610",
+    "canton": "VD"
+  },
+  {
+    "id": "1633|Vuippens|FR",
+    "name": "Vuippens",
+    "zipCode": "1633",
+    "canton": "FR"
+  },
+  {
+    "id": "1486|Vuissens|FR",
+    "name": "Vuissens",
+    "zipCode": "1486",
+    "canton": "FR"
+  },
+  {
+    "id": "1687|Vuisternens-devant-Romont|FR",
+    "name": "Vuisternens-devant-Romont",
+    "zipCode": "1687",
+    "canton": "FR"
+  },
+  {
+    "id": "1696|Vuisternens-en-Ogoz|FR",
+    "name": "Vuisternens-en-Ogoz",
+    "zipCode": "1696",
+    "canton": "FR"
+  },
+  {
+    "id": "1445|Vuiteboeuf|VD",
+    "name": "Vuiteboeuf",
+    "zipCode": "1445",
+    "canton": "VD"
+  },
+  {
+    "id": "1085|Vulliens|VD",
+    "name": "Vulliens",
+    "zipCode": "1085",
+    "canton": "VD"
+  },
+  {
+    "id": "1115|Vullierens|VD",
+    "name": "Vullierens",
+    "zipCode": "1115",
+    "canton": "VD"
+  },
+  {
+    "id": "7552|Vulpera|GR",
+    "name": "Vulpera",
+    "zipCode": "7552",
+    "canton": "GR"
+  },
+  {
+    "id": "8842|Waag|SZ",
+    "name": "Waag",
+    "zipCode": "8842",
+    "canton": "SZ"
+  },
+  {
+    "id": "3084|Wabern|BE",
+    "name": "Wabern",
+    "zipCode": "3084",
+    "canton": "BE"
+  },
+  {
+    "id": "3618|Wachseldorn|BE",
+    "name": "Wachseldorn",
+    "zipCode": "3618",
+    "canton": "BE"
+  },
+  {
+    "id": "3476|Wäckerschwend|BE",
+    "name": "Wäckerschwend",
+    "zipCode": "3476",
+    "canton": "BE"
+  },
+  {
+    "id": "8820|Wädenswil|ZH",
+    "name": "Wädenswil",
+    "zipCode": "8820",
+    "canton": "ZH"
+  },
+  {
+    "id": "8646|Wagen|SG",
+    "name": "Wagen",
+    "zipCode": "8646",
+    "canton": "SG"
+  },
+  {
+    "id": "8259|Wagenhausen|TG",
+    "name": "Wagenhausen",
+    "zipCode": "8259",
+    "canton": "TG"
+  },
+  {
+    "id": "8564|Wagerswil|TG",
+    "name": "Wagerswil",
+    "zipCode": "8564",
+    "canton": "TG"
+  },
+  {
+    "id": "4246|Wahlen bei Laufen|BL",
+    "name": "Wahlen bei Laufen",
+    "zipCode": "4246",
+    "canton": "BL"
+  },
+  {
+    "id": "3046|Wahlendorf|BE",
+    "name": "Wahlendorf",
+    "zipCode": "3046",
+    "canton": "BE"
+  },
+  {
+    "id": "1738|Wahlenhütten|BE",
+    "name": "Wahlenhütten",
+    "zipCode": "1738",
+    "canton": "BE"
+  },
+  {
+    "id": "3150|Wahlern|BE",
+    "name": "Wahlern",
+    "zipCode": "3150",
+    "canton": "BE"
+  },
+  {
+    "id": "6318|Walchwil|ZG",
+    "name": "Walchwil",
+    "zipCode": "6318",
+    "canton": "ZG"
+  },
+  {
+    "id": "6034|Wald|LU",
+    "name": "Wald",
+    "zipCode": "6034",
+    "canton": "LU"
+  },
+  {
+    "id": "8636|Wald|ZH",
+    "name": "Wald",
+    "zipCode": "8636",
+    "canton": "ZH"
+  },
+  {
+    "id": "9044|Wald|AR",
+    "name": "Wald",
+    "zipCode": "9044",
+    "canton": "AR"
+  },
+  {
+    "id": "9105|Wald|SG",
+    "name": "Wald",
+    "zipCode": "9105",
+    "canton": "SG"
+  },
+  {
+    "id": "5046|Walde|AG",
+    "name": "Walde",
+    "zipCode": "5046",
+    "canton": "AG"
+  },
+  {
+    "id": "8727|Walde|SG",
+    "name": "Walde",
+    "zipCode": "8727",
+    "canton": "SG"
+  },
+  {
+    "id": "3803|Waldegg|BE",
+    "name": "Waldegg",
+    "zipCode": "3803",
+    "canton": "BE"
+  },
+  {
+    "id": "8142|Waldegg bei Uitikon|ZH",
+    "name": "Waldegg bei Uitikon",
+    "zipCode": "8142",
+    "canton": "ZH"
+  },
+  {
+    "id": "4437|Waldenburg|BL",
+    "name": "Waldenburg",
+    "zipCode": "4437",
+    "canton": "BL"
+  },
+  {
+    "id": "3432|Waldhaus|BE",
+    "name": "Waldhaus",
+    "zipCode": "3432",
+    "canton": "BE"
+  },
+  {
+    "id": "5624|Waldhäusern|AG",
+    "name": "Waldhäusern",
+    "zipCode": "5624",
+    "canton": "AG"
+  },
+  {
+    "id": "8564|Wäldi|TG",
+    "name": "Wäldi",
+    "zipCode": "8564",
+    "canton": "TG"
+  },
+  {
+    "id": "9205|Waldkirch|SG",
+    "name": "Waldkirch",
+    "zipCode": "9205",
+    "canton": "SG"
+  },
+  {
+    "id": "9104|Waldstatt|AR",
+    "name": "Waldstatt",
+    "zipCode": "9104",
+    "canton": "AR"
+  },
+  {
+    "id": "8880|Walenstadt|SG",
+    "name": "Walenstadt",
+    "zipCode": "8880",
+    "canton": "SG"
+  },
+  {
+    "id": "8881|Walenstadtberg|SG",
+    "name": "Walenstadtberg",
+    "zipCode": "8881",
+    "canton": "SG"
+  },
+  {
+    "id": "3512|Walkringen|BE",
+    "name": "Walkringen",
+    "zipCode": "3512",
+    "canton": "BE"
+  },
+  {
+    "id": "4323|Wallbach|AG",
+    "name": "Wallbach",
+    "zipCode": "4323",
+    "canton": "AG"
+  },
+  {
+    "id": "3206|Wallenbuch|FR",
+    "name": "Wallenbuch",
+    "zipCode": "3206",
+    "canton": "FR"
+  },
+  {
+    "id": "1784|Wallenried|FR",
+    "name": "Wallenried",
+    "zipCode": "1784",
+    "canton": "FR"
+  },
+  {
+    "id": "5636|Wallenschwil|AG",
+    "name": "Wallenschwil",
+    "zipCode": "5636",
+    "canton": "AG"
+  },
+  {
+    "id": "8360|Wallenwil|TG",
+    "name": "Wallenwil",
+    "zipCode": "8360",
+    "canton": "TG"
+  },
+  {
+    "id": "8330|Wallikon|ZH",
+    "name": "Wallikon",
+    "zipCode": "8330",
+    "canton": "ZH"
+  },
+  {
+    "id": "8304|Wallisellen|ZH",
+    "name": "Wallisellen",
+    "zipCode": "8304",
+    "canton": "ZH"
+  },
+  {
+    "id": "3380|Walliswil bei Niederbipp|BE",
+    "name": "Walliswil bei Niederbipp",
+    "zipCode": "3380",
+    "canton": "BE"
+  },
+  {
+    "id": "3377|Walliswil bei Wangen|BE",
+    "name": "Walliswil bei Wangen",
+    "zipCode": "3377",
+    "canton": "BE"
+  },
+  {
+    "id": "3272|Walperswil|BE",
+    "name": "Walperswil",
+    "zipCode": "3272",
+    "canton": "BE"
+  },
+  {
+    "id": "8468|Waltalingen|ZH",
+    "name": "Waltalingen",
+    "zipCode": "8468",
+    "canton": "ZH"
+  },
+  {
+    "id": "7158|Waltensburg/Vuorz|GR",
+    "name": "Waltensburg/Vuorz",
+    "zipCode": "7158",
+    "canton": "GR"
+  },
+  {
+    "id": "5622|Waltenschwil|AG",
+    "name": "Waltenschwil",
+    "zipCode": "5622",
+    "canton": "AG"
+  },
+  {
+    "id": "8418|Waltenstein|ZH",
+    "name": "Waltenstein",
+    "zipCode": "8418",
+    "canton": "ZH"
+  },
+  {
+    "id": "4942|Walterswil|BE",
+    "name": "Walterswil",
+    "zipCode": "4942",
+    "canton": "BE"
+  },
+  {
+    "id": "5746|Walterswil|SO",
+    "name": "Walterswil",
+    "zipCode": "5746",
+    "canton": "SO"
+  },
+  {
+    "id": "8126|Waltikon|ZH",
+    "name": "Waltikon",
+    "zipCode": "8126",
+    "canton": "ZH"
+  },
+  {
+    "id": "3463|Waltrigen|BE",
+    "name": "Waltrigen",
+    "zipCode": "3463",
+    "canton": "BE"
+  },
+  {
+    "id": "3251|Waltwil|BE",
+    "name": "Waltwil",
+    "zipCode": "3251",
+    "canton": "BE"
+  },
+  {
+    "id": "9428|Walzenhausen|AR",
+    "name": "Walzenhausen",
+    "zipCode": "9428",
+    "canton": "AR"
+  },
+  {
+    "id": "9428|Walzenhausen|AI",
+    "name": "Walzenhausen",
+    "zipCode": "9428",
+    "canton": "AI"
+  },
+  {
+    "id": "3615|Wangelen|BE",
+    "name": "Wangelen",
+    "zipCode": "3615",
+    "canton": "BE"
+  },
+  {
+    "id": "8855|Wangen|SZ",
+    "name": "Wangen",
+    "zipCode": "8855",
+    "canton": "SZ"
+  },
+  {
+    "id": "3380|Wangen an der Aare|BE",
+    "name": "Wangen an der Aare",
+    "zipCode": "3380",
+    "canton": "BE"
+  },
+  {
+    "id": "8602|Wangen bei Dübendorf|ZH",
+    "name": "Wangen bei Dübendorf",
+    "zipCode": "8602",
+    "canton": "ZH"
+  },
+  {
+    "id": "4612|Wangen bei Olten|SO",
+    "name": "Wangen bei Olten",
+    "zipCode": "4612",
+    "canton": "SO"
+  },
+  {
+    "id": "3374|Wangenried|BE",
+    "name": "Wangenried",
+    "zipCode": "3374",
+    "canton": "BE"
+  },
+  {
+    "id": "9545|Wängi|TG",
+    "name": "Wängi",
+    "zipCode": "9545",
+    "canton": "TG"
+  },
+  {
+    "id": "7323|Wangs|SG",
+    "name": "Wangs",
+    "zipCode": "7323",
+    "canton": "SG"
+  },
+  {
+    "id": "3372|Wanzwil|BE",
+    "name": "Wanzwil",
+    "zipCode": "3372",
+    "canton": "BE"
+  },
+  {
+    "id": "9478|Wartau|SG",
+    "name": "Wartau",
+    "zipCode": "9478",
+    "canton": "SG"
+  },
+  {
+    "id": "8532|Warth|TG",
+    "name": "Warth",
+    "zipCode": "8532",
+    "canton": "TG"
+  },
+  {
+    "id": "8165|Wasen|ZH",
+    "name": "Wasen",
+    "zipCode": "8165",
+    "canton": "ZH"
+  },
+  {
+    "id": "3457|Wasen im Emmental|BE",
+    "name": "Wasen im Emmental",
+    "zipCode": "3457",
+    "canton": "BE"
+  },
+  {
+    "id": "6484|Wassen|UR",
+    "name": "Wassen",
+    "zipCode": "6484",
+    "canton": "UR"
+  },
+  {
+    "id": "9057|Wasserauen|AI",
+    "name": "Wasserauen",
+    "zipCode": "9057",
+    "canton": "AI"
+  },
+  {
+    "id": "9620|Wasserfluh|SG",
+    "name": "Wasserfluh",
+    "zipCode": "9620",
+    "canton": "SG"
+  },
+  {
+    "id": "6084|Wasserwendi|BE",
+    "name": "Wasserwendi",
+    "zipCode": "6084",
+    "canton": "BE"
+  },
+  {
+    "id": "8195|Wasterkingen|ZH",
+    "name": "Wasterkingen",
+    "zipCode": "8195",
+    "canton": "ZH"
+  },
+  {
+    "id": "8105|Watt|ZH",
+    "name": "Watt",
+    "zipCode": "8105",
+    "canton": "ZH"
+  },
+  {
+    "id": "3665|Wattenwil|BE",
+    "name": "Wattenwil",
+    "zipCode": "3665",
+    "canton": "BE"
+  },
+  {
+    "id": "3076|Wattenwil bei Worb|BE",
+    "name": "Wattenwil bei Worb",
+    "zipCode": "3076",
+    "canton": "BE"
+  },
+  {
+    "id": "9630|Wattwil|SG",
+    "name": "Wattwil",
+    "zipCode": "9630",
+    "canton": "SG"
+  },
+  {
+    "id": "6242|Wauwil|LU",
+    "name": "Wauwil",
+    "zipCode": "6242",
+    "canton": "LU"
+  },
+  {
+    "id": "6243|Wauwilermoos|LU",
+    "name": "Wauwilermoos",
+    "zipCode": "6243",
+    "canton": "LU"
+  },
+  {
+    "id": "2075|Wavre|NE",
+    "name": "Wavre",
+    "zipCode": "2075",
+    "canton": "NE"
+  },
+  {
+    "id": "8532|Weckingen|TG",
+    "name": "Weckingen",
+    "zipCode": "8532",
+    "canton": "TG"
+  },
+  {
+    "id": "8570|Weerswilen|TG",
+    "name": "Weerswilen",
+    "zipCode": "8570",
+    "canton": "TG"
+  },
+  {
+    "id": "8872|Weesen|GL",
+    "name": "Weesen",
+    "zipCode": "8872",
+    "canton": "GL"
+  },
+  {
+    "id": "8872|Weesen|SG",
+    "name": "Weesen",
+    "zipCode": "8872",
+    "canton": "SG"
+  },
+  {
+    "id": "4317|Wegenstetten|AG",
+    "name": "Wegenstetten",
+    "zipCode": "4317",
+    "canton": "AG"
+  },
+  {
+    "id": "6353|Weggis|LU",
+    "name": "Weggis",
+    "zipCode": "6353",
+    "canton": "LU"
+  },
+  {
+    "id": "8187|Weiach|ZH",
+    "name": "Weiach",
+    "zipCode": "8187",
+    "canton": "ZH"
+  },
+  {
+    "id": "3462|Weier im Emmental|BE",
+    "name": "Weier im Emmental",
+    "zipCode": "3462",
+    "canton": "BE"
+  },
+  {
+    "id": "9523|Weieren|SG",
+    "name": "Weieren",
+    "zipCode": "9523",
+    "canton": "SG"
+  },
+  {
+    "id": "9547|Weiern|TG",
+    "name": "Weiern",
+    "zipCode": "9547",
+    "canton": "TG"
+  },
+  {
+    "id": "8570|Weinfelden|TG",
+    "name": "Weinfelden",
+    "zipCode": "8570",
+    "canton": "TG"
+  },
+  {
+    "id": "9508|Weingarten|TG",
+    "name": "Weingarten",
+    "zipCode": "9508",
+    "canton": "TG"
+  },
+  {
+    "id": "8104|Weiningen|ZH",
+    "name": "Weiningen",
+    "zipCode": "8104",
+    "canton": "ZH"
+  },
+  {
+    "id": "8532|Weiningen|TG",
+    "name": "Weiningen",
+    "zipCode": "8532",
+    "canton": "TG"
+  },
+  {
+    "id": "4936|Weinstegen|BE",
+    "name": "Weinstegen",
+    "zipCode": "4936",
+    "canton": "BE"
+  },
+  {
+    "id": "9057|Weissbad|AI",
+    "name": "Weissbad",
+    "zipCode": "9057",
+    "canton": "AI"
+  },
+  {
+    "id": "3766|Weissenbach|BE",
+    "name": "Weissenbach",
+    "zipCode": "3766",
+    "canton": "BE"
+  },
+  {
+    "id": "5632|Weissenbach|AG",
+    "name": "Weissenbach",
+    "zipCode": "5632",
+    "canton": "AG"
+  },
+  {
+    "id": "3000|Weissenbühl|BE",
+    "name": "Weissenbühl",
+    "zipCode": "3000",
+    "canton": "BE"
+  },
+  {
+    "id": "3764|Weissenburg|BE",
+    "name": "Weissenburg",
+    "zipCode": "3764",
+    "canton": "BE"
+  },
+  {
+    "id": "3764|Weissenburgberg|BE",
+    "name": "Weissenburgberg",
+    "zipCode": "3764",
+    "canton": "BE"
+  },
+  {
+    "id": "3919|Weissenried|VS",
+    "name": "Weissenried",
+    "zipCode": "3919",
+    "canton": "VS"
+  },
+  {
+    "id": "3045|Weissenstein|BE",
+    "name": "Weissenstein",
+    "zipCode": "3045",
+    "canton": "BE"
+  },
+  {
+    "id": "4515|Weissenstein bei Solothurn|SO",
+    "name": "Weissenstein bei Solothurn",
+    "zipCode": "4515",
+    "canton": "SO"
+  },
+  {
+    "id": "8484|Weisslingen|ZH",
+    "name": "Weisslingen",
+    "zipCode": "8484",
+    "canton": "ZH"
+  },
+  {
+    "id": "7326|Weisstannen|SG",
+    "name": "Weisstannen",
+    "zipCode": "7326",
+    "canton": "SG"
+  },
+  {
+    "id": "9476|Weite|SG",
+    "name": "Weite",
+    "zipCode": "9476",
+    "canton": "SG"
+  },
+  {
+    "id": "9515|Welfensberg|TG",
+    "name": "Welfensberg",
+    "zipCode": "9515",
+    "canton": "TG"
+  },
+  {
+    "id": "8494|Wellenau|ZH",
+    "name": "Wellenau",
+    "zipCode": "8494",
+    "canton": "ZH"
+  },
+  {
+    "id": "8500|Wellenberg|TG",
+    "name": "Wellenberg",
+    "zipCode": "8500",
+    "canton": "TG"
+  },
+  {
+    "id": "8552|Wellhausen|TG",
+    "name": "Wellhausen",
+    "zipCode": "8552",
+    "canton": "TG"
+  },
+  {
+    "id": "4716|Welschenrohr|SO",
+    "name": "Welschenrohr",
+    "zipCode": "4716",
+    "canton": "SO"
+  },
+  {
+    "id": "8474|Welsikon|ZH",
+    "name": "Welsikon",
+    "zipCode": "8474",
+    "canton": "ZH"
+  },
+  {
+    "id": "3823|Wengen|BE",
+    "name": "Wengen",
+    "zipCode": "3823",
+    "canton": "BE"
+  },
+  {
+    "id": "3251|Wengi bei Büren|BE",
+    "name": "Wengi bei Büren",
+    "zipCode": "3251",
+    "canton": "BE"
+  },
+  {
+    "id": "3714|Wengi bei Frutigen|BE",
+    "name": "Wengi bei Frutigen",
+    "zipCode": "3714",
+    "canton": "BE"
+  },
+  {
+    "id": "1715|Wengliswil|FR",
+    "name": "Wengliswil",
+    "zipCode": "1715",
+    "canton": "FR"
+  },
+  {
+    "id": "4493|Wenslingen|BL",
+    "name": "Wenslingen",
+    "zipCode": "4493",
+    "canton": "BL"
+  },
+  {
+    "id": "8354|Wenzikon|ZH",
+    "name": "Wenzikon",
+    "zipCode": "8354",
+    "canton": "ZH"
+  },
+  {
+    "id": "8919|Werd|AG",
+    "name": "Werd",
+    "zipCode": "8919",
+    "canton": "AG"
+  },
+  {
+    "id": "9470|Werdenberg|SG",
+    "name": "Werdenberg",
+    "zipCode": "9470",
+    "canton": "SG"
+  },
+  {
+    "id": "3273|Werdthof|BE",
+    "name": "Werdthof",
+    "zipCode": "3273",
+    "canton": "BE"
+  },
+  {
+    "id": "7433|Wergenstein|GR",
+    "name": "Wergenstein",
+    "zipCode": "7433",
+    "canton": "GR"
+  },
+  {
+    "id": "8615|Wermatswil|ZH",
+    "name": "Wermatswil",
+    "zipCode": "8615",
+    "canton": "ZH"
+  },
+  {
+    "id": "8342|Wernetshausen|ZH",
+    "name": "Wernetshausen",
+    "zipCode": "8342",
+    "canton": "ZH"
+  },
+  {
+    "id": "8606|Werrikon|ZH",
+    "name": "Werrikon",
+    "zipCode": "8606",
+    "canton": "ZH"
+  },
+  {
+    "id": "6106|Werthenstein|LU",
+    "name": "Werthenstein",
+    "zipCode": "6106",
+    "canton": "LU"
+  },
+  {
+    "id": "6106|Werthenstein-Unterdorf|LU",
+    "name": "Werthenstein-Unterdorf",
+    "zipCode": "6106",
+    "canton": "LU"
+  },
+  {
+    "id": "5430|Wettingen|AG",
+    "name": "Wettingen",
+    "zipCode": "5430",
+    "canton": "AG"
+  },
+  {
+    "id": "4000|Wettstein|BS",
+    "name": "Wettstein",
+    "zipCode": "4000",
+    "canton": "BS"
+  },
+  {
+    "id": "8907|Wettswil am Albis|ZH",
+    "name": "Wettswil am Albis",
+    "zipCode": "8907",
+    "canton": "ZH"
+  },
+  {
+    "id": "8512|Wetzikon|TG",
+    "name": "Wetzikon",
+    "zipCode": "8512",
+    "canton": "TG"
+  },
+  {
+    "id": "8620|Wetzikon|ZH",
+    "name": "Wetzikon",
+    "zipCode": "8620",
+    "canton": "ZH"
+  },
+  {
+    "id": "3036|Wickacker|BE",
+    "name": "Wickacker",
+    "zipCode": "3036",
+    "canton": "BE"
+  },
+  {
+    "id": "5425|Widen|AG",
+    "name": "Widen",
+    "zipCode": "5425",
+    "canton": "AG"
+  },
+  {
+    "id": "8967|Widen|AG",
+    "name": "Widen",
+    "zipCode": "8967",
+    "canton": "AG"
+  },
+  {
+    "id": "4522|Widlisbach|SO",
+    "name": "Widlisbach",
+    "zipCode": "4522",
+    "canton": "SO"
+  },
+  {
+    "id": "9443|Widnau|SG",
+    "name": "Widnau",
+    "zipCode": "9443",
+    "canton": "SG"
+  },
+  {
+    "id": "8000|Wiedikon|ZH",
+    "name": "Wiedikon",
+    "zipCode": "8000",
+    "canton": "ZH"
+  },
+  {
+    "id": "4537|Wiedlisbach|BE",
+    "name": "Wiedlisbach",
+    "zipCode": "4537",
+    "canton": "BE"
+  },
+  {
+    "id": "9405|Wienacht|AR",
+    "name": "Wienacht",
+    "zipCode": "9405",
+    "canton": "AR"
+  },
+  {
+    "id": "3255|Wierezwil|BE",
+    "name": "Wierezwil",
+    "zipCode": "3255",
+    "canton": "BE"
+  },
+  {
+    "id": "7494|Wiesen|GR",
+    "name": "Wiesen",
+    "zipCode": "7494",
+    "canton": "GR"
+  },
+  {
+    "id": "6383|Wiesenberg|NW",
+    "name": "Wiesenberg",
+    "zipCode": "6383",
+    "canton": "NW"
+  },
+  {
+    "id": "8542|Wiesendangen|ZH",
+    "name": "Wiesendangen",
+    "zipCode": "8542",
+    "canton": "ZH"
+  },
+  {
+    "id": "8262|Wiesholz|SH",
+    "name": "Wiesholz",
+    "zipCode": "8262",
+    "canton": "SH"
+  },
+  {
+    "id": "8372|Wiezikon bei Sirnach|TG",
+    "name": "Wiezikon bei Sirnach",
+    "zipCode": "8372",
+    "canton": "TG"
+  },
+  {
+    "id": "9621|Wigetshof|SG",
+    "name": "Wigetshof",
+    "zipCode": "9621",
+    "canton": "SG"
+  },
+  {
+    "id": "6192|Wiggen|LU",
+    "name": "Wiggen",
+    "zipCode": "6192",
+    "canton": "LU"
+  },
+  {
+    "id": "3053|Wiggiswil|BE",
+    "name": "Wiggiswil",
+    "zipCode": "3053",
+    "canton": "BE"
+  },
+  {
+    "id": "5637|Wiggwil|AG",
+    "name": "Wiggwil",
+    "zipCode": "5637",
+    "canton": "AG"
+  },
+  {
+    "id": "8556|Wigoltingen|TG",
+    "name": "Wigoltingen",
+    "zipCode": "8556",
+    "canton": "TG"
+  },
+  {
+    "id": "3512|Wikartswil|BE",
+    "name": "Wikartswil",
+    "zipCode": "3512",
+    "canton": "BE"
+  },
+  {
+    "id": "4806|Wikon|LU",
+    "name": "Wikon",
+    "zipCode": "4806",
+    "canton": "LU"
+  },
+  {
+    "id": "5276|Wil|AG",
+    "name": "Wil",
+    "zipCode": "5276",
+    "canton": "AG"
+  },
+  {
+    "id": "6436|Wil|SZ",
+    "name": "Wil",
+    "zipCode": "6436",
+    "canton": "SZ"
+  },
+  {
+    "id": "8196|Wil|ZH",
+    "name": "Wil",
+    "zipCode": "8196",
+    "canton": "ZH"
+  },
+  {
+    "id": "9500|Wil|SG",
+    "name": "Wil",
+    "zipCode": "9500",
+    "canton": "SG"
+  },
+  {
+    "id": "8600|Wil bei Dübendorf|ZH",
+    "name": "Wil bei Dübendorf",
+    "zipCode": "8600",
+    "canton": "ZH"
+  },
+  {
+    "id": "4656|Wil bei Starrkirch|SO",
+    "name": "Wil bei Starrkirch",
+    "zipCode": "4656",
+    "canton": "SO"
+  },
+  {
+    "id": "5300|Wil bei Turgi|AG",
+    "name": "Wil bei Turgi",
+    "zipCode": "5300",
+    "canton": "AG"
+  },
+  {
+    "id": "8492|Wila|ZH",
+    "name": "Wila",
+    "zipCode": "8492",
+    "canton": "ZH"
+  },
+  {
+    "id": "8217|Wilchingen|SH",
+    "name": "Wilchingen",
+    "zipCode": "8217",
+    "canton": "SH"
+  },
+  {
+    "id": "8489|Wildberg|ZH",
+    "name": "Wildberg",
+    "zipCode": "8489",
+    "canton": "ZH"
+  },
+  {
+    "id": "5103|Wildegg|AG",
+    "name": "Wildegg",
+    "zipCode": "5103",
+    "canton": "AG"
+  },
+  {
+    "id": "8465|Wildensbuch|ZH",
+    "name": "Wildensbuch",
+    "zipCode": "8465",
+    "canton": "ZH"
+  },
+  {
+    "id": "3812|Wilderswil|BE",
+    "name": "Wilderswil",
+    "zipCode": "3812",
+    "canton": "BE"
+  },
+  {
+    "id": "9658|Wildhaus|SG",
+    "name": "Wildhaus",
+    "zipCode": "9658",
+    "canton": "SG"
+  },
+  {
+    "id": "3928|Wildi|VS",
+    "name": "Wildi",
+    "zipCode": "3928",
+    "canton": "VS"
+  },
+  {
+    "id": "6062|Wilen|OW",
+    "name": "Wilen",
+    "zipCode": "6062",
+    "canton": "OW"
+  },
+  {
+    "id": "9100|Wilen|AR",
+    "name": "Wilen",
+    "zipCode": "9100",
+    "canton": "AR"
+  },
+  {
+    "id": "9428|Wilen|AR",
+    "name": "Wilen",
+    "zipCode": "9428",
+    "canton": "AR"
+  },
+  {
+    "id": "9225|Wilen (Gottshaus)|TG",
+    "name": "Wilen (Gottshaus)",
+    "zipCode": "9225",
+    "canton": "TG"
+  },
+  {
+    "id": "8535|Wilen bei Herdern|TG",
+    "name": "Wilen bei Herdern",
+    "zipCode": "8535",
+    "canton": "TG"
+  },
+  {
+    "id": "8525|Wilen bei Neunforn|ZH",
+    "name": "Wilen bei Neunforn",
+    "zipCode": "8525",
+    "canton": "ZH"
+  },
+  {
+    "id": "8525|Wilen bei Neunforn|TG",
+    "name": "Wilen bei Neunforn",
+    "zipCode": "8525",
+    "canton": "TG"
+  },
+  {
+    "id": "9535|Wilen bei Wil|TG",
+    "name": "Wilen bei Wil",
+    "zipCode": "9535",
+    "canton": "TG"
+  },
+  {
+    "id": "8832|Wilen bei Wollerau|SZ",
+    "name": "Wilen bei Wollerau",
+    "zipCode": "8832",
+    "canton": "SZ"
+  },
+  {
+    "id": "4252|Wiler|SO",
+    "name": "Wiler",
+    "zipCode": "4252",
+    "canton": "SO"
+  },
+  {
+    "id": "6482|Wiler|UR",
+    "name": "Wiler",
+    "zipCode": "6482",
+    "canton": "UR"
+  },
+  {
+    "id": "8427|Wiler|ZH",
+    "name": "Wiler",
+    "zipCode": "8427",
+    "canton": "ZH"
+  },
+  {
+    "id": "3918|Wiler (Lötschen)|VS",
+    "name": "Wiler (Lötschen)",
+    "zipCode": "3918",
+    "canton": "VS"
+  },
+  {
+    "id": "3266|Wiler bei Seedorf|BE",
+    "name": "Wiler bei Seedorf",
+    "zipCode": "3266",
+    "canton": "BE"
+  },
+  {
+    "id": "3428|Wiler bei Utzenstorf|BE",
+    "name": "Wiler bei Utzenstorf",
+    "zipCode": "3428",
+    "canton": "BE"
+  },
+  {
+    "id": "1714|Wiler vor Holz|FR",
+    "name": "Wiler vor Holz",
+    "zipCode": "1714",
+    "canton": "FR"
+  },
+  {
+    "id": "3207|Wileroltigen|BE",
+    "name": "Wileroltigen",
+    "zipCode": "3207",
+    "canton": "BE"
+  },
+  {
+    "id": "5058|Wiliberg|AG",
+    "name": "Wiliberg",
+    "zipCode": "5058",
+    "canton": "AG"
+  },
+  {
+    "id": "6236|Wilihof|LU",
+    "name": "Wilihof",
+    "zipCode": "6236",
+    "canton": "LU"
+  },
+  {
+    "id": "3425|Willadingen|BE",
+    "name": "Willadingen",
+    "zipCode": "3425",
+    "canton": "BE"
+  },
+  {
+    "id": "8846|Willerzell|SZ",
+    "name": "Willerzell",
+    "zipCode": "8846",
+    "canton": "SZ"
+  },
+  {
+    "id": "3860|Willigen|BE",
+    "name": "Willigen",
+    "zipCode": "3860",
+    "canton": "BE"
+  },
+  {
+    "id": "8618|Willikon|ZH",
+    "name": "Willikon",
+    "zipCode": "8618",
+    "canton": "ZH"
+  },
+  {
+    "id": "6130|Willisau|LU",
+    "name": "Willisau",
+    "zipCode": "6130",
+    "canton": "LU"
+  },
+  {
+    "id": "8253|Willisdorf|TG",
+    "name": "Willisdorf",
+    "zipCode": "8253",
+    "canton": "TG"
+  },
+  {
+    "id": "3752|Wimmis|BE",
+    "name": "Wimmis",
+    "zipCode": "3752",
+    "canton": "BE"
+  },
+  {
+    "id": "9315|Winden|TG",
+    "name": "Winden",
+    "zipCode": "9315",
+    "canton": "TG"
+  },
+  {
+    "id": "5210|Windisch|AG",
+    "name": "Windisch",
+    "zipCode": "5210",
+    "canton": "AG"
+  },
+  {
+    "id": "8175|Windlach|ZH",
+    "name": "Windlach",
+    "zipCode": "8175",
+    "canton": "ZH"
+  },
+  {
+    "id": "2513|Wingreis|BE",
+    "name": "Wingreis",
+    "zipCode": "2513",
+    "canton": "BE"
+  },
+  {
+    "id": "6235|Winikon|LU",
+    "name": "Winikon",
+    "zipCode": "6235",
+    "canton": "LU"
+  },
+  {
+    "id": "4558|Winistorf|SO",
+    "name": "Winistorf",
+    "zipCode": "4558",
+    "canton": "SO"
+  },
+  {
+    "id": "8185|Winkel|ZH",
+    "name": "Winkel",
+    "zipCode": "8185",
+    "canton": "ZH"
+  },
+  {
+    "id": "9015|Winkeln|SG",
+    "name": "Winkeln",
+    "zipCode": "9015",
+    "canton": "SG"
+  },
+  {
+    "id": "8312|Winterberg|ZH",
+    "name": "Winterberg",
+    "zipCode": "8312",
+    "canton": "ZH"
+  },
+  {
+    "id": "5647|Winterhalden|AG",
+    "name": "Winterhalden",
+    "zipCode": "5647",
+    "canton": "AG"
+  },
+  {
+    "id": "5637|Winterschwil|AG",
+    "name": "Winterschwil",
+    "zipCode": "5637",
+    "canton": "AG"
+  },
+  {
+    "id": "4451|Wintersingen|BL",
+    "name": "Wintersingen",
+    "zipCode": "4451",
+    "canton": "BL"
+  },
+  {
+    "id": "8400|Winterthur|ZH",
+    "name": "Winterthur",
+    "zipCode": "8400",
+    "canton": "ZH"
+  },
+  {
+    "id": "4652|Winznau|SO",
+    "name": "Winznau",
+    "zipCode": "4652",
+    "canton": "SO"
+  },
+  {
+    "id": "8000|Wipkingen|ZH",
+    "name": "Wipkingen",
+    "zipCode": "8000",
+    "canton": "ZH"
+  },
+  {
+    "id": "6383|Wirzweli|NW",
+    "name": "Wirzweli",
+    "zipCode": "6383",
+    "canton": "NW"
+  },
+  {
+    "id": "4634|Wisen|SO",
+    "name": "Wisen",
+    "zipCode": "4634",
+    "canton": "SO"
+  },
+  {
+    "id": "5463|Wislikofen|AG",
+    "name": "Wislikofen",
+    "zipCode": "5463",
+    "canton": "AG"
+  },
+  {
+    "id": "8000|Witikon|ZH",
+    "name": "Witikon",
+    "zipCode": "8000",
+    "canton": "ZH"
+  },
+  {
+    "id": "9300|Wittenbach|SG",
+    "name": "Wittenbach",
+    "zipCode": "9300",
+    "canton": "SG"
+  },
+  {
+    "id": "9547|Wittenwil|TG",
+    "name": "Wittenwil",
+    "zipCode": "9547",
+    "canton": "TG"
+  },
+  {
+    "id": "4108|Witterswil|SO",
+    "name": "Witterswil",
+    "zipCode": "4108",
+    "canton": "SO"
+  },
+  {
+    "id": "9430|Witti|SG",
+    "name": "Witti",
+    "zipCode": "9430",
+    "canton": "SG"
+  },
+  {
+    "id": "4443|Wittinsburg|BL",
+    "name": "Wittinsburg",
+    "zipCode": "4443",
+    "canton": "BL"
+  },
+  {
+    "id": "5064|Wittnau|AG",
+    "name": "Wittnau",
+    "zipCode": "5064",
+    "canton": "AG"
+  },
+  {
+    "id": "5053|Wittwil|AG",
+    "name": "Wittwil",
+    "zipCode": "5053",
+    "canton": "AG"
+  },
+  {
+    "id": "3236|Witzwil|BE",
+    "name": "Witzwil",
+    "zipCode": "3236",
+    "canton": "BE"
+  },
+  {
+    "id": "3033|Wohlei|BE",
+    "name": "Wohlei",
+    "zipCode": "3033",
+    "canton": "BE"
+  },
+  {
+    "id": "5610|Wohlen|AG",
+    "name": "Wohlen",
+    "zipCode": "5610",
+    "canton": "AG"
+  },
+  {
+    "id": "3033|Wohlen bei Bern|BE",
+    "name": "Wohlen bei Bern",
+    "zipCode": "3033",
+    "canton": "BE"
+  },
+  {
+    "id": "5512|Wohlenschwil|AG",
+    "name": "Wohlenschwil",
+    "zipCode": "5512",
+    "canton": "AG"
+  },
+  {
+    "id": "6386|Wolfenschiessen|NW",
+    "name": "Wolfenschiessen",
+    "zipCode": "6386",
+    "canton": "NW"
+  },
+  {
+    "id": "9116|Wolfertswil|SG",
+    "name": "Wolfertswil",
+    "zipCode": "9116",
+    "canton": "SG"
+  },
+  {
+    "id": "7265|Wolfgang|GR",
+    "name": "Wolfgang",
+    "zipCode": "7265",
+    "canton": "GR"
+  },
+  {
+    "id": "9427|Wolfhalden|AR",
+    "name": "Wolfhalden",
+    "zipCode": "9427",
+    "canton": "AR"
+  },
+  {
+    "id": "9427|Wolfhalden|AI",
+    "name": "Wolfhalden",
+    "zipCode": "9427",
+    "canton": "AI"
+  },
+  {
+    "id": "8633|Wolfhausen|ZH",
+    "name": "Wolfhausen",
+    "zipCode": "8633",
+    "canton": "ZH"
+  },
+  {
+    "id": "8514|Wolfikon|TG",
+    "name": "Wolfikon",
+    "zipCode": "8514",
+    "canton": "TG"
+  },
+  {
+    "id": "9533|Wolfikon|SG",
+    "name": "Wolfikon",
+    "zipCode": "9533",
+    "canton": "SG"
+  },
+  {
+    "id": "4704|Wolfisberg|BE",
+    "name": "Wolfisberg",
+    "zipCode": "4704",
+    "canton": "BE"
+  },
+  {
+    "id": "5063|Wölflinswil|AG",
+    "name": "Wölflinswil",
+    "zipCode": "5063",
+    "canton": "AG"
+  },
+  {
+    "id": "3036|Wölflisried|BE",
+    "name": "Wölflisried",
+    "zipCode": "3036",
+    "canton": "BE"
+  },
+  {
+    "id": "4628|Wolfwil|SO",
+    "name": "Wolfwil",
+    "zipCode": "4628",
+    "canton": "SO"
+  },
+  {
+    "id": "6110|Wolhusen|LU",
+    "name": "Wolhusen",
+    "zipCode": "6110",
+    "canton": "LU"
+  },
+  {
+    "id": "8832|Wollerau|SZ",
+    "name": "Wollerau",
+    "zipCode": "8832",
+    "canton": "SZ"
+  },
+  {
+    "id": "8000|Wollishofen|ZH",
+    "name": "Wollishofen",
+    "zipCode": "8000",
+    "canton": "ZH"
+  },
+  {
+    "id": "8912|Wolsen|ZH",
+    "name": "Wolsen",
+    "zipCode": "8912",
+    "canton": "ZH"
+  },
+  {
+    "id": "3076|Worb|BE",
+    "name": "Worb",
+    "zipCode": "3076",
+    "canton": "BE"
+  },
+  {
+    "id": "3252|Worben|BE",
+    "name": "Worben",
+    "zipCode": "3252",
+    "canton": "BE"
+  },
+  {
+    "id": "3048|Worblaufen|BE",
+    "name": "Worblaufen",
+    "zipCode": "3048",
+    "canton": "BE"
+  },
+  {
+    "id": "5012|Wöschnau|SO",
+    "name": "Wöschnau",
+    "zipCode": "5012",
+    "canton": "SO"
+  },
+  {
+    "id": "8400|Wülflingen|ZH",
+    "name": "Wülflingen",
+    "zipCode": "8400",
+    "canton": "ZH"
+  },
+  {
+    "id": "3184|Wünnewil|FR",
+    "name": "Wünnewil",
+    "zipCode": "3184",
+    "canton": "FR"
+  },
+  {
+    "id": "9514|Wuppenau|TG",
+    "name": "Wuppenau",
+    "zipCode": "9514",
+    "canton": "TG"
+  },
+  {
+    "id": "5303|Würenlingen|AG",
+    "name": "Würenlingen",
+    "zipCode": "5303",
+    "canton": "AG"
+  },
+  {
+    "id": "5436|Würenlos|AG",
+    "name": "Würenlos",
+    "zipCode": "5436",
+    "canton": "AG"
+  },
+  {
+    "id": "3862|Wyler|BE",
+    "name": "Wyler",
+    "zipCode": "3862",
+    "canton": "BE"
+  },
+  {
+    "id": "4923|Wynau|BE",
+    "name": "Wynau",
+    "zipCode": "4923",
+    "canton": "BE"
+  },
+  {
+    "id": "3472|Wynigen|BE",
+    "name": "Wynigen",
+    "zipCode": "3472",
+    "canton": "BE"
+  },
+  {
+    "id": "4954|Wyssachen|BE",
+    "name": "Wyssachen",
+    "zipCode": "4954",
+    "canton": "BE"
+  },
+  {
+    "id": "4934|Wyssbach|BE",
+    "name": "Wyssbach",
+    "zipCode": "4934",
+    "canton": "BE"
+  },
+  {
+    "id": "1169|Yens|VD",
+    "name": "Yens",
+    "zipCode": "1169",
+    "canton": "VD"
+  },
+  {
+    "id": "1981|Ypresses|VS",
+    "name": "Ypresses",
+    "zipCode": "1981",
+    "canton": "VS"
+  },
+  {
+    "id": "1400|Yverdon-les-Bains|VD",
+    "name": "Yverdon-les-Bains",
+    "zipCode": "1400",
+    "canton": "VD"
+  },
+  {
+    "id": "1462|Yvonand|VD",
+    "name": "Yvonand",
+    "zipCode": "1462",
+    "canton": "VD"
+  },
+  {
+    "id": "1853|Yvorne|VD",
+    "name": "Yvorne",
+    "zipCode": "1853",
+    "canton": "VD"
+  },
+  {
+    "id": "7748|Zalende|GR",
+    "name": "Zalende",
+    "zipCode": "7748",
+    "canton": "GR"
+  },
+  {
+    "id": "7107|Zalön|GR",
+    "name": "Zalön",
+    "zipCode": "7107",
+    "canton": "GR"
+  },
+  {
+    "id": "3309|Zauggenried|BE",
+    "name": "Zauggenried",
+    "zipCode": "3309",
+    "canton": "BE"
+  },
+  {
+    "id": "3532|Zäziwil|BE",
+    "name": "Zäziwil",
+    "zipCode": "3532",
+    "canton": "BE"
+  },
+  {
+    "id": "4495|Zeglingen|BL",
+    "name": "Zeglingen",
+    "zipCode": "4495",
+    "canton": "BL"
+  },
+  {
+    "id": "5079|Zeihen|AG",
+    "name": "Zeihen",
+    "zipCode": "5079",
+    "canton": "AG"
+  },
+  {
+    "id": "4314|Zeiningen|AG",
+    "name": "Zeiningen",
+    "zipCode": "4314",
+    "canton": "AG"
+  },
+  {
+    "id": "9427|Zelg bei Wolfhalden|AR",
+    "name": "Zelg bei Wolfhalden",
+    "zipCode": "9427",
+    "canton": "AR"
+  },
+  {
+    "id": "6144|Zell|LU",
+    "name": "Zell",
+    "zipCode": "6144",
+    "canton": "LU"
+  },
+  {
+    "id": "8487|Zell|ZH",
+    "name": "Zell",
+    "zipCode": "8487",
+    "canton": "ZH"
+  },
+  {
+    "id": "1724|Zénauva|FR",
+    "name": "Zénauva",
+    "zipCode": "1724",
+    "canton": "FR"
+  },
+  {
+    "id": "3934|Zeneggen|VS",
+    "name": "Zeneggen",
+    "zipCode": "3934",
+    "canton": "VS"
+  },
+  {
+    "id": "3920|Zermatt|VS",
+    "name": "Zermatt",
+    "zipCode": "3920",
+    "canton": "VS"
+  },
+  {
+    "id": "7530|Zernez|GR",
+    "name": "Zernez",
+    "zipCode": "7530",
+    "canton": "GR"
+  },
+  {
+    "id": "5732|Zetzwil|AG",
+    "name": "Zetzwil",
+    "zipCode": "5732",
+    "canton": "AG"
+  },
+  {
+    "id": "9556|Zezikon|TG",
+    "name": "Zezikon",
+    "zipCode": "9556",
+    "canton": "TG"
+  },
+  {
+    "id": "4417|Ziefen|BL",
+    "name": "Ziefen",
+    "zipCode": "4417",
+    "canton": "BL"
+  },
+  {
+    "id": "8866|Ziegelbrücke|GL",
+    "name": "Ziegelbrücke",
+    "zipCode": "8866",
+    "canton": "GL"
+  },
+  {
+    "id": "8866|Ziegelbrücke|SG",
+    "name": "Ziegelbrücke",
+    "zipCode": "8866",
+    "canton": "SG"
+  },
+  {
+    "id": "3054|Ziegelried|BE",
+    "name": "Ziegelried",
+    "zipCode": "3054",
+    "canton": "BE"
+  },
+  {
+    "id": "4564|Zielebach|BE",
+    "name": "Zielebach",
+    "zipCode": "4564",
+    "canton": "BE"
+  },
+  {
+    "id": "7167|Zignau|GR",
+    "name": "Zignau",
+    "zipCode": "7167",
+    "canton": "GR"
+  },
+  {
+    "id": "3238|Zihlbrücke|BE",
+    "name": "Zihlbrücke",
+    "zipCode": "3238",
+    "canton": "BE"
+  },
+  {
+    "id": "8588|Zihlschlacht|TG",
+    "name": "Zihlschlacht",
+    "zipCode": "8588",
+    "canton": "TG"
+  },
+  {
+    "id": "7432|Zillis|GR",
+    "name": "Zillis",
+    "zipCode": "7432",
+    "canton": "GR"
+  },
+  {
+    "id": "8604|Zimikon|ZH",
+    "name": "Zimikon",
+    "zipCode": "8604",
+    "canton": "ZH"
+  },
+  {
+    "id": "3255|Zimlisberg|BE",
+    "name": "Zimlisberg",
+    "zipCode": "3255",
+    "canton": "BE"
+  },
+  {
+    "id": "3086|Zimmerwald|BE",
+    "name": "Zimmerwald",
+    "zipCode": "3086",
+    "canton": "BE"
+  },
+  {
+    "id": "3961|Zinal|VS",
+    "name": "Zinal",
+    "zipCode": "3961",
+    "canton": "VS"
+  },
+  {
+    "id": "7205|Zizers|GR",
+    "name": "Zizers",
+    "zipCode": "7205",
+    "canton": "GR"
+  },
+  {
+    "id": "4800|Zofingen|AG",
+    "name": "Zofingen",
+    "zipCode": "4800",
+    "canton": "AG"
+  },
+  {
+    "id": "3436|Zollbrück|BE",
+    "name": "Zollbrück",
+    "zipCode": "3436",
+    "canton": "BE"
+  },
+  {
+    "id": "1716|Zollhaus|FR",
+    "name": "Zollhaus",
+    "zipCode": "1716",
+    "canton": "FR"
+  },
+  {
+    "id": "8125|Zollikerberg|ZH",
+    "name": "Zollikerberg",
+    "zipCode": "8125",
+    "canton": "ZH"
+  },
+  {
+    "id": "3052|Zollikofen|BE",
+    "name": "Zollikofen",
+    "zipCode": "3052",
+    "canton": "BE"
+  },
+  {
+    "id": "8702|Zollikon|ZH",
+    "name": "Zollikon",
+    "zipCode": "8702",
+    "canton": "ZH"
+  },
+  {
+    "id": "8702|Zollikon Dorf|ZH",
+    "name": "Zollikon Dorf",
+    "zipCode": "8702",
+    "canton": "ZH"
+  },
+  {
+    "id": "7082|Zorten|GR",
+    "name": "Zorten",
+    "zipCode": "7082",
+    "canton": "GR"
+  },
+  {
+    "id": "8585|Zuben|TG",
+    "name": "Zuben",
+    "zipCode": "8585",
+    "canton": "TG"
+  },
+  {
+    "id": "9523|Züberwangen|SG",
+    "name": "Züberwangen",
+    "zipCode": "9523",
+    "canton": "SG"
+  },
+  {
+    "id": "4528|Zuchwil|SO",
+    "name": "Zuchwil",
+    "zipCode": "4528",
+    "canton": "SO"
+  },
+  {
+    "id": "9526|Zuckenriet|SG",
+    "name": "Zuckenriet",
+    "zipCode": "9526",
+    "canton": "SG"
+  },
+  {
+    "id": "5621|Zufikon|AG",
+    "name": "Zufikon",
+    "zipCode": "5621",
+    "canton": "AG"
+  },
+  {
+    "id": "6300|Zug|ZG",
+    "name": "Zug",
+    "zipCode": "6300",
+    "canton": "ZG"
+  },
+  {
+    "id": "6300|Zugerberg|ZG",
+    "name": "Zugerberg",
+    "zipCode": "6300",
+    "canton": "ZG"
+  },
+  {
+    "id": "4234|Zullwil|SO",
+    "name": "Zullwil",
+    "zipCode": "4234",
+    "canton": "SO"
+  },
+  {
+    "id": "1713|Zumholz|FR",
+    "name": "Zumholz",
+    "zipCode": "1713",
+    "canton": "FR"
+  },
+  {
+    "id": "1719|Zumholz bei Plaffeien|FR",
+    "name": "Zumholz bei Plaffeien",
+    "zipCode": "1719",
+    "canton": "FR"
+  },
+  {
+    "id": "8126|Zumikon|ZH",
+    "name": "Zumikon",
+    "zipCode": "8126",
+    "canton": "ZH"
+  },
+  {
+    "id": "8543|Zünikon|ZH",
+    "name": "Zünikon",
+    "zipCode": "8543",
+    "canton": "ZH"
+  },
+  {
+    "id": "4455|Zunzgen|BL",
+    "name": "Zunzgen",
+    "zipCode": "4455",
+    "canton": "BL"
+  },
+  {
+    "id": "7557|Zuort|GR",
+    "name": "Zuort",
+    "zipCode": "7557",
+    "canton": "GR"
+  },
+  {
+    "id": "7524|Zuoz|GR",
+    "name": "Zuoz",
+    "zipCode": "7524",
+    "canton": "GR"
+  },
+  {
+    "id": "9107|Zürchersmühle|AR",
+    "name": "Zürchersmühle",
+    "zipCode": "9107",
+    "canton": "AR"
+  },
+  {
+    "id": "8000|Zürich|ZH",
+    "name": "Zürich",
+    "zipCode": "8000",
+    "canton": "ZH"
+  },
+  {
+    "id": "4315|Zuzgen|AG",
+    "name": "Zuzgen",
+    "zipCode": "4315",
+    "canton": "AG"
+  },
+  {
+    "id": "3303|Zuzwil|BE",
+    "name": "Zuzwil",
+    "zipCode": "3303",
+    "canton": "BE"
+  },
+  {
+    "id": "9524|Zuzwil|SG",
+    "name": "Zuzwil",
+    "zipCode": "9524",
+    "canton": "SG"
+  },
+  {
+    "id": "8192|Zweidlen|ZH",
+    "name": "Zweidlen",
+    "zipCode": "8192",
+    "canton": "ZH"
+  },
+  {
+    "id": "3815|Zweilütschinen|BE",
+    "name": "Zweilütschinen",
+    "zipCode": "3815",
+    "canton": "BE"
+  },
+  {
+    "id": "3770|Zweisimmen|BE",
+    "name": "Zweisimmen",
+    "zipCode": "3770",
+    "canton": "BE"
+  },
+  {
+    "id": "3645|Zwieselberg|BE",
+    "name": "Zwieselberg",
+    "zipCode": "3645",
+    "canton": "BE"
+  },
+  {
+    "id": "8909|Zwillikon|ZH",
+    "name": "Zwillikon",
+    "zipCode": "8909",
+    "canton": "ZH"
+  },
+  {
+    "id": "4222|Zwingen|BL",
+    "name": "Zwingen",
+    "zipCode": "4222",
+    "canton": "BL"
+  },
+  {
+    "id": "3907|Zwischbergen|VS",
+    "name": "Zwischbergen",
+    "zipCode": "3907",
+    "canton": "VS"
+  },
+  {
+    "id": "3756|Zwischenflüh|BE",
+    "name": "Zwischenflüh",
+    "zipCode": "3756",
+    "canton": "BE"
+  }
+]

--- a/yarn.lock
+++ b/yarn.lock
@@ -2823,6 +2823,14 @@ argparse@^2.0.1:
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
+arguments-extended@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/arguments-extended/-/arguments-extended-0.0.3.tgz#6107e4917d0eb6f0a4dd66320fc15afc72ef4946"
+  integrity sha512-MNYdPKgCiywbgHAmNsYr1tSNLtfbSdwE1akZV+33hU9A8RG0lO5HAK9oMnw7y7bjYUhc04dJpcIBMUaPPYYtXg==
+  dependencies:
+    extended "~0.0.3"
+    is-extended "~0.0.8"
+
 aria-query@5.1.3:
   version "5.1.3"
   resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.1.3.tgz#19db27cd101152773631396f7a95a3b58c22c35e"
@@ -2842,6 +2850,15 @@ array-buffer-byte-length@^1.0.0, array-buffer-byte-length@^1.0.1, array-buffer-b
   dependencies:
     call-bound "^1.0.3"
     is-array-buffer "^3.0.5"
+
+array-extended@~0.0.3, array-extended@~0.0.4, array-extended@~0.0.5:
+  version "0.0.11"
+  resolved "https://registry.yarnpkg.com/array-extended/-/array-extended-0.0.11.tgz#d7144ae748de93ca726f121009dbff1626d164bd"
+  integrity sha512-Fe4Ti2YgM1onQgrcCD8dUhFuZgHQxzqylSl1C5IDJVVVqY5D07h8RghIXL9sZ6COZ0e+oTL5IusTv5eXABJ9Kw==
+  dependencies:
+    arguments-extended "~0.0.3"
+    extended "~0.0.3"
+    is-extended "~0.0.3"
 
 array-flatten@1.1.1:
   version "1.1.1"
@@ -3901,6 +3918,15 @@ data-view-byte-offset@^1.0.1:
     es-errors "^1.3.0"
     is-data-view "^1.0.1"
 
+date-extended@~0.0.3:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/date-extended/-/date-extended-0.0.6.tgz#23802d57dd1bf7818813fe0c32e851a86da267c9"
+  integrity sha512-v9a2QLTVn1GQGXf02TQaSvNfeXA/V1FL2Tr0OQYqjI5+L9T5jEtCpLYG01sxFk+m1OtwMxydkKa8NKcflANAoQ==
+  dependencies:
+    array-extended "~0.0.3"
+    extended "~0.0.3"
+    is-extended "~0.0.3"
+
 debug@2.6.9, debug@^2.6.0:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -3926,6 +3952,11 @@ decimal.js@^10.2.1:
   version "10.6.0"
   resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.6.0.tgz#e649a43e3ab953a72192ff5983865e509f37ed9a"
   integrity sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==
+
+declare.js@~0.0.4:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/declare.js/-/declare.js-0.0.8.tgz#0478adff9564c004f51df73d8bc134019d28dcde"
+  integrity sha512-O659hy1gcHef7JnwtqdQlrj2c5DAEgtxm8pgFXofW7eUE1L4FjsSLlziovWcrOJAOFlEPaOJshY+0hBWCG/AnA==
 
 dedent@^0.7.0:
   version "0.7.0"
@@ -4815,6 +4846,31 @@ express@^4.17.3:
     utils-merge "1.0.1"
     vary "~1.1.2"
 
+extended@0.0.6, extended@~0.0.3:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/extended/-/extended-0.0.6.tgz#7fb8bf7b9dae397586e48570acfd642c78e50669"
+  integrity sha512-rvAV3BDGsV1SYGzUOu7aO0k82quhfl0QAyZudYhAcTeIr1rPbBnyOhOlkCLwLpDfP7HyKAWAPNSjRb9p7lE3rg==
+  dependencies:
+    extender "~0.0.5"
+
+extender@~0.0.5:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/extender/-/extender-0.0.10.tgz#589c07482be61a1460b6d81f9c24aa67e8f324cd"
+  integrity sha512-iPLUHZJaNW6RuOShQX33ZpewEUIlijFBcsXnKWyiYERKWPsFxfKgx8J0xRz29hKQWPFFPACgBW6cHM7Ke1pfaA==
+  dependencies:
+    declare.js "~0.0.4"
+
+fast-csv@^2.0.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/fast-csv/-/fast-csv-2.5.0.tgz#5332dfede3f59340cb8e9f46b2e6dff1e7612005"
+  integrity sha512-M/9ezLU9/uDwvDZTt9sNFJa0iLDUsbhYJwPtnE0D9MjeuB6DY9wRCyUPZta9iI6cSz5wBWGaUPL61QH8h92cNA==
+  dependencies:
+    extended "0.0.6"
+    is-extended "0.0.10"
+    object-extended "0.0.7"
+    safer-buffer "^2.1.2"
+    string-extended "0.0.8"
+
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
@@ -5667,6 +5723,13 @@ is-docker@^2.0.0, is-docker@^2.1.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.2.1.tgz#33eeabe23cfe86f14bde4408a02c0cfb853acdaa"
   integrity sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==
+
+is-extended@0.0.10, is-extended@~0.0.3, is-extended@~0.0.8:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/is-extended/-/is-extended-0.0.10.tgz#244e140df75bb1c9a3106f412ff182fb534a6d62"
+  integrity sha512-qp+HR+L9QXbgFurvqiVgD+JiGyUboRgICNzCXmbiLtZBFVSNFbxRsI4q7Be9mCWTO5PoO1IxoWp5sl+j5b83FA==
+  dependencies:
+    extended "~0.0.3"
 
 is-extglob@^2.1.1:
   version "2.1.1"
@@ -6765,7 +6828,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==
 
-lodash@^4.17.20, lodash@^4.17.21, lodash@^4.7.0:
+lodash@^4.13.1, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -7095,6 +7158,15 @@ object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
+
+object-extended@0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/object-extended/-/object-extended-0.0.7.tgz#84fd23f56b15582aeb3e88b05cb55d2432d68a33"
+  integrity sha512-2LJYIacEXoZ1glGkAZuvA/4pfJM4Y1ShReAo9jWpBSuz89TiUCdiPqhGJJ6m97F3WjhCSRwrbgaxYEAm9dRYBw==
+  dependencies:
+    array-extended "~0.0.4"
+    extended "~0.0.3"
+    is-extended "~0.0.3"
 
 object-inspect@^1.13.3, object-inspect@^1.13.4:
   version "1.13.4"
@@ -8070,6 +8142,11 @@ raf@^3.4.1:
   dependencies:
     performance-now "^2.1.0"
 
+random-js@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/random-js/-/random-js-1.0.8.tgz#968fd689a6f25d6c0aac766283de2f688c9c190a"
+  integrity sha512-LznfUohEMi6jfwZXa0C5uY1p1tciZozzMiwf9LGlwj52tfvpHozYklHHkrvh2Ya/mdiJ9qPGXR6byVN7+hCMTw==
+
 randombytes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
@@ -8506,7 +8583,7 @@ safe-regex-test@^1.0.3, safe-regex-test@^1.1.0:
     es-errors "^1.3.0"
     is-regex "^1.2.1"
 
-"safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0":
+"safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0", safer-buffer@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
@@ -8912,6 +8989,16 @@ stop-iteration-iterator@^1.0.0, stop-iteration-iterator@^1.1.0:
     es-errors "^1.3.0"
     internal-slot "^1.1.0"
 
+string-extended@0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/string-extended/-/string-extended-0.0.8.tgz#741957dff487b0272a79eec5a44f239ee6f17ccd"
+  integrity sha512-CK46p3AxBvBhJbBi6WrF9bCcaWH20E4NwlLSzpooG2nXWvcP2gy2YR8VN6fSwZyrbcvL4S4zoNKbR0QG52X4rw==
+  dependencies:
+    array-extended "~0.0.5"
+    date-extended "~0.0.3"
+    extended "~0.0.3"
+    is-extended "~0.0.3"
+
 string-length@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/string-length/-/string-length-4.0.2.tgz#a8a8dc7bd5c1a82b9b3c8b87e125f66871b6e57a"
@@ -9169,6 +9256,15 @@ svgo@^2.7.0:
     csso "^4.2.0"
     picocolors "^1.0.0"
     stable "^0.1.8"
+
+swiss-cities@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/swiss-cities/-/swiss-cities-1.2.0.tgz#35ce85b19b8e32da148a926fc2478ca593975343"
+  integrity sha512-GM6vhzaG0YfBPfTYtwziF5N8Uera+U3N0B+zYKUfkUfzDzLxIqSBkTx0IO6N6a9igdorfnWqNZag7KWTfBXZBw==
+  dependencies:
+    fast-csv "^2.0.0"
+    lodash "^4.13.1"
+    random-js "^1.0.8"
 
 symbol-tree@^3.2.4:
   version "3.2.4"


### PR DESCRIPTION
## Summary
- add a comprehensive Swiss localities dataset and require startups to choose a locality while optionally providing an exact address when creating a job
- introduce advanced job filters (location, employment type, weekly hours, required studies, role focus) and display the new metadata across job cards and detail modals
- enable startups to remove job offers and students to review and withdraw their applications through dedicated management views

## Testing
- yarn test --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68d5189a795083268398d07836f21195