### PR TITLE
Add applicant communication threads to applications view

### DIFF
--- a/src/SwissStartupConnect.css
+++ b/src/SwissStartupConnect.css
@@ -2722,6 +2722,162 @@
   color: var(--ssc-muted);
 }
 
+.ssc__application-thread {
+  background: rgba(15, 23, 42, 0.04);
+  border-radius: 16px;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.ssc__thread-header {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-weight: 600;
+  color: var(--ssc-ink);
+}
+
+.ssc__thread-icon {
+  width: 34px;
+  height: 34px;
+  border-radius: 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--ssc-primary);
+}
+
+.ssc__thread-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.ssc__thread-item {
+  border: 1px solid var(--ssc-border);
+  border-radius: 14px;
+  padding: 0.75rem 1rem;
+  background: #fff;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.ssc__thread-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  font-size: 0.78rem;
+  color: var(--ssc-muted);
+}
+
+.ssc__thread-schedule {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.85rem;
+  color: var(--ssc-muted);
+}
+
+.ssc__thread-empty {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--ssc-muted);
+}
+
+.ssc__thread-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.ssc__thread-form-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.ssc__thread-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  flex: 1;
+  min-width: 200px;
+  font-size: 0.85rem;
+  color: var(--ssc-muted);
+}
+
+.ssc__thread-field textarea,
+.ssc__thread-field input,
+.ssc__thread-field select {
+  border-radius: 12px;
+  border: 1px solid var(--ssc-border);
+  padding: 0.6rem 0.75rem;
+  font-size: 0.95rem;
+  color: var(--ssc-ink);
+  background: #fff;
+}
+
+.ssc__thread-field textarea {
+  min-height: 96px;
+  resize: vertical;
+}
+
+.ssc__thread-field textarea:focus,
+.ssc__thread-field input:focus,
+.ssc__thread-field select:focus {
+  outline: none;
+  border-color: var(--ssc-primary);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+}
+
+.ssc__thread-field small {
+  font-size: 0.75rem;
+  color: var(--ssc-muted);
+}
+
+.ssc__thread-error {
+  margin: 0;
+  color: var(--ssc-error, #dc2626);
+  font-size: 0.85rem;
+}
+
+.ssc__thread-submit {
+  align-self: flex-end;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.ssc__badge--message {
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--ssc-primary);
+}
+
+.ssc__badge--interview {
+  background: rgba(16, 185, 129, 0.18);
+  color: #047857;
+}
+
+.ssc__badge--note {
+  background: rgba(79, 70, 229, 0.12);
+  color: #4338ca;
+}
+
+.ssc__thread-label {
+  font-weight: 600;
+  color: var(--ssc-ink);
+  font-size: 0.85rem;
+}
+
 .ssc__application-footer {
   display: flex;
   justify-content: flex-end;


### PR DESCRIPTION
## Summary
- add a communication and scheduling thread to each application card for startup founders
- persist thread entries locally and expose translated labels in English, French, and German
- style the new workspace so it fits the existing applications layout

## Testing
- yarn test --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68de9ebcd3b483269f505f83f720471d