### PR TITLE
Fix company skeleton guard initialization

### DIFF
--- a/src/SwissStartupConnect.css
+++ b/src/SwissStartupConnect.css
@@ -1085,7 +1085,7 @@
   height: 100%;
   margin: 0;
   background: none;
-  pointer-events: auto;
+  pointer-events: none;
 }
 
 .ssc__salary-slider input[type='range']::-webkit-slider-runnable-track,

--- a/src/SwissStartupConnect.jsx
+++ b/src/SwissStartupConnect.jsx
@@ -4238,8 +4238,15 @@ const SwissStartupConnect = () => {
 
   const [savedJobs, setSavedJobs] = useState(() => {
     if (typeof window === 'undefined') return [];
-    const stored = window.localStorage.getItem('ssc_saved_jobs');
-    return stored ? JSON.parse(stored) : [];
+
+    try {
+      const stored = window.localStorage.getItem('ssc_saved_jobs');
+      const parsed = stored ? JSON.parse(stored) : [];
+      return sanitizeIdArray(parsed);
+    } catch (error) {
+      console.error('Failed to parse saved jobs', error);
+      return [];
+    }
   });
   const [selectedJob, setSelectedJob] = useState(null);
 
@@ -4809,7 +4816,9 @@ const SwissStartupConnect = () => {
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
-    window.localStorage.setItem('ssc_saved_jobs', JSON.stringify(savedJobs));
+
+    const sanitised = sanitizeIdArray(savedJobs);
+    window.localStorage.setItem('ssc_saved_jobs', JSON.stringify(sanitised));
   }, [savedJobs]);
 
   useEffect(() => {
@@ -8793,9 +8802,6 @@ const SwissStartupConnect = () => {
   const closeResourceModal = () => setResourceModal(null);
   const closeReviewsModal = () => setReviewsModal(null);
 
-  const loadingSpinner = jobsLoading || companiesLoading || authLoading;
-  const showCompanySkeleton = companiesLoading && sortedCompanies.length === 0;
-
   const navTabs = useMemo(() => {
     const baseTabs = ['general', 'jobs', 'companies'];
     if (user?.type === 'startup') {
@@ -8924,6 +8930,9 @@ const SwissStartupConnect = () => {
       return bTime - aTime;
     });
   }, [augmentedCompanies, companyJobCounts, companySort, followedCompanies, resolveCompanyFollowKey]);
+
+  const loadingSpinner = jobsLoading || companiesLoading || authLoading;
+  const showCompanySkeleton = companiesLoading && sortedCompanies.length === 0;
 
   const featuredCompanies = useMemo(() => {
     return [...sortedCompanies]


### PR DESCRIPTION
## Summary
- guard saved job state initialisation against malformed localStorage entries that previously crashed rendering
- normalise saved job ids before persisting them back to storage to avoid reintroducing invalid data
- ensure the companies skeleton only checks the sorted list after it has been initialised to prevent runtime ReferenceErrors

## Testing
- yarn test --watchAll=false


------
https://chatgpt.com/codex/tasks/task_e_68e26bb849f083269ea4ec4e56035748