### PR TITLE
Restore Startups tab content

### DIFF
--- a/src/SwissStartupConnect.css
+++ b/src/SwissStartupConnect.css
@@ -549,8 +549,14 @@
   color: var(--ssc-ink);
   box-shadow: 0 18px 40px rgba(var(--ssc-ink-rgb), 0.18);
   cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, opacity 0.3s ease;
   backdrop-filter: blur(10px);
+}
+
+.ssc__hero-scroll-indicator.is-hidden {
+  opacity: 0;
+  transform: translateX(-50%) translateY(12px);
+  pointer-events: none;
 }
 
 .ssc__hero-scroll-indicator:hover,
@@ -1997,6 +2003,27 @@
   align-items: center;
   justify-content: center;
   color: var(--ssc-primary);
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+.ssc__company-logo img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 12px;
+}
+
+.ssc__company-logo svg {
+  width: 24px;
+  height: 24px;
+}
+
+.ssc__company-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  flex: 1;
 }
 
 .ssc__company-name {
@@ -2028,6 +2055,9 @@
   background: rgba(var(--ssc-ink-rgb), 0.05);
   padding: 0.35rem 0.75rem;
   border-radius: 10px;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
 }
 
 .ssc__company-stats {


### PR DESCRIPTION
## Summary
- add localized copy for the Startups directory count and empty state across supported languages
- render the Startups tab with a grid of company cards that surface metadata, follow actions, and review links
- enhance company card styling so logos, icons, and layouts display correctly

## Testing
- yarn test --watchAll=false *(fails: package missing from lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68e24e9236a0832694280bb80154af03